### PR TITLE
Remove hardcoded minimum birth year in patient register/edit forms

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -446,7 +446,7 @@
     "MONTH"               : "This Month",
     "SEARCH"              : "Search",
     "INCORRECT_DATE_TYPE" : "Provided date value is invalid",
-    "INCORRECT_DATE_LIMIT" : "Year of birth must be between 1900 and 2014",
+    "INCORRECT_DATE_LIMIT" : "Year of birth must be between <min> and <max>",
     "INCORRECT_LOCATION_CURRENT" : "Current village not specified",
     "INCORRECT_LOCATION_ORIGIN" : "Origin village not specified",
     "STATUS_NEW_TITLE" : "Patient is new to the hospital",

--- a/client/src/i18n/fr.json
+++ b/client/src/i18n/fr.json
@@ -434,7 +434,7 @@
     "MONTH"               : "Ce Mois",
     "SEARCH"              : "Rechercher",
     "INCORRECT_DATE_TYPE"         : "la valeur de la date est invalide",
-    "INCORRECT_DATE_LIMIT"        : "Année de naissance doit être comprise entre 1900 et 2014",
+    "INCORRECT_DATE_LIMIT"        : "Année de naissance doit être comprise entre <min> et <max>",
     "INCORRECT_LOCATION_CURRENT"  : "village actuel non spécifiée",
     "INCORRECT_LOCATION_ORIGIN"   : "village d'origine non spécifiée",
     "STATUS_NEW_TITLE"            : "Le patient est de nouveau à l'hôpital",

--- a/client/src/js/services/util.js
+++ b/client/src/js/services/util.js
@@ -64,4 +64,7 @@ angular.module('bhima.services')
     return names.join(' ');
   };
 
+  // Define the minimum date for any patient data
+  this.minPatientDate = new Date('1900-01-01');
+
 }]);

--- a/client/src/partials/patient_registration/patient.html
+++ b/client/src/partials/patient_registration/patient.html
@@ -55,11 +55,10 @@
                     </div>
                   </div>
 
-
                   <div class="form-group" >
                     <label for="patient-dob" class="col-xs-3 control-label">{{ "PATIENT_REG.DOB" | translate }}</label>
                     <div class="col-xs-9">
-                      <input required id="patient-dob" type="date" class="form-bhima" ng-disabled="!session.fullDateEnabled" ng-model="patient.dob" min="{{ getMinDate() }}" max="{{ getMaxDate() }}">
+                      <input required id="patient-dob" type="date" class="form-bhima" ng-disabled="!session.fullDateEnabled" ng-model="patient.dob" min="{{ minDOB }}" max="{{ maxDOB }}">
                     </div>
                   </div>
 

--- a/client/src/partials/patient_registration/patient.js
+++ b/client/src/partials/patient_registration/patient.js
@@ -12,12 +12,14 @@ angular.module('bhima.controllers')
   'uuid',
   function ($scope, $q, $location, $translate, connect, messenger, validate, appstate, util, uuid) {
 
-    var dependencies = {};
-    var defaultBirthMonth = '06-01';
+    var dependencies = {},
+        defaultBirthMonth = '06-01',
+        timestamp = new Date(),
+        minYear = util.minPatientDate.getFullYear(),
+        maxYear = timestamp.getFullYear(),
+        session = $scope.session = { };
 
-    var session = $scope.session = { };
-
-    session.timestamp = new Date();
+    session.timestamp = timestamp;
     session.originLocationUuid = null;
     session.currentLocationUuid = null;
 
@@ -70,11 +72,18 @@ angular.module('bhima.controllers')
       query : 'user_session'
     };
 
+
     function patientRegistration(model) {
-      console.log('Model is: ', model);
       angular.extend($scope, model);
+
+      // Update the year limit message (has to be done late to use current language)
+      validation.dates.tests.limit.message = $translate.instant(validation.dates.tests.limit.message)
+        .replace('<min>', minYear)
+	.replace('<max>', maxYear);
+
       return $q.when();
     }
+
 
     // Tests in an ng-disabled method often got called in the wrong order/ scope was not updated
     $scope.$watch('patient.dob', function (nval, oval) {
@@ -119,9 +128,9 @@ angular.module('bhima.controllers')
       return;
     }
 
-    // Conveluted date validation
+    // Convoluted date validation
     function validateDates() {
-      var extractYear = session.yob;
+      var yearOfBirth = session.yob;
       validation.dates.flag = false;
 
       if (session.fullDateEnabled) {
@@ -131,24 +140,34 @@ angular.module('bhima.controllers')
           return true;
         }
 
-        extractYear = $scope.patient.dob.getFullYear();
+        yearOfBirth = $scope.patient.dob.getFullYear();
       }
 
-      if (extractYear) {
+      if (yearOfBirth) {
 
-        if (isNaN(extractYear)) {
+	// NOTE: The following checks on the yearOfBirth are never executed with
+	//       the html5+angular date input field since the form value becomes
+	//       undefined when invalid and is caught by the previous check.
+	//       Leaving them in as a precaution in case the input form behavior
+	//       changes in the future.
+
+        if (isNaN(yearOfBirth)) {
           validation.dates.flag = validation.dates.tests.type;
           return true;
         }
 
         // Sensible year limits - may need to change to accomidate legacy patients
-        if (extractYear > 2014 || extractYear < 1900) {
+        if (yearOfBirth > maxYear || yearOfBirth < minYear) {
           validation.dates.flag = validation.dates.tests.limit;
           return true;
         }
       }
       return false;
     }
+
+    // Define limits for DOB
+    $scope.minDOB = util.htmlDate(util.minPatientDate);
+    $scope.maxDOB = util.htmlDate(timestamp);
 
     // Location methods
     function setOriginLocation(uuid) {
@@ -172,15 +191,6 @@ angular.module('bhima.controllers')
       patient.current_location_id = session.originLocationUuid;
       patient.origin_location_id = session.currentLocationUuid;
       writePatient(patient);
-    };
-
-    $scope.getMinDate = function getMinDate() {
-      // TODO: Define this globally somewhere (same for patient edit)
-      return '1900-01-01';
-    };
-
-    $scope.getMaxDate = function getMaxDate () {
-      return util.htmlDate(session.timestamp);
     };
 
     function writePatient(patient) {
@@ -268,6 +278,6 @@ angular.module('bhima.controllers')
 
     $scope.setOriginLocation = setOriginLocation;
     $scope.setCurrentLocation = setCurrentLocation;
-
   }
+
 ]);


### PR DESCRIPTION
Added a global value for the minimum patient DOB in the util service:    util.minimumPatientDate.

Updated DOB year-out-of-range error message to include tokens for <min> and <max> which are replaced in the form controller code.

Updated patient register/edit forms to use util.minimumPatientDate and eliminate any hardcoded dates in the form html and controller code. 
