### PR TITLE
Fixed translation issue with find-patient directive

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -1426,12 +1426,12 @@
     "CHOOSE"           : "Assign a service"
   },
 
-  "FIND"              : {
-    "TITLE"           : "Find a patient",
-    "ENTER_DEBTOR_ID" : "Find by Patient ID",
-    "PLACEHOLDER"     : "Search patient name",
-    "SEARCH"          : "Find by Name",
-    "PATIENT_ID"      : "Patient ID"
+  "FIND"               : {
+    "ENTER_PATIENT_ID" : "Find by Patient ID",
+    "PATIENT_ID"       : "Patient ID",
+    "PLACEHOLDER"      : "Search patient name",
+    "SEARCH"           : "Find by Name",
+    "TITLE"            : "Find a patient"
   },
 
   "EFIND" : {

--- a/client/src/i18n/fr.json
+++ b/client/src/i18n/fr.json
@@ -1426,12 +1426,12 @@
     "CHOOSE"           : "Choisir le service"
   },
 
-  "FIND"              : {
-    "TITLE"           : "Trouver Malade",
-    "ENTER_DEBTOR_ID" : "Chercher ID Débiteur",
-    "SEARCH"          : "Chercher Par Nom",
-    "PLACEHOLDER"     : "Chercher un Débiteur",
-    "PATIENT_ID"      : "ID Patient"
+  "FIND"               : {
+    "ENTER_PATIENT_ID" : "Chercher ID Patient",
+    "PATIENT_ID"       : "ID Patient",
+    "PLACEHOLDER"      : "Chercher un Patient",
+    "SEARCH"           : "Chercher Par Nom",
+    "TITLE"            : "Trouver Malade"
   },
 
   "EFIND" : {

--- a/client/src/partials/templates/findpatient.tmpl.html
+++ b/client/src/partials/templates/findpatient.tmpl.html
@@ -4,7 +4,7 @@
      <div ng-switch-when="false">
        <span class="glyphicon glyphicon-search"></span> {{ "FIND.TITLE" | translate }}
        <div class="pull-right">
-         <a id="findById" style="cursor:pointer;" ng-class="{'link-selected': findPatient.state==='id'}" ng-click="findPatient.updateState('id')" class="patient-find"><span class="glyphicon glyphicon-pencil"></span> {{ "FIND.ENTER_DEBTOR_ID" | translate }} </a>
+         <a id="findById" style="cursor:pointer;" ng-class="{'link-selected': findPatient.state==='id'}" ng-click="findPatient.updateState('id')" class="patient-find"><span class="glyphicon glyphicon-pencil"></span> {{ "FIND.ENTER_PATIENT_ID" | translate }} </a>
          <a id="findByName" style="cursor:pointer;" ng-class="{'link-selected': findPatient.state==='name'}" ng-click="findPatient.updateState('name')" class="patient-find"><span class="glyphicon glyphicon-user"></span> {{ "FIND.SEARCH" | translate }} </a>
        </div>
      </div>


### PR DESCRIPTION


The 'Find patient' directive (findPatient) was displaying 'Find by Debitor ID' for the translation item ENTER_DEBITOR_ID. This was translated as "Find by Patient ID" in english but 'Cherchez Debitor ID" in french. The english seemed correct so I changed the translation tag to ENTER_PATIENT_ID and fixed the french translation to match the english translation.

This directive should be general and seems to work that way, although the directive code does seem to reference debitor info. Not sure if some cleanup/updating is necessary on this since it seems to work okay.
