### PR TITLE
Server Tests: Sanitize.js

### DIFF
--- a/server/lib/sanitize.js
+++ b/server/lib/sanitize.js
@@ -14,7 +14,7 @@ module.exports = {
 
   isIn : function (s) {  return String(s).indexOf('(') > -1; },
 
-  isFloat : function (f) { return parseFloat(f) !== undefined && ~f.toString().indexOf('.'); },
+  isFloat : function (f) { return parseFloat(f) !== undefined && f.toString().indexOf('.') > -1; },
 
   // this also works for hexadecimal ('0x12')
   isNumber: function (n) { return !Number.isNaN(Number(n)); },

--- a/server/test/sanitize.spec.js
+++ b/server/test/sanitize.spec.js
@@ -1,0 +1,67 @@
+// tests for server/lib/util/sanitize.js
+
+// FIXME
+// sanitize.js is deprecated and should be replaced with db.exec() escapes,
+// which are much safer.  See the db.js file for documentation on how to use
+// db.exec() to sanitize SQL inputs correctly.
+// However, since sanitize.js is still used in production code, these tests
+// should continue to be run until the sanitze.js file is extracted.
+
+var expect = require('chai').expect,
+    s = require('../lib/sanitize');
+
+describe('sanitize', function () {
+
+  describe('#isArray()', function () {
+    it('should recognize constructed arrays of various types', function () {
+      expect(s.isArray([1,2,'s'])).to.be.true;
+      expect(s.isArray({id: 1})).to.be.false;
+      expect(s.isArray('[1,2]')).to.be.false;
+      expect(s.isArray(1)).to.be.false;
+    });
+  });
+
+  describe('#escape()', function () {
+    it('should escape strings and integers correctly', function () {
+      expect(s.escape('id')).to.eql('"id"');
+      expect(s.escape(1)).to.eql('"1"');
+      expect(s.escape('12.4')).to.eql('"12.4"');
+    });
+  });
+
+  describe('#escapeid()', function () {
+    it('should escape ids with SQL tick marks', function () {
+      expect(s.escapeid('id')).to.eql('`id`');
+    });
+  });
+
+  describe('#isInt()', function () {
+    it('should recognize and convert integers', function () {
+      expect(s.isInt(0)).to.be.true;
+      expect(s.isInt(3)).to.be.true;
+      expect(s.isInt('3')).to.be.true;
+    });
+  });
+
+  describe('#isObject()', function () {
+    it('should recognize objects', function () {
+      expect(s.isObject({})).to.be.true;
+      expect(s.isObject('string')).to.be.false;
+    });
+  });
+
+  describe('#isFloat()', function () {
+    it('should recognize floats', function () {
+      expect(s.isFloat(3.5)).to.be.true;
+      expect(s.isFloat('3.5')).to.be.true;
+      expect(s.isFloat('5')).to.be.false;
+    });
+  });
+
+  describe('#isString()', function () {
+    it('should recognize strings', function () {
+      expect(s.isString('string')).to.be.true;
+      expect(s.isString(3)).to.be.false;
+    });
+  });
+});

--- a/server/test/set.spec.js
+++ b/server/test/set.spec.js
@@ -16,7 +16,7 @@ describe('set', function () {
       expect(results).to.eql(answer);
     });
 
-    it ('should not add a second item of the same value', function () {
+    it('should not add a second item of the same value', function () {
       var set = new Set();
 
       set.insert('a');


### PR DESCRIPTION
In this PR, I've added tests for sanitize.js that run as part of the bhima build.  The sanitize.js module __should__ be deprecated, but while we extract it from the server code, we should make sure that it continues working properly.

Partially fixes #306.