### PR TITLE
Remove JS linting from default gulp

### DIFF
--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -23,8 +23,6 @@ var paths = {
 
 gulp.task('scripts', function () {
   return gulp.src(paths.scripts)
-    .pipe(jshint(jshintrcPath))
-    .pipe(jshint.reporter('default'))
     .pipe(gulpif(UGLIFY, uglify()))
     .pipe(concat('js/bhima.min.js'))
     .pipe(gulp.dest(destPath));
@@ -92,5 +90,5 @@ gulp.task('i18n', function () {
 });
 
 gulp.task('default', [], function () {
-  gulp.start('lint', 'i18n', 'scripts', 'styles', 'assets', 'vendor', 'jquery', 'slick', 'static');
+  gulp.start('i18n', 'scripts', 'styles', 'assets', 'vendor', 'jquery', 'slick', 'static');
 });


### PR DESCRIPTION
In this PR:
 - Linting is no longer required for building the project.  You should still type `gulp lint` before submitting a PR, but it is unnecessary to run each time.

**Motivation:** On my (fairly high-powered) machine, it takes an average of 10 seconds to lint the whole repository.  See the attached output.  This leads to unnecessary wait for small changes.  We already have TravisCI to check these errors when submitting PRs.  (See #563)

```bash
[15:32:44] ⲗ →  for i in `seq 1 10`; do gulp lint; done
[15:33:38] Using gulpfile ~/code/bhima/client/gulpfile.js
[15:33:38] Starting 'lint'...
/home/jniles/code/bhima/client/src/partials/cash/extra_payment/extra_payment.js: line 182, col 20, Extending prototype of native object: 'Array'.

1 error
[15:33:47] Finished 'lint' after 9.7 s
[15:33:48] Using gulpfile ~/code/bhima/client/gulpfile.js
[15:33:48] Starting 'lint'...
/home/jniles/code/bhima/client/src/partials/cash/extra_payment/extra_payment.js: line 182, col 20, Extending prototype of native object: 'Array'.

1 error
[15:33:59] Finished 'lint' after 11 s
[15:33:59] Using gulpfile ~/code/bhima/client/gulpfile.js
[15:33:59] Starting 'lint'...
/home/jniles/code/bhima/client/src/partials/cash/extra_payment/extra_payment.js: line 182, col 20, Extending prototype of native object: 'Array'.

1 error
[15:34:10] Finished 'lint' after 11 s
[15:34:11] Using gulpfile ~/code/bhima/client/gulpfile.js
[15:34:11] Starting 'lint'...
/home/jniles/code/bhima/client/src/partials/cash/extra_payment/extra_payment.js: line 182, col 20, Extending prototype of native object: 'Array'.

1 error
[15:34:24] Finished 'lint' after 13 s
[15:34:25] Using gulpfile ~/code/bhima/client/gulpfile.js
[15:34:25] Starting 'lint'...
/home/jniles/code/bhima/client/src/partials/cash/extra_payment/extra_payment.js: line 182, col 20, Extending prototype of native object: 'Array'.

1 error
[15:34:36] Finished 'lint' after 11 s
[15:34:37] Using gulpfile ~/code/bhima/client/gulpfile.js
[15:34:37] Starting 'lint'...
/home/jniles/code/bhima/client/src/partials/cash/extra_payment/extra_payment.js: line 182, col 20, Extending prototype of native object: 'Array'.

1 error
[15:34:47] Finished 'lint' after 10 s
[15:34:48] Using gulpfile ~/code/bhima/client/gulpfile.js
[15:34:48] Starting 'lint'...
/home/jniles/code/bhima/client/src/partials/cash/extra_payment/extra_payment.js: line 182, col 20, Extending prototype of native object: 'Array'.

1 error
[15:34:58] Finished 'lint' after 11 s
[15:34:59] Using gulpfile ~/code/bhima/client/gulpfile.js
[15:34:59] Starting 'lint'...
/home/jniles/code/bhima/client/src/partials/cash/extra_payment/extra_payment.js: line 182, col 20, Extending prototype of native object: 'Array'.

1 error
[15:35:09] Finished 'lint' after 9.99 s
[15:35:10] Using gulpfile ~/code/bhima/client/gulpfile.js
[15:35:10] Starting 'lint'...
/home/jniles/code/bhima/client/src/partials/cash/extra_payment/extra_payment.js: line 182, col 20, Extending prototype of native object: 'Array'.

1 error
[15:35:21] Finished 'lint' after 11 s
[15:35:22] Using gulpfile ~/code/bhima/client/gulpfile.js
[15:35:22] Starting 'lint'...
/home/jniles/code/bhima/client/src/partials/cash/extra_payment/extra_payment.js: line 182, col 20, Extending prototype of native object: 'Array'.

1 error
[15:35:32] Finished 'lint' after 9.87 s
```