### PR TITLE
Account statement num fix

### DIFF
--- a/client/src/partials/reports/account_statement/account_statement.html
+++ b/client/src/partials/reports/account_statement/account_statement.html
@@ -41,11 +41,12 @@
           type="text"
           ng-model="session.requestId"
           placeholder="Account ID"
-          typeahead="account.id as formatAccount(account) for account in session.accounts.data | filter:$viewValue | limitTo:10" typeahead-template-url="AccountList.html"
-          typeahead-on-select="requestAccount(session.requestID)"
+          typeahead="account.id as formatAccount(account) for account in session.accounts.data | filter:$viewValue | limitTo:10" 
+          typeahead-template-url="AccountList.html"
+          typeahead-on-select="requestAccount()"
           >
         <span class="input-group-btn">
-          <button ng-click="requestAccount(session.requestId)" class="btn btn-default btn-sm square">{{ "FORM.SUBMIT" | translate }}</button>
+          <button ng-click="requestAccount(session.requestId)" class="btn-sm-bhima btn-default square">{{ "FORM.SUBMIT" | translate }}</button>
         </span>
       </div>      
     </div>

--- a/client/src/partials/reports/account_statement/account_statement.js
+++ b/client/src/partials/reports/account_statement/account_statement.js
@@ -24,6 +24,7 @@ angular.module('bhima.controllers')
     };
     session.config.dateFrom = new Date();
     session.config.dateTo = new Date();
+    session.selectedRequestId = null;
 
     dependencies.accounts = {
       query : {
@@ -41,20 +42,33 @@ angular.module('bhima.controllers')
       .then(init, handleError);
     });
 
-    function init (models) {
+    function init(models) {
       angular.extend(session, models);
     }
 
-    function handleError (err) {
+    function handleError(err) {
        messenger.danger($translate.instant('REPORT.ACCOUNT_STATEMENT.CANNOT_FIND_ACCOUNT') + ' ' + session.requestId);      
     }
 
-    function formatAccount (account) {
+    function formatAccount(account) {
+      if (account) {
+	if (!isNaN(account)) {
+	  var data = session.accounts.data.filter(function (obj) { 
+	    return obj.id === session.requestId; 
+	  })[0];
+	  session.selectedRequestId = session.requestId;
+	  session.requestId = data.account_txt + ' [' + data.account_number + ']';
+	}
+      }
       return account ? [account.account_txt].join(' ') : '';
     }
 
-    function requestAccount(accountId) {
-      if (accountId) { fetchReport(accountId); }
+    function requestAccount() {
+      if (session.selectedRequestId) { 
+	fetchReport(session.selectedRequestId); 
+	session.selectedRequestId = null;
+	session.requestId = null;
+      }
     }
 
     function fetchReport(accountId) {
@@ -86,7 +100,6 @@ angular.module('bhima.controllers')
 
     function initialise(model) {
       $scope.report = model.data;
-      console.log($scope.report);
       $scope.report.uuid = uuid();
     }
 
@@ -130,9 +143,9 @@ angular.module('bhima.controllers')
     //   throw error;
     // }
 
-    
 
     function print () { $window.print(); }
+
     $scope.print = print;
     $scope.requestAccount = requestAccount;
     $scope.formatAccount = formatAccount;


### PR DESCRIPTION
The account selector on the Report/Account Statement page shows the database ID number in the field once it is selected (before submission).  This mod changes it to display the Account name and number (similar to the drop-down menu during selection).  Once the user presses the [Submit] button, this field is cleared in case the user wants to start another search.  