### PR TITLE
Integrate npm to run tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - "0.10"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 BHIMA
 =================
 
+[![Build Status](https://travis-ci.org/jniles/bhima.svg?branch=features%2Ftest-framework)](https://travis-ci.org/jniles/bhima)
+
 _Bhima is alpha version software. Please do not use this in a commerical context._
 
 Bhima is a free, open source accounting and hospital information management system

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 BHIMA
 =================
+[![Build Status](https://travis-ci.org/jniles/bhima.svg?branch=features%2Ftest-framework)](https://travis-ci.org/jniles/bhima)
 
 _Bhima is alpha version software. Please do not use this in a commerical context._
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 BHIMA
 =================
-[![Build Status](https://travis-ci.org/jniles/bhima.svg?branch=features%2Ftest-framework)](https://travis-ci.org/jniles/bhima)
 
 _Bhima is alpha version software. Please do not use this in a commerical context._
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A rural hospital information management system.",
   "main": "server/app.js",
   "scripts": {
-    "test": "node server/app.js"
+    "test": "mocha server/test/"
   },
   "repository": {
     "type": "git",

--- a/server/lib/util.js
+++ b/server/lib/util.js
@@ -14,7 +14,7 @@ module.exports = {
 
   isString: function (str) { return typeof str === 'string'; },
 
-  isObject: function (obj) { return Object.prototype.toString.call(obj) === '[object Object]'; },
+  isObject: function (obj) { return typeof obj === 'object'; },
 
   //convertToMysqlDate: function convertToMysqlDate(dateString){ return toMySqlDate(dateString); }
 
@@ -34,20 +34,14 @@ module.exports = {
     return [year, month, day].join('-');
   },
 
-  isPositive : function (number) { return this.isValidNumber(number) && Number(number) >= 0; },
+  isPositive : function (number) { return this.isNumber(number) && Number(number) >= 0; },
 
-  isNegative : function (number) { return !this.isPositive(number); },
-
-  isEqual : function (a, b) { return a === b; },
+  isNegative : function (number) { return this.isNumber(number) && !this.isPositive(number); },
 
   isDefined : function (a) { return a !== undefined; },
 
-  isUndefined : function (a) { return !this.isDefined(a); },
-
-  isNull : function (a) { return a === null; },
-
   exists : function (a) { return this.isDefined(a) && !this.isNull(a); },
 
-  toDistinctValues : function(a) { return a.reduce(function(p, c) { if (p.indexOf(c) < 0) { p.push(c); return p;}}, []); }
+  toDistinctValues : function(a) { return a.reduce(function(p, c) { if (p.indexOf(c) < 0) { p.push(c); } return p; }, []); }
 
 };

--- a/server/test/util.spec.js
+++ b/server/test/util.spec.js
@@ -1,0 +1,119 @@
+var expect = require('chai').expect,
+    u      = require('../lib/util');
+
+// tests for utility functions
+describe('utilities', function () {
+  'use strict';
+
+  // tests components that are assertions (return true/false)
+  describe('#assertions', function () {
+
+    // testing primatives
+
+    // integers
+    it('should correctly distinguish integers with isInt', function () {
+
+      expect(u.isInt({})).is.false();
+
+      // NOTE by design, util coerces strings into integers.
+      expect(u.isInt('2')).is.true();
+
+      expect(u.isInt(2.00000001)).is.false();
+
+      expect(u.isInt(Number(2))).is.true();
+
+      expect(u.isInt(2)).is.true();
+    });
+
+    // numbers
+    it('should correctly distinguish numbers with isNumber', function () {
+
+      expect(u.isNumber({})).is.false();
+
+      expect(u.isNumber(Number.NaN)).is.false();
+
+      // NOTE by design, util coerces strings into numbers
+      expect(u.isNumber('2')).is.true();
+
+      expect(u.isNumber(2.00000001)).is.true();
+
+      expect(u.isNumber(2)).is.true();
+    });
+
+    // arrays
+    it('should correctly distinguish arrays with isArray', function () {
+
+      expect(u.isArray([])).is.true();
+
+      expect(u.isArray({})).is.false();
+
+      expect(u.isArray('string')).is.false();
+
+      expect(u.isArray(2)).is.false();
+    });
+    
+    // strings
+    it('should correctly distinguish strings with isString', function () {
+
+      expect(u.isString({})).is.false();
+
+      expect(u.isString(2)).is.false();
+
+      expect(u.isString('2')).is.true();
+    });
+    
+    // objects
+    it('should correctly distinguish objects with isObject', function () {
+
+      expect(u.isObject(2)).is.false();
+
+      expect(u.isObject('2')).is.false();
+
+      expect(u.isObject([])).is.true();
+
+      expect(u.isObject({})).is.true();
+    });
+
+    // positive and negative numbers
+    it('should correctly distinguish positive and negative numbers', function () {
+
+
+      // positives
+      expect(u.isPositive(-2)).is.false();
+
+      expect(u.isPositive(2)).is.true();
+
+      // negatives
+      expect(u.isNegative(2)).is.false();
+
+      expect(u.isNegative(-2)).is.true();
+    });
+
+    // defined
+    it('should detect if an object is undefined', function () {
+
+      var x;
+      expect(u.isDefined(x)).is.false();
+
+      expect(u.isDefined(undefined)).is.false();
+
+      expect(u.isDefined(null)).is.true();
+
+      expect(u.isDefined(2)).is.true();
+    });
+  });
+
+  // tests components that are transformations of the input
+  describe('#transforms', function () {
+
+    it('should filter out duplicate values', function () {
+      var unique = [1,2,3];
+
+      // should be self-symmetric
+      expect(u.toDistinctValues(unique)).to.deep.equal(unique);
+
+      expect(u.toDistinctValues([1, 2, 3, 3])).to.deep.equal(unique);
+    });
+
+  });
+});


### PR DESCRIPTION
In this PR:
 - `npm test` now runs server-side mocha tests
 - .travis.yml added for future Travis CI integration
 - tests for `lib/util.js` added
 - rm a few, irrelevant features in util.js
 - FIX: util.toDistinctValues() no longer results in an error for arrays with duplicate values.