### PR TITLE
Enable edit patient restart

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -1102,7 +1102,7 @@
   },
 
   "PATIENT_EDIT"             : {
-    "CHANGE_DEBITOR_GROUP"   : "Change Debitor Group",
+    "RESTART_SEARCH"         : "Find another patient",
     "TITLE"                  : "Edit Patient Details:",
     "UPDATE_FAILED"          : "Patient update failed!",
     "UPDATE_PATIENT"         : "Update Patient",

--- a/client/src/i18n/fr.json
+++ b/client/src/i18n/fr.json
@@ -1219,7 +1219,7 @@
   },
 
   "PATIENT_EDIT"             : {
-    "CHANGE_DEBITOR_GROUP"   : "Modifier Groupe de Débiteurs",
+    "RESTART_SEARCH"         : "Trouver un autre patient",
     "TITLE"                  : "Modifier Patient:",
     "UPDATE_FAILED"          : "Echec durant le mise à jour du patient!",
     "UPDATE_PATIENT"         : "Modifier Patient",

--- a/client/src/js/directives/findpatient.js
+++ b/client/src/js/directives/findpatient.js
@@ -14,7 +14,8 @@ angular.module('bhima.directives')
         required : true,
         query : {
           tables : {
-            patient : {columns : ['uuid', 'project_id', 'debitor_uuid', 'first_name', 'last_name', 'sex', 'dob', 'origin_location_id', 'reference']},
+            patient : {columns : ['uuid', 'project_id', 'debitor_uuid', 'first_name', 'last_name', 
+				  'sex', 'dob', 'origin_location_id', 'reference']},
             project : { columns : ['abbr'] },
             debitor : { columns : ['text']},
             debitor_group : { columns : ['account_id', 'price_list_uuid', 'is_convention', 'locked']}
@@ -37,7 +38,7 @@ angular.module('bhima.directives')
       };
 
       scope.findPatient = {
-        state : 'id',
+        state : 'name',
         submitSuccess : false,
         
         // #Sorry - string hack

--- a/client/src/js/directives/findpatient.js
+++ b/client/src/js/directives/findpatient.js
@@ -176,6 +176,7 @@ angular.module('bhima.directives')
       function resetSearch() {
         scope.findPatient.valid = false;
         scope.findPatient.submitSuccess = false;
+	scope.findPatient.state = 'name';
         scope.findPatient.debtor = '';
       }
 

--- a/client/src/js/services/exchange.js
+++ b/client/src/js/services/exchange.js
@@ -89,7 +89,7 @@ angular.module('bhima.services')
       // loads in an array of rates
       // cfg.rates = rates;
 
-      console.log('RATES:', rates);
+      // console.log('RATES:', rates);
 
       rates.forEach(function (rate) {
         createDailyRateStore(rate);

--- a/client/src/js/services/validate.js
+++ b/client/src/js/services/validate.js
@@ -6,6 +6,13 @@ angular.module('bhima.services')
     {flag: 'required', message : 'Required data not found!', method : hasData}
   ];
 
+  function clear(dependencies, limit) {
+    var list = limit || Object.keys(dependencies);
+    list.forEach(function(modelKey) {
+      dependencies[modelKey].processed = false;
+    });
+  }
+
   function refresh(dependencies, limit) {
     var list = limit || Object.keys(dependencies);
 
@@ -167,6 +174,7 @@ angular.module('bhima.services')
 
   return {
     process : process,
+    clear   : clear,
     refresh : refresh
   };
 }]);

--- a/client/src/partials/patient_edit/edit_patient.html
+++ b/client/src/partials/patient_edit/edit_patient.html
@@ -7,7 +7,7 @@
 
     <div class="row" ng-if="session.mode === 'search'">
       <div class="col-xs-7">
-	<div find-patient on-search-complete="initialiseEditing"></div>
+        <div find-patient on-search-complete="initialiseEditing"></div>
       </div>
     </div>
 
@@ -72,16 +72,16 @@
                   <div class="form-group">
                     <label class="control-label col-xs-3"> {{ "INVOICE.PATIENT_ID" | translate }}</label>
                     <div class="col-xs-9">
-		      <label class="control-label">{{ patient.hr_id }}</label>
-		    </div> 
-		  </div> <!-- form group -->
+                      <label class="control-label">{{ patient.hr_id }}</label>
+                    </div> 
+                  </div> <!-- form group -->
 
                   <div class="form-group">
                     <label class="control-label col-xs-3"> {{ "INVOICE.DATE_REGISTRATION" | translate }}</label>
                     <div class="col-xs-9">
-		      <label class="control-label">{{ patient.registration_date | date }}</label>
-		    </div> 
-		  </div> <!-- form group -->
+                      <label class="control-label">{{ patient.registration_date | date }}</label>
+                    </div> 
+                  </div> <!-- form group -->
 
                 </fieldset>
               </form>
@@ -122,10 +122,11 @@
                   <fieldset>
                     <legend>{{ "PATIENT_REG.FINANCE" | translate }}</legend>
                     <div class="form-group">
+                      <label class="control-label col-xs-3"> {{ "PATIENT_REG.DEBTOR_GROUP" | translate }}</label>
                       <div class="col-xs-9">
-			  {{ "PATIENT_REG.DEBTOR_GROUP" | translate }}: {{patient.debitor_group_name | translate}}
-		      </div>
-                    </div>
+                        <label class="control-label">{{ patient.debitor_group_name | translate }}</label>
+                      </div> 
+                    </div> <!-- form group -->
                   </fieldset>
                 </form>
 
@@ -214,9 +215,9 @@
         </div> <!-- End other info row -->
       </div> <!-- End main column 7 -->
       <div class="col-xs-5">
-	<div class="panel-input">
-	  <button class="btn btn-default" ng-click="restartSearch()">{{ "PATIENT_EDIT.RESTART_SEARCH" | translate }}</button>
-	</div>
+        <div class="panel-input">
+          <button class="btn btn-default" ng-click="restartSearch()">{{ "PATIENT_EDIT.RESTART_SEARCH" | translate }}</button>
+        </div>
       </div> <!-- End column 5 row -->
     </div> <!-- end row -->
   </div>

--- a/client/src/partials/patient_edit/edit_patient.html
+++ b/client/src/partials/patient_edit/edit_patient.html
@@ -214,6 +214,9 @@
         </div> <!-- End other info row -->
       </div> <!-- End main column 7 -->
       <div class="col-xs-5">
+	<div class="panel-input">
+	  <button class="btn btn-default" ng-click="restartSearch()">{{ "PATIENT_EDIT.RESTART_SEARCH" | translate }}</button>
+	</div>
       </div> <!-- End column 5 row -->
     </div> <!-- end row -->
   </div>

--- a/client/src/partials/patient_edit/edit_patient.js
+++ b/client/src/partials/patient_edit/edit_patient.js
@@ -189,9 +189,23 @@ angular.module('bhima.controllers')
       customValidation();
     });
 
+    // Restart the search
+    $scope.restartSearch = function () {
+      originalPatientData = null;
+      $scope.patient = { origin_location_id: null, current_location_id: null };
+      $scope.initialOriginLocation = null;
+      $scope.initialCurrentLocation = null;
+
+      // Make sure the patient query gets processed
+      if ('processed' in dependencies.patient) {
+	dependencies.patient.processed = false;
+      }
+
+      session.mode = 'search';
+    };
 
     // Define the function that switches to the edit mode
-    $scope.initialiseEditing = function initialiseEditing (selectedPatient) {
+    $scope.initialiseEditing = function initialiseEditing(selectedPatient) {
       if (selectedPatient && 'uuid' in selectedPatient && selectedPatient.uuid) {
         patientUuid = selectedPatient.uuid;
 	dependencies.patient.query.where[0] = 'patient.uuid=' + patientUuid;

--- a/client/src/partials/patient_edit/edit_patient.js
+++ b/client/src/partials/patient_edit/edit_patient.js
@@ -189,22 +189,17 @@ angular.module('bhima.controllers')
       customValidation();
     });
 
-    // Restart the search
+    // Function to switch back to search mode (and reset the search)
     $scope.restartSearch = function () {
       originalPatientData = null;
       $scope.patient = { origin_location_id: null, current_location_id: null };
       $scope.initialOriginLocation = null;
       $scope.initialCurrentLocation = null;
-
-      // Make sure the patient query gets processed
-      if ('processed' in dependencies.patient) {
-	dependencies.patient.processed = false;
-      }
-
+      validate.clear(dependencies, ['patient']); // So future patient query gets processed
       session.mode = 'search';
     };
 
-    // Define the function that switches to the edit mode
+    // Function to switch to the edit mode
     $scope.initialiseEditing = function initialiseEditing(selectedPatient) {
       if (selectedPatient && 'uuid' in selectedPatient && selectedPatient.uuid) {
         patientUuid = selectedPatient.uuid;
@@ -214,7 +209,6 @@ angular.module('bhima.controllers')
 	session.mode = 'edit';
       }
     };
-
 
     // Main function to save the updated patient data to the database
     $scope.updatePatient = function () {
@@ -260,7 +254,6 @@ angular.module('bhima.controllers')
       session.mode = 'edit';
     };
 
-
     // Basic setup function when the models are loaded
     function startup (models) {
       var patient = $scope.patient = models.patient.data[0];
@@ -279,6 +272,7 @@ angular.module('bhima.controllers')
         .replace('<min>', minYear)
 	.replace('<max>', maxYear);
     }
+
 
     // Register this controller
     appstate.register('enterprise', function (enterprise) {


### PR DESCRIPTION
Currently, when editing a patient, once you start editing a patient, you cannot switch to another patient without going to some other page. 

This PR adds a button on the right side of the Patient Details edting area (only when editing).  The user can click on the button to switch back to the search mode to find another patient to edit.

Currently when the user is editing a patient and clicks on the  main menu 'Edit Patient Details' item, nothing happens.  I'm sure it would be possible to fix this, but having an button for that purpose may be simpler for users.

Also disabled the automatic logging of the exchange rate on ever startup.