### PR TITLE
Improve usability of Account management page and remove obsolete translation items

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -258,7 +258,6 @@
   },
 
   "ERROR"                 : {
-    "HTTP_STATUS_CODE" : "HTTP Status Code",
     "ERR_IMBALANCE"       : "Imbalancing Error",
     "ERR_SQL"             : "SQL Error",
     "ERR_ACCNT_LOCKED"    : "Locked Account Error",
@@ -349,10 +348,6 @@
     "CONFIG_CLOSING_ACCOUNT"  : "Choose the closing balance account",
     "CLOSING_ACCOUNT"         : "Closing Account",
     "CLOSING_ACCOUNT_MESSAGE" : "The new fiscal year is next in a series.  Please specify a balance account which will recieve the balances of the enterprise's income and expense accounts at the close of the previous fiscal year.",
-    "CLOSE_NOTICE"          : "Close notice for previous years",
-    "CLOSE_PREVIOUS_YEAR"   : "Reminder: close previous fiscal years",
-    "CLOSE_PREVIOUS_YEAR_MESSAGE" : "A previous fiscal year exists.  You must close the last fiscal year to properly carry forward balances.  Any reports generated before closing the previous fiscal year will be inaccurate.",
-    "ACCEPT"                : "I understand",
     "SUBMIT_YEAR"           : "Submit the fiscal year",
     "PREVIOUS_YEAR"         : "Previous fiscal year",
     "CREATE_SUCCESS"        : "Fiscal year creation successful",
@@ -1189,7 +1184,7 @@
     "ROOT_ACCOUNT"   : "Root Account",
     "IS_ASSET"       : "Is asset",
     "IS_PASSIVE"     : "Is passive",
-    "IS_NOTHING"     : "Neither"
+    "IS_NOTHING"     : "Other"
   },
 
   "LOCATION"                : {

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -1179,16 +1179,17 @@
     "ACCOUNT_TYPE"   : "Account Type",
     "ACCOUNT_NUMBER" : "Account Number",
     "FIXED"          : "Fixed",
+    "LABEL"          : "Label",
     "NO"             : "No.",
-    "TXT"            : "Text",
     "TYPE"           : "Type",
+    "IS_ASSET_TITLE" : "Asset?",
     "VARIABLE"       : "Variable",
     "ACCOUNT_GROUP"  : "Account Group (Title Account)",
     "TITLE_ACCOUNT"  : "Title Account",
     "ROOT_ACCOUNT"   : "Root Account",
     "IS_ASSET"       : "Is asset",
-    "IS_PASSIVE"     : "Est un passif",
-    "IS_NOTHING"     : "Nothing"        
+    "IS_PASSIVE"     : "Is passive",
+    "IS_NOTHING"     : "Neither"
   },
 
   "LOCATION"                : {

--- a/client/src/i18n/fr.json
+++ b/client/src/i18n/fr.json
@@ -1314,15 +1314,16 @@
     "ACCOUNT_NUMBER" : "Numéro de Compte",
     "FIXED"          : "Fixe",
     "NO"             : "No.",
-    "TXT"            : "Texte",
+    "LABEL"          : "Label",
     "TYPE"           : "Type",
+    "IS_ASSET_TITLE" : "Est ce actif?",
     "VARIABLE"       : "Variable",
     "ACCOUNT_GROUP"  : "Groupe des Comptes (Comptes Titres)",
     "TITLE_ACCOUNT"  : "Comptes Titre",
     "ROOT_ACCOUNT"   : "Compte Parent",
     "IS_ASSET"       : "Est un actif",
     "IS_PASSIVE"     : "Est un passif",
-    "IS_NOTHING"     : "Rien"
+    "IS_NOTHING"     : "Autre"
   },
 
   "LOCATION" : {

--- a/client/src/partials/accounts/create_account/create.js
+++ b/client/src/partials/accounts/create_account/create.js
@@ -22,9 +22,11 @@ angular.module('bhima.controllers')
       query : {
         identifier : 'account_number',
         tables : {
-          account : { columns : ['id', 'account_number', 'account_txt', 'account_type_id', 'is_asset', 'parent'] }
-        }
-      },
+          account : { columns : ['id', 'account_number', 'account_txt', 'account_type_id', 'is_asset', 'parent'] },
+	  account_type : { columns : ['type::account_type'] }
+        },
+	join: [ 'account.account_type_id=account_type.id' ]
+      }
     };
 
     dependencies.accountType = {
@@ -50,10 +52,10 @@ angular.module('bhima.controllers')
     function defineGridOptions() {
 
       columns = [
-        {id: 'ACCOUNT.TXT', name: 'Text', field: 'account_txt', formatter: AccountFormatter},
+        {id: 'ACCOUNT.LABEL', name: 'Label', field: 'account_txt', formatter: AccountFormatter},
         {id: 'ACCOUNT.NO', name: 'No.', field: 'account_number'},
-        {id: 'ACCOUNT.TYPE', name: 'Type', field: 'account_type_id', maxWidth: 60},
-        {id: 'ACCOUNT.IS_ASSET', name: 'IsAsset', field: 'is_asset', maxWidth: 90}
+        {id: 'ACCOUNT.TYPE', name: 'Type', field: 'account_type', maxWidth: 90},
+        {id: 'ACCOUNT.IS_ASSET_TITLE', name: 'IsAsset', field: 'is_asset', maxWidth: 90}
       ];
 
       columns.forEach(function (col) {


### PR DESCRIPTION
Fixes and cleaned up terms for Account management page.  Display actual account type, not a number.  Other improvements.  French updates done with Dedrick's help. 

Removed obsolete translation items orphaned by removal of fiscal year closing code.