### PR TITLE
Added support for 'as' aliasing in SQL select queries

### DIFF
--- a/server/lib/parser.js
+++ b/server/lib/parser.js
@@ -256,7 +256,14 @@ function escapeWhereCondition(condition) {
 // the proper query.
 function mkColumns(table /* String */, columns /* Array */) {
   return columns.map(function (col) {
-    return table + '.' + col;
+    if (col.indexOf('::') < 0) {
+      return table + '.' + col;
+    }
+    else {
+      // Handle aliasing
+      var cparts = col.split('::');
+      return table + '.' + cparts[0] + ' as ' + cparts[1];
+    }
   })
   .join(', ');
 }


### PR DESCRIPTION
For SQL queries created by validate.process(dependencies), add support for SQL 'AS' aliasing using a '::' syntax.  For instance

    dependencies.patient = {
       tables :  { 
          'patient' : 
              columns : ['first_name', 'last_name::surname']
    }

This will expand out to:

      SELECT patient.first_name, patient.last_name as surname, from patient...
