### PR TITLE
Impliment sorting/filtering on General Ledger

### DIFF
--- a/TODOs.md
+++ b/TODOs.md
@@ -1,0 +1,5 @@
+Miscellaneous TODOs
+------------------
+
+- [ ] Wrap slickgrid as a directive (`<data-grid id="glgrid"></data-grid>`)
+- [ ] Make column selection dropdown (as seen on the GL page) a directive (`<column-selection data-columns="grid.columns"></column-selection>`)

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -2984,5 +2984,12 @@
    "REGISTERED"       : "Registered villages",
    "SECTOR"           : "Sector",
    "TITLE"            : "Village Manager"
-   }
+   },
+"GRID" : {
+  "CLEAR" : "Clear Selection",
+  "UPDATE" : "Update Selection",
+  "REFRESH" : "Refresh Selection",
+  "GROUP_ROWS" : "Group Rows",
+  "ABOLISH_GROUPS" : "Abolish Grouping"
+}
 }

--- a/client/src/i18n/fr.json
+++ b/client/src/i18n/fr.json
@@ -2985,5 +2985,12 @@
    "REGISTERED"       : "Villages Enregistrés",
    "SECTOR"           : "Commune",
    "TITLE"            : "Gestion des Villages"
-   }
+   },
+"GRID" : {
+  "CLEAR" : "Clear Selection",
+  "UPDATE" : "Update Selection",
+  "REFRESH" : "Refresh Selection",
+  "GROUP_ROWS" : "Group Rows",
+  "ABOLISH_GROUPS" : "Abolish Grouping"
+}
 }

--- a/client/src/js/services/generalledger.js
+++ b/client/src/js/services/generalledger.js
@@ -1,0 +1,37 @@
+
+angular.module('bhima.services')
+.service('GeneralLedgerService', [
+  '$http',
+  '$q',
+  'messenger',
+  'store',
+  function ($http, $q, messenger, Store) {
+    'use strict';
+
+    this.load = function () {
+
+      var dfd = $q.defer();
+
+      $http.get('/ledgers/general')
+      .success(function (data) {
+
+        // package data into a nice store
+        var store = new Store({
+          identifier : 'uuid',
+          data       : data
+        });
+
+        dfd.resolve(store);
+      })
+      .error(function (data) {
+
+        // TODO: messenger's error warnings should be an $httpInterceptor
+        messenger.danger(data);
+        dfd.reject(data);
+      });
+
+      return dfd.promise;
+    };
+
+  }
+]);

--- a/client/src/js/services/gridhelper.js
+++ b/client/src/js/services/gridhelper.js
@@ -61,7 +61,7 @@ angular.module('bhima.services')
   /** collapsed is a boolean */
   service.grouping.byTransaction = function (dataview, collapsed) {
     var formatter = function (g) {
-      return '<span>TRANSACTION (' + g.value + ')</span>';
+      return '<span>TRANSACTION (<b>' + g.value + '</b>)</span>';
     };
 
     dataview.setGrouping({
@@ -86,7 +86,7 @@ angular.module('bhima.services')
   service.grouping.byAccount = function (dataview, collapsed) {
     var formatter = function (g) {
       // FIXME: THIS IS A HACK
-      return '<span>ACCOUNT (' + g.rows[0].account_number + ')</span>';
+      return '<span>ACCOUNT (<b>' + g.rows[0].account_number + '</b>)</span>';
     };
     dataview.setGrouping({
       getter: 'account_id',
@@ -130,26 +130,30 @@ angular.module('bhima.services')
   // matches the param
   service.filtering.filterFn = function (filter) {
     return function (item, args) {
-      if (filter.by.field || String(item[filter.by.field]).match(args.param)) {
+      if (!filter.by.field || String(item[filter.by.field]).match(args.param)) {
         return true;
       }
       return false;
     };
   };
 
+  service.filtering.init = function (dataview, filterFn) {
+    dataview.beginUpdate();
+    dataview.setFilter(filterFn);
+    dataview.setFilterArgs({ param : '' });
+    dataview.endUpdate();
+  };
+
   // clears the data in the filter and dataview
   service.filtering.clear = function (dataview, filter) {
     filter.param = '';
-    dataview.setFilterArgs({
-      param : filter.param
-    });
+    dataview.setFilterArgs(filter);
     dataview.refresh();
   };
 
   // updates the dataview to filter with the new parameter provided in filter
   service.filtering.update = function (dataview, filter) {
-    if (!filter.param) { return; }
-    dataview.setFilterArgs({ param : filter.param });
+    dataview.setFilterArgs(filter);
     dataview.refresh();
   };
 

--- a/client/src/js/services/gridhelper.js
+++ b/client/src/js/services/gridhelper.js
@@ -15,14 +15,15 @@ angular.module('bhima.services')
 
   // These column utitilites eliminate redundency by encapsulating
   // common actions on columns.  Currently supported:
-  // service.columns.toggleVisibleColumns(grid, columns):
+  // service.columns.filterColumns(grid, columns):
 
   // filter out columns with a false-y visible property
-  service.columns.toggleVisibileColumns = function (grid, columns) {
+  service.columns.filterColumns = function (grid, columns) {
+    if (!columns) { return; }
     var visibleColumns = columns.filter(function (column) {
       return column.visible;
     });
-    grid.setColumns(columns);
+    grid.setColumns(visibleColumns);
   };
 
 
@@ -35,7 +36,7 @@ angular.module('bhima.services')
   function sortFn(column) {
     return function (a,b) {
       var x = a[column], y = b[column];
-      return x - y;
+      return (x > y) ? 1 : -1;
     };
   }
 
@@ -45,9 +46,9 @@ angular.module('bhima.services')
     // set up the listener
     grid.onSort.subscribe(function (evt, args) {
       var key = args.sortCol.field,
-          sorter = sortFn(key);
+          comparer = sortFn(key);
 
-      dataview.sort(sorter, args.sortAsc);
+      dataview.sort(comparer, args.sortAsc);
     });
   };
 

--- a/client/src/js/services/gridhelper.js
+++ b/client/src/js/services/gridhelper.js
@@ -85,7 +85,8 @@ angular.module('bhima.services')
 
   service.grouping.byAccount = function (dataview, collapsed) {
     var formatter = function (g) {
-      return '<span>ACCOUNT (' + g.value + ')</span>';
+      // FIXME: THIS IS A HACK
+      return '<span>ACCOUNT (' + g.rows[0].account_number + ')</span>';
     };
     dataview.setGrouping({
       getter: 'account_id',
@@ -103,7 +104,7 @@ angular.module('bhima.services')
 
   // clears the grouping
   service.grouping.clear = function (dataview) {
-    dataview.setGrouping({});
+    dataview.setGrouping([]);
   };
 
   /** Filter utilities */
@@ -120,21 +121,35 @@ angular.module('bhima.services')
   // of the fitler property.
 
   // returns a new filter object
+  // "by" object controls view
+  // "param" controls what is filtered
   service.filtering.filter = function () {
-    return { by : {} };
+    return { by : {}, param : null };
+  };
+
+  // matches the param
+  service.filtering.filterFn = function (filter) {
+    return function (item, args) {
+      if (filter.by.field || String(item[filter.by.field]).match(args.param)) {
+        return true;
+      }
+      return false;
+    };
   };
 
   // clears the data in the filter and dataview
   service.filtering.clear = function (dataview, filter) {
-    filter.by = '';
-    dataview.setFilterArgs(filter);
+    filter.param = '';
+    dataview.setFilterArgs({
+      param : filter.param
+    });
     dataview.refresh();
   };
 
   // updates the dataview to filter with the new parameter provided in filter
   service.filtering.update = function (dataview, filter) {
-    if (!filter.by) { return; }
-    dataview.setFilterArgs(filter);
+    if (!filter.param) { return; }
+    dataview.setFilterArgs({ param : filter.param });
     dataview.refresh();
   };
 

--- a/client/src/js/services/gridhelper.js
+++ b/client/src/js/services/gridhelper.js
@@ -1,0 +1,141 @@
+/** helper functions for working with DataView and slickgrids*/
+angular.module('bhima.services')
+.factory('GridHelperFactory', function () {
+  // utilities for dataviews
+
+  var service = {
+    sorting : {},
+    filtering : {},
+    grouping : {},
+    columns : {}
+  };
+
+
+  /** Column Utilities */
+
+  // These column utitilites eliminate redundency by encapsulating
+  // common actions on columns.  Currently supported:
+  // service.columns.toggleVisibleColumns(grid, columns):
+
+  // filter out columns with a false-y visible property
+  service.columns.toggleVisibileColumns = function (grid, columns) {
+    var visibleColumns = columns.filter(function (column) {
+      return column.visible;
+    });
+    grid.setColumns(columns);
+  };
+
+
+  /** Sort Utilities */
+
+  // Sort utilities provides the framework for generic sorting on
+  // any column of the grid.
+
+  // create a sort function for a column
+  function sortFn(column) {
+    return function (a,b) {
+      var x = a[column], y = b[column];
+      return x - y;
+    };
+  }
+
+  // set up default sorting on the grid by column
+  service.sorting.setupSorting = function (grid, dataview) {
+
+    // set up the listener
+    grid.onSort.subscribe(function (evt, args) {
+      var key = args.sortCol.field,
+          sorter = sortFn(key);
+
+      dataview.sort(sorter, args.sortAsc);
+    });
+  };
+
+
+  /** Group/Grouping Utilities */
+
+  // Grouping utilities include variosu formatting options for collapsed
+  // groups as well as aggregators.
+
+  /** collapsed is a boolean */
+  service.grouping.byTransaction = function (dataview, collapsed) {
+    var formatter = function (g) {
+      return '<span>TRANSACTION (' + g.value + ')</span>';
+    };
+
+    dataview.setGrouping({
+      getter: 'trans_id',
+      formatter: formatter,
+      comparer : function (a, b) {
+        var x =  parseFloat(a.groupingKey.substr(3));
+        var y =  parseFloat(b.groupingKey.substr(3));
+        return x > y ? 1 : -1;
+      },
+      aggregators: [
+        new Slick.Data.Aggregators.Sum('debit'),
+        new Slick.Data.Aggregators.Sum('credit'),
+        new Slick.Data.Aggregators.Sum('debit_equiv'),
+        new Slick.Data.Aggregators.Sum('credit_equiv')
+      ],
+      aggregateCollapsed: collapsed,
+      lazyTotalsCalculation : true
+    });
+  };
+
+  service.grouping.byAccount = function (dataview, collapsed) {
+    var formatter = function (g) {
+      return '<span>ACCOUNT (' + g.value + ')</span>';
+    };
+    dataview.setGrouping({
+      getter: 'account_id',
+      formatter: formatter,
+      aggregators: [
+        new Slick.Data.Aggregators.Sum('debit'),
+        new Slick.Data.Aggregators.Sum('credit'),
+        new Slick.Data.Aggregators.Sum('debit_equiv'),
+        new Slick.Data.Aggregators.Sum('credit_equiv')
+      ],
+      aggregateCollapsed: collapsed,
+      lazyTotalsCalculation : true
+    });
+  };
+
+  // clears the grouping
+  service.grouping.clear = function (dataview) {
+    dataview.setGrouping({});
+  };
+
+  /** Filter utilities */
+
+  // Filtering works on a single column stored in the 'by' parameter
+  // of the filter object.  Once the fitler is created, it can be
+  // updated by using service.filtering.update(dv, filter).
+  //
+  // With the exception of the service.filtering.filter() method,
+  // all other methods accept a dataview as the first parameter and
+  // the filter object as the second.
+  //
+  // The current filter parameter is provided in the 'by' property
+  // of the fitler property.
+
+  // returns a new filter object
+  service.filtering.filter = function () {
+    return { by : {} };
+  };
+
+  // clears the data in the filter and dataview
+  service.filtering.clear = function (dataview, filter) {
+    filter.by = '';
+    dataview.setFilterArgs(filter);
+    dataview.refresh();
+  };
+
+  // updates the dataview to filter with the new parameter provided in filter
+  service.filtering.update = function (dataview, filter) {
+    if (!filter.by) { return; }
+    dataview.setFilterArgs(filter);
+    dataview.refresh();
+  };
+
+  return service;
+});

--- a/client/src/partials/journal/journal.grid.js
+++ b/client/src/partials/journal/journal.grid.js
@@ -13,7 +13,7 @@ angular.module('bhima.controllers')
     var columns, options, dataview, grid,
         manager = { session : {}, fn : {}, mode : {} };
 
-    // FIXME : this is <i>terrible</i>.  Never ever do this ever again
+    // FIXME : this is <i>terrible</i>.  Never ever do this ever again!
     appstate.set('journal.ready', ready.promise);
 
     dependencies.journal_bis = {

--- a/client/src/partials/journal/journal.grid.js
+++ b/client/src/partials/journal/journal.grid.js
@@ -13,6 +13,7 @@ angular.module('bhima.controllers')
     var columns, options, dataview, grid,
         manager = { session : {}, fn : {}, mode : {} };
 
+    // FIXME : this is <i>terrible</i>.  Never ever do this ever again
     appstate.set('journal.ready', ready.promise);
 
     dependencies.journal_bis = {

--- a/client/src/partials/journal/journal.utilities.js
+++ b/client/src/partials/journal/journal.utilities.js
@@ -321,7 +321,7 @@ angular.module('bhima.controllers')
       manager.fn.regroup();
     };
 
-    function filter (item, args) {
+    function filter(item, args) {
       if (!$scope.filter.by.field || String(item[$scope.filter.by.field]).match(args.param)) {
         return true;
       }
@@ -339,6 +339,5 @@ angular.module('bhima.controllers')
     };
 
     $scope.$watch('filter', $scope.updateFilter, true);
-
   }
 ]);

--- a/client/src/partials/journal/journal.utilities.js
+++ b/client/src/partials/journal/journal.utilities.js
@@ -257,6 +257,7 @@ angular.module('bhima.controllers')
     };
 
     // Toggle column visibility
+    // this is terrible
     $scope.$watch('columns', function () {
       if (!$scope.columns) { return; }
       var columns = $scope.columns.filter(function (column) { return column.visible; });

--- a/client/src/partials/reports/ledger/general_ledger.css
+++ b/client/src/partials/reports/ledger/general_ledger.css
@@ -1,6 +1,6 @@
 
-#general_ledger,
-#general_ledger div {
+#generalLedger,
+#generalLedger div {
   -webkit-box-sizing : content-box;
   -moz-box-sizing    : content-box;
   box-sizing         : content-box;

--- a/client/src/partials/reports/ledger/general_ledger.html
+++ b/client/src/partials/reports/ledger/general_ledger.html
@@ -47,7 +47,7 @@
 <main class="extend">
   <div class="row" style="height:99%;">
     <div class="col-xs-12" style="height:100%;">
-      <div id="general_ledger" class="grid" style="height: 100%; overflow: hidden; outline: 0px; position: relative; font-size: 8pt"></div>
+      <div id="generalLedger" class="grid" style="height: 100%; overflow: hidden; outline: 0px; position: relative; font-size: 8pt"></div>
     </div>
   </div>
 </main>

--- a/client/src/partials/reports/ledger/general_ledger.html
+++ b/client/src/partials/reports/ledger/general_ledger.html
@@ -8,10 +8,9 @@
       <span class="glyphicon glyphicon-list-alt"></span> {{ "REPORT.GROUP_ROWS" | translate }}
     </button>
     <ul class="dropdown-menu">
-      <li class="dropdown-header">{{ "REPORT.GROUPING" | translate }}</li>
       <li><a class="clk" ng-click="groupByTransaction()"><i class="glyphicon glyphicon-th-list"></i> {{ 'POSTING_JOURNAL.TRANSACTION' | translate }}</a></li>
       <li><a class="clk" ng-click="groupByAccount()"><i class="glyphicon glyphicon-euro"></i> {{ 'POSTING_JOURNAL.ACCOUNT' | translate }}</a></li>
-      <li><a class="clk" ng-click="clearGrouping()"><i class="glyphicon glyphicon-remove"></i> {{ 'POSTING_JOURNAL.ABOLISH_GROUPS' | translate }}</a></li>
+      <li><a class="clk" ng-click="clearGrouping()"><i class="glyphicon glyphicon-remove"></i> {{ 'GRID.ABOLISH_GROUPS' | translate }}</a></li>
     </ul>
   </div>
 
@@ -23,13 +22,15 @@
         {{ filter.by.name }}
       </button>
     </span>
+
     <input class="form-bhima" ng-model="filter.param" ng-change="updateFilter()">
+
     <ul class="dropdown-menu">
       <li ng-repeat="column in columns">
         <a ng-click="filterBy(column)" class="clk">{{ column.name }}</a>
       </li>
       <li>
-        <a ng-click="refreshfilter()" class="clk"><span class="glyphicon glyphicon-refresh"></span> {{ "POSTING_JOURNAL.REFRESH" | translate }}</a>
+        <a ng-click="clearFilter()" class="clk" ><i class="glyphicon glyphicon-remove"></i> {{ 'GRID.CLEAR' | translate }}</a>
       </li>
     </ul>
   </div>
@@ -44,7 +45,7 @@
       </li>
       <li ng-repeat="column in columns">
         <a class="clk" ng-click="column.visible=!column.visible">
-          <i class="glyphicon" ng-class="{'glyphicon-unchecked' : !column.visible, 'glyphicon-check' : !!column.visible}"></i> {{column.name || column.id}}
+          <i class="glyphicon" ng-class="{'glyphicon-unchecked' : !column.visible, 'glyphicon-check' : !!column.visible}"></i> {{ column.name }}
         </a>
       </li>
     </ul>

--- a/client/src/partials/reports/ledger/general_ledger.html
+++ b/client/src/partials/reports/ledger/general_ledger.html
@@ -9,22 +9,29 @@
     </button>
     <ul class="dropdown-menu">
       <li class="dropdown-header">{{ "REPORT.GROUPING" | translate }}</li>
-      <li ng-repeat="groupDefinition in groupDefinitions">
-        <a ng-click="groupby(groupDefinition)">{{ groupDefinition.title }}</a>
-      </li>
+      <li><a class="clk" ng-click="groupByTransaction()"><i class="glyphicon glyphicon-th-list"></i> {{ 'POSTING_JOURNAL.TRANSACTION' | translate }}</a></li>
+      <li><a class="clk" ng-click="groupByAccount()"><i class="glyphicon glyphicon-euro"></i> {{ 'POSTING_JOURNAL.ACCOUNT' | translate }}</a></li>
+      <li><a class="clk" ng-click="clearGrouping()"><i class="glyphicon glyphicon-remove"></i> {{ 'POSTING_JOURNAL.ABOLISH_GROUPS' | translate }}</a></li>
     </ul>
   </div>
 
-  <div class="pull-left">
-    <ol class="breadcrumb">
-      <li>{{ "REPORT.GROUP_DETAIL" | translate }}</li>
-      <li ng-repeat="activeGroup in groups">
-        <span class="label label-info" style="white-space:inherit;"> <!-- FIXME: style hack -->
-          {{ activeGroup.title }}
-        </span>
+  <div class="pull-left dropdown input-group col-xs-4">
+    <span class="input-group-btn dropdown-toggle" style="background : white;">
+      <button class="btn btn-sm btn-default" type="button" ng-class="{'active': !!filter.by && !!filter.param }">
+        <span class="glyphicon glyphicon-filter"></span>
+        <span class="caret" data-caret="&#9660;"></span>
+        {{ filter.by.name }}
+      </button>
+    </span>
+    <input class="form-bhima" ng-model="filter.param" ng-change="updateFilter()">
+    <ul class="dropdown-menu">
+      <li ng-repeat="column in columns">
+        <a ng-click="filterBy(column)" class="clk">{{ column.name }}</a>
       </li>
-      <li ng-if="groups.length>0"><span class="label label-danger" style="cursor:pointer;" ng-click="removeLastGroup()"><span class="glyphicon glyphicon-chevron-left"></span><span class="glyphicon glyphicon-remove"></span></span></li>
-    </ol>
+      <li>
+        <a ng-click="refreshfilter()" class="clk"><span class="glyphicon glyphicon-refresh"></span> {{ "POSTING_JOURNAL.REFRESH" | translate }}</a>
+      </li>
+    </ul>
   </div>
 
   <div class="pull-right dropdown">

--- a/client/src/partials/reports/ledger/general_ledger.js
+++ b/client/src/partials/reports/ledger/general_ledger.js
@@ -44,7 +44,7 @@ angular.module('bhima.controllers')
       }
 
       function formatDate (row, cell, value) {
-        return $filter('date')(value);
+        return $filter('date')(value, 'yyyy-MM-dd');
       }
 
       function formatGroupTotalRow(totals, column) {
@@ -57,16 +57,14 @@ angular.module('bhima.controllers')
 
       columns = [
         {id: 'uuid'           , name: $translate.instant('COLUMNS.ID')             , field:'uuid'           , visible : false} ,
-        {id: 'fiscal_year_id' , name: $translate.instant('COLUMNS.FISCAL_YEAR_ID') , field:'fiscal_year_id' , visible : true } ,
-        {id: 'period_id'      , name: $translate.instant('COLUMNS.PERIOD_ID')      , field:'period_id'      , visible : true } ,
+        {id: 'fiscal_year_id' , name: $translate.instant('COLUMNS.FISCAL_YEAR_ID') , field:'fiscal_year_id' , visible : false} ,
+        {id: 'period_id'      , name: $translate.instant('COLUMNS.PERIOD_ID')      , field:'period_id'      , visible : false} ,
         {id: 'trans_id'       , name: $translate.instant('COLUMNS.TRANS_ID')       , field:'trans_id'       , visible : true } ,
         {id: 'trans_date'     , name: $translate.instant('COLUMNS.DATE')           , field:'trans_date'     , visible : true   , formatter: formatDate  , sortable : true },
-        {id: 'doc_num'        , name: $translate.instant('COLUMNS.DOCUMENT_ID')    , field:'doc_num'        , visible : true } ,
+        {id: 'doc_num'        , name: $translate.instant('COLUMNS.DOCUMENT_ID')    , field:'doc_num'        , visible : false} ,
         {id: 'description'    , name: $translate.instant('COLUMNS.DESCRIPTION')    , field:'description'    , visible : true } ,
         {id: 'account_number' , name: $translate.instant('COLUMNS.ACCOUNT_NUMBER') , field:'account_number' , visible : true   , sortable : true } ,
         {id: 'account_id'     , name: $translate.instant('COLUMNS.ACCOUNT_ID')     , field:'account_id'     , visible : false} ,
-        {id: 'debit'          , name: $translate.instant('COLUMNS.DEBIT')          , field:'debit'          , visible : false  , formatter: formatAmount , groupTotalsFormatter: formatGroupTotalRow}  ,
-        {id: 'credit'         , name: $translate.instant('COLUMNS.CREDIT')         , field:'credit'         , visible : false  , formatter: formatAmount , groupTotalsFormatter: formatGroupTotalRow}  ,
         {id: 'debit_equiv'    , name: $translate.instant('COLUMNS.DEB_EQUIV')      , field:'debit_equiv'    , visible : true   , formatter: formatEquiv  , groupTotalsFormatter: formatGroupTotalRow } ,
         {id: 'credit_equiv'   , name: $translate.instant('COLUMNS.CRE_EQUIV')      , field:'credit_equiv'   , visible : true   , formatter: formatEquiv  , groupTotalsFormatter: formatGroupTotalRow}  ,
         {id: 'currency_id'    , name: $translate.instant('COLUMNS.CURRENCY')       , field:'currency_id'    , visible : false} ,
@@ -82,10 +80,11 @@ angular.module('bhima.controllers')
       $scope.columns = angular.copy(columns);
 
       options = {
+        enableTextSelectionOnCells : true,
         enableCellNavigation: true,
         enableColumnReorder: true,
         forceFitColumns: true,
-        rowHeight: 35,
+        rowHeight: 35
       };
     }
 
@@ -108,27 +107,47 @@ angular.module('bhima.controllers')
       });
 
       grid = new Slick.Grid('#generalLedger', dataview, columns, options);
-      grid.setSelectionModel(new Slick.RowSelectionModel());
 
       grid.registerPlugin(groupItemMetadataProvider);
+      grid.setSelectionModel(new Slick.RowSelectionModel({ selectActiveRow: false }));
 
       // set up sorting
       GridHelper.sorting.setupSorting(grid, dataview);
 
+      // intialize the items
       dataview.beginUpdate();
       dataview.setItems($scope.ledger.data, 'uuid');
       dataview.endUpdate();
 
       dataview.syncGridSelection(grid, true);
 
-      // filter stuff
-      dataview.beginUpdate();
-      dataview.setFilter(filterFn);
-      dataview.setFilterArgs({
-        param : ''
-      });
-      dataview.endUpdate();
 
+      var filter = $scope.filter = GridHelper.filtering.filter();
+      var filterFn = GridHelper.filtering.filterFn(filter);
+
+      // filtering controls
+
+      function clearFilter() {
+        GridHelper.filtering.clear(dataview, filter);
+      }
+
+      // sets the filter.by parameter to the given column
+      function filterBy(column) {
+        filter.by = column;
+      }
+
+      // updates on ng-model change
+      function updateFilter() {
+        GridHelper.filtering.update(dataview, filter);
+      }
+
+      // init filtering
+      GridHelper.filtering.init(dataview, filterFn);
+
+      // expose filtering
+      $scope.updateFilter = updateFilter;
+      $scope.clearFilter = clearFilter;
+      $scope.filterBy = filterBy;
     }
 
     // grouping
@@ -149,33 +168,9 @@ angular.module('bhima.controllers')
       GridHelper.columns.filterColumns(grid, cols);
     }, true);
 
-    // filtering controls
-    
-    var filter = $scope.filter = GridHelper.filtering.filter();
-    var filterFn = GridHelper.filtering.filterFn(filter);
-
-    function refreshFilter() {
-      GridHelper.filtering.clear(dataview, filter);
-    }
-
-    // sets the filter.by parameter to the given column
-    function filterBy(column) {
-      filter.by = column;
-    }
-
-    // updates on ng-model change
-    function updateFilter() { 
-      GridHelper.filtering.update(dataview, filter);
-    }
-
     // expose groupings
     $scope.groupByTransaction = groupByTransaction;
     $scope.groupByAccount = groupByAccount;
     $scope.clearGrouping = clearGrouping;
-    
-    // expose filtering
-    $scope.refreshFilter = refreshFilter;
-    $scope.updateFilter = updateFilter;
-    $scope.filterBy = filterBy;
   }
 ]);

--- a/client/src/partials/reports/ledger/general_ledger.js
+++ b/client/src/partials/reports/ledger/general_ledger.js
@@ -60,7 +60,7 @@ angular.module('bhima.controllers')
         {id: 'fiscal_year_id' , name: $translate.instant('COLUMNS.FISCAL_YEAR_ID') , field:'fiscal_year_id' , visible : true } ,
         {id: 'period_id'      , name: $translate.instant('COLUMNS.PERIOD_ID')      , field:'period_id'      , visible : true } ,
         {id: 'trans_id'       , name: $translate.instant('COLUMNS.TRANS_ID')       , field:'trans_id'       , visible : true } ,
-        {id: 'trans_date'     , name: $translate.instant('COLUMNS.DATE')           , field:'trans_date'     , visible : true   , formatter: formatDate}  ,
+        {id: 'trans_date'     , name: $translate.instant('COLUMNS.DATE')           , field:'trans_date'     , visible : true   , formatter: formatDate  , sortable : true },
         {id: 'doc_num'        , name: $translate.instant('COLUMNS.DOCUMENT_ID')    , field:'doc_num'        , visible : true } ,
         {id: 'description'    , name: $translate.instant('COLUMNS.DESCRIPTION')    , field:'description'    , visible : true } ,
         {id: 'account_number' , name: $translate.instant('COLUMNS.ACCOUNT_NUMBER') , field:'account_number' , visible : true } ,
@@ -135,12 +135,9 @@ angular.module('bhima.controllers')
       GridHelper.grouping.clear();
     }
 
-    $scope.$watch('columns', function () {
-      if (!$scope.columns) { return; }
-      var columns = $scope.columns.filter(function (column) {
-        return column.visible;
-      });
-      grid.setColumns(columns);
+    // make sure that columns are properly filtered
+    $scope.$watch('columns', function (cols) {
+      GridHelper.columns.filterColumns(grid, cols);
     }, true);
 
     $scope.groupByTransaction = groupByTransaction;

--- a/client/src/partials/reports/ledger/general_ledger.js
+++ b/client/src/partials/reports/ledger/general_ledger.js
@@ -11,6 +11,8 @@ angular.module('bhima.controllers')
     var dependencies = {};
     var columns, dataview, options, grid, groups = $scope.groups = [];
 
+
+
     dependencies.ledger = {
       query : {
         tables : {

--- a/client/src/partials/reports/ledger/general_ledger.js
+++ b/client/src/partials/reports/ledger/general_ledger.js
@@ -63,7 +63,8 @@ angular.module('bhima.controllers')
         {id: 'trans_date'     , name: $translate.instant('COLUMNS.DATE')           , field:'trans_date'     , visible : true   , formatter: formatDate  , sortable : true },
         {id: 'doc_num'        , name: $translate.instant('COLUMNS.DOCUMENT_ID')    , field:'doc_num'        , visible : true } ,
         {id: 'description'    , name: $translate.instant('COLUMNS.DESCRIPTION')    , field:'description'    , visible : true } ,
-        {id: 'account_number' , name: $translate.instant('COLUMNS.ACCOUNT_NUMBER') , field:'account_number' , visible : true } ,
+        {id: 'account_number' , name: $translate.instant('COLUMNS.ACCOUNT_NUMBER') , field:'account_number' , visible : true   , sortable : true } ,
+        {id: 'account_id'     , name: $translate.instant('COLUMNS.ACCOUNT_ID')     , field:'account_id'     , visible : false} ,
         {id: 'debit'          , name: $translate.instant('COLUMNS.DEBIT')          , field:'debit'          , visible : false  , formatter: formatAmount , groupTotalsFormatter: formatGroupTotalRow}  ,
         {id: 'credit'         , name: $translate.instant('COLUMNS.CREDIT')         , field:'credit'         , visible : false  , formatter: formatAmount , groupTotalsFormatter: formatGroupTotalRow}  ,
         {id: 'debit_equiv'    , name: $translate.instant('COLUMNS.DEB_EQUIV')      , field:'debit_equiv'    , visible : true   , formatter: formatEquiv  , groupTotalsFormatter: formatGroupTotalRow } ,
@@ -74,7 +75,7 @@ angular.module('bhima.controllers')
         {id: 'inv_po_id'      , name: $translate.instant('COLUMNS.INVPO_ID')       , field:'inv_po_id'      , visible : true } ,
         {id: 'comment'        , name: $translate.instant('COLUMNS.COMMENT')        , field:'comment'        , visible : false} ,
         {id: 'origin_id'      , name: $translate.instant('COLUMNS.ORIGIN_ID')      , field:'origin_id'      , visible : false} ,
-        {id: 'user_id'        , name: $translate.instant('COLUMNS.USER_ID')        , field:'user_id'        , visible : false}
+        {id: 'user_id'        , name: $translate.instant('COLUMNS.USER_ID')        , field:'user_id'        , visible : false  , sortable : true }
       ];
 
       // TODO : make this into a directive
@@ -119,8 +120,16 @@ angular.module('bhima.controllers')
       dataview.endUpdate();
 
       dataview.syncGridSelection(grid, true);
-    }
 
+      // filter stuff
+      dataview.beginUpdate();
+      dataview.setFilter(filterFn);
+      dataview.setFilterArgs({
+        param : ''
+      });
+      dataview.endUpdate();
+
+    }
 
     // grouping
     function groupByTransaction() {
@@ -132,7 +141,7 @@ angular.module('bhima.controllers')
     }
 
     function clearGrouping() {
-      GridHelper.grouping.clear();
+      GridHelper.grouping.clear(dataview);
     }
 
     // make sure that columns are properly filtered
@@ -140,8 +149,33 @@ angular.module('bhima.controllers')
       GridHelper.columns.filterColumns(grid, cols);
     }, true);
 
+    // filtering controls
+    
+    var filter = $scope.filter = GridHelper.filtering.filter();
+    var filterFn = GridHelper.filtering.filterFn(filter);
+
+    function refreshFilter() {
+      GridHelper.filtering.clear(dataview, filter);
+    }
+
+    // sets the filter.by parameter to the given column
+    function filterBy(column) {
+      filter.by = column;
+    }
+
+    // updates on ng-model change
+    function updateFilter() { 
+      GridHelper.filtering.update(dataview, filter);
+    }
+
+    // expose groupings
     $scope.groupByTransaction = groupByTransaction;
-    $scope.groupbyAccount = groupByAccount;
+    $scope.groupByAccount = groupByAccount;
     $scope.clearGrouping = clearGrouping;
+    
+    // expose filtering
+    $scope.refreshFilter = refreshFilter;
+    $scope.updateFilter = updateFilter;
+    $scope.filterBy = filterBy;
   }
 ]);

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -13,24 +13,25 @@
  */
 
 // Require application controllers
-var data            = require('./../controllers/data');
-var location        = require('./../controllers/location');
+var data            = require('../controllers/data');
+var locations       = require('../controllers/location');
 
-var createPurchase  = require('./../controllers/createPurchase');
-var createSale      = require('./../controllers/createSale');
+var createPurchase  = require('../controllers/createPurchase');
+var createSale      = require('../controllers/createSale');
 
-var serviceDist     = require('./../controllers/serviceDist');
-var consumptionLoss = require('./../controllers/consumptionLoss');
-var trialbalance    = require('./../controllers/trialbalance');
-var journal         = require('./../controllers/journal');
-var ledger          = require('./../controllers/ledger');
-var fiscal          = require('./../controllers/fiscal');
-var report          = require('./../controllers/report');
-var tree            = require('./../controllers/tree');
-var uncategorised   = require('./../controllers/uncategorised');
-var compileReport   = require('./../controllers/reports_proposed/reports.js');
-var snis            = require('./../controllers/snis');
-var extra           = require('./../controllers/extraPayment');
+var serviceDist     = require('../controllers/serviceDist');
+var consumptionLoss = require('../controllers/consumptionLoss');
+var trialbalance    = require('../controllers/trialbalance');
+var journal         = require('../controllers/journal');
+var ledger          = require('../controllers/ledger');
+var fiscal          = require('../controllers/fiscal');
+var report          = require('../controllers/report');
+var tree            = require('../controllers/tree');
+var uncategorised   = require('../controllers/uncategorised');
+var compileReport   = require('../controllers/reports_proposed/reports.js');
+var snis            = require('../controllers/snis');
+var extra           = require('../controllers/extraPayment');
+var gl              = require('../controllers/ledgers/general');
 
 
 
@@ -47,13 +48,13 @@ exports.initialise = function (app) {
 
   // location routes
   // -> /location/:scope(list || lookup)/:target(village || sector || province)/:id(optional)
-  app.get('/location/villages', location.allVillages);
-  app.get('/location/sectors', location.allSectors);
-  app.get('/location/provinces', location.allProvinces);
-  app.get('/location/village/:uuid', location.lookupVillage);
-  app.get('/location/sector/:uuid', location.lookupSector);
-  app.get('/location/province/:uuid', location.lookupProvince);
-  app.get('/location/detail/:uuid', location.lookupDetail);
+  app.get('/location/villages', locations.allVillages);
+  app.get('/location/sectors', locations.allSectors);
+  app.get('/location/provinces', locations.allProvinces);
+  app.get('/location/village/:uuid', locations.lookupVillage);
+  app.get('/location/sector/:uuid', locations.lookupSector);
+  app.get('/location/province/:uuid', locations.lookupProvince);
+  app.get('/location/detail/:uuid', locations.lookupDetail);
 
   // -> Add :route
   app.post('/report/build/:route', compileReport.build);
@@ -188,5 +189,9 @@ exports.initialise = function (app) {
 
   // Extra Payement
   app.post('/extraPayment/', extra.handleExtraPayment);
+
+  // general ledger controller
+  // transitioning to a more traditional angular application architecture
+  app.get('/ledgers/general', gl.route);
 
 };

--- a/server/controllers/ledgers/general.js
+++ b/server/controllers/ledgers/general.js
@@ -1,0 +1,24 @@
+
+var db = require('../../lib/db');
+
+/** queries the general ledger for all columns */
+// route: /ledgers/general
+exports.route = function (req, res, next) {
+  'use strict';
+  var sql;
+ 
+  sql =
+    'SELECT gl.uuid, gl.fiscal_year_id, gl.period_id, gl.trans_id, gl.trans_date, gl.doc_num, gl.description, ' +
+      'gl.account_id, gl.debit, gl.credit, gl.debit_equiv, gl.credit_equiv, gl.currency_id, gl.deb_cred_uuid, ' +
+      'gl.deb_cred_type, gl.inv_po_id, gl.comment, gl.cost_ctrl_id, gl.origin_id, gl.user_id, acc.account_number ' + 
+    'FROM general_ledger AS gl JOIN account AS acc ' +
+      'ON gl.account_id = acc.id ' +
+    'ORDER BY gl.trans_date;';
+
+  db.exec(sql)
+  .then(function (rows) {
+    res.send(rows);
+  })   
+  .catch(next)
+  .done();
+};

--- a/server/controllers/ledgers/general.js
+++ b/server/controllers/ledgers/general.js
@@ -5,9 +5,8 @@ var db = require('../../lib/db');
 // route: /ledgers/general
 exports.route = function (req, res, next) {
   'use strict';
-  var sql;
  
-  sql =
+  var sql =
     'SELECT gl.uuid, gl.fiscal_year_id, gl.period_id, gl.trans_id, gl.trans_date, gl.doc_num, gl.description, ' +
       'gl.account_id, gl.debit, gl.credit, gl.debit_equiv, gl.credit_equiv, gl.currency_id, gl.deb_cred_uuid, ' +
       'gl.deb_cred_type, gl.inv_po_id, gl.comment, gl.cost_ctrl_id, gl.origin_id, gl.user_id, acc.account_number ' + 


### PR DESCRIPTION
In this PR:
 - Sorting, column filtering and text filtering are implemented on the General Ledger.
 - Added a TODOs to keep track of work in progress

I've introduced two new services, `GridHelperService` and `GeneralLedgerService` to be responsible to providing functions common to SlickGrid and load data into the General Ledger.  In the future, we can use `GridHelperService` to maximize code reuse in the Posting Journal.

**NOTE**  This does not implement printing on the General Ledger.  That is a design issue that will have to be approached soon.

Partially addresses #571.