### PR TITLE
Find-Patient Directive Re-write

### DIFF
--- a/client/src/js/directives/findpatient.js
+++ b/client/src/js/directives/findpatient.js
@@ -11,10 +11,11 @@ angular.module('bhima.directives')
       var dependencies = {},
           cache = new AppCache('patientSearchDirective');
 
-      // mode is 'uuid' || 'fuzzy'
-      scope.mode = 'fuzzy';
-      scope.dirty = false;
-      scope.state = {};
+      var session = scope.session = {};
+
+      session.state = 'name'; // 'name || 'uuid'
+      session.submitted = false;
+      session.valid = null;
 
       // calls bhima API for a patient by uuid
       function uuidSearch(uuid) {
@@ -27,14 +28,24 @@ angular.module('bhima.directives')
         var url = '/patient/fuzzy/';
         return $http.get(url + text)
         .then(function (response) {
+          console.log('Got response:', response);
+
           response.data.results.map(function (item) {
             return item.first_name + ' ' + item.last_name;
           });
+
         });
       }
+      
+      function toggleSearch(s) {
+        session.method = s;
+      }
 
+      // expose to view
       scope.uuidSearch = uuidSearch;
-      scope.nameSearch = fuzzyNameSearch;
+      scope.fuzzyNameSearch = fuzzyNameSearch;
+      scope.toggleSearch = toggleSearch;
+
 
       scope.findPatient = {
         state : 'name',

--- a/client/src/js/directives/findpatient.js
+++ b/client/src/js/directives/findpatient.js
@@ -11,131 +11,81 @@ angular.module('bhima.directives')
       var dependencies = {},
           cache = new AppCache('patientSearchDirective');
 
-      var session = scope.session = {};
+      var session = scope.session = {},
+          input = scope.input = {};
 
       session.state = 'name'; // 'name || 'uuid'
       session.submitted = false;
       session.valid = null;
 
-      // calls bhima API for a patient by uuid
-      function uuidSearch(uuid) {
-        var url = '/patient/search/';
-        return $http.get(url + uuid);
+      // calls bhima API for a patient by hospital reference
+      // (e.g. HBB123)
+      function searchReference(ref) {
+        var url = '/patient/search/reference/';
+        return $http.get(url + ref);
       }
 
       // matches the patient's name via SOUNDEX()
       function fuzzyNameSearch(text) {
-        var url = '/patient/fuzzy/';
+        var url = '/patient/search/fuzzy/';
         return $http.get(url + text)
         .then(function (response) {
           console.log('Got response:', response);
-
-          response.data.results.map(function (item) {
-            return item.first_name + ' ' + item.last_name;
-          });
-
         });
       }
-      
+
+      // make a pretty label
+      function fmtPatient(p) {
+        return p.first_name + ' ' + p.last_name;
+      }
+
+      // change the input type
       function toggleSearch(s) {
         session.state = s;
       }
 
       // expose to view
-      scope.uuidSearch = uuidSearch;
+      scope.searchReference = searchReference;
       scope.fuzzyNameSearch = fuzzyNameSearch;
       scope.toggleSearch = toggleSearch;
-
-
-      scope.findPatient = {
-        state : 'name',
-        submitSuccess : false,
-        enableRefresh : scope.enableRefresh
-      };
+      scope.fmtPatient = fmtPatient;
 
       // init the module
       cache.fetch('state')
       .then(loadDefaultState);
 
-
-      // TODO should this be temporary?
-      function parseId(idString) {
-        var codeLength = 3, namespacedId = {};
-
-        // Current format VarChar(3):Int
-        namespacedId.projectCode = idString.substr(0, codeLength);
-        namespacedId.reference = idString.substr(codeLength);
-
-        // console.log(namespacedId);
-        if (!namespacedId.projectCode || !namespacedId.reference) { return null; }
-        if (isNaN(Number(namespacedId.reference))) { return null; }
-
-        // Ignore case temporary fix
-        // FIXME MySQL request is not case sensitive - only the get on a
-        //       model - this should be leveraged to not required uppercase
-        namespacedId.projectCode = namespacedId.projectCode.toUpperCase();
-        return namespacedId;
+      // once fuzzy search finds something,
+      // this is called
+      function selectPatient(patient) {
+        scope.patient = patient;
       }
 
-      function handleIdRequest(model) {
-        var debtor = scope.findPatient.debtor = extractMetaData(model.debtor.data)[0];
-        //Validate only one debtor matches
-        if (!debtor) {
-          return messenger.danger('Received invalid debtor, unknown');
-        }
-        scope.findPatient.valid = true;
-        scope.callback(debtor);
-        scope.findPatient.submitSuccess = true;
-      }
-
-      function extractMetaData(patientData) {
-
-        patientData.forEach(function(patient) {
-
-          // Searchable name
-          patient.name = patient.first_name + ' ' + patient.last_name;
-
-          // Age - naive quick method, not a priority to calculate the difference between two dates
-          patient.age = getAge(patient.dob);
-
-          // Human readable ID
-          // FIXME This should be a select CONCAT() from MySQL
-          patient.hr_id = patient.abbr.concat(patient.reference);
-        });
-
-        return patientData;
-      }
 
       // naive quick method to calculate the difference between two dates
       function getAge(date) {
         var current = new Date(),
             dob = (typeof date === 'object') ? date : new Date(date);
-        
+
         return current.getFullYear() - dob.getFullYear() - Math.round(current.getMonth() / 12 + dob.getMonth() / 12);
       }
 
       function validateNameSearch(value) {
         if (!value) { return true; }
 
-        if (typeof(value) === 'string') {
-          scope.findPatient.valid = false;
+        if (typeof value === 'string') {
+          session.valid = false;
           return true;
         }
-        scope.findPatient.valid = true;
+
+        session.valid = true;
       }
 
-      function resetSearch() {
-        scope.findPatient.valid = null;
-        scope.findPatient.submitSuccess = false;
-        scope.findPatient.selectedDebtor = null;
-        scope.findPatient.debtorId = null;
-        scope.findPatient.debtor = '';
+      function refresh() {
+        session.submitted = false;
+        session.valid = null;
+        input = {};
       }
 
-      function updateState(newState) {
-        scope.findPatient.state = newState;
-        cache.put('state', { state: newState });
-      }
 
       // FIXME Configure component on this data being available, avoid glitching interface
       function loadDefaultState(defaultState) {
@@ -146,8 +96,7 @@ angular.module('bhima.directives')
       }
 
       scope.validateNameSearch = validateNameSearch;
-      scope.findPatient.refresh = resetSearch;
-      scope.findPatient.updateState = updateState;
+      scope.refresh = refresh;
     }
   };
 }]);

--- a/client/src/js/directives/findpatient.js
+++ b/client/src/js/directives/findpatient.js
@@ -33,9 +33,9 @@ angular.module('bhima.directives')
       // matches the patient's name via SOUNDEX()
       function fuzzyNameSearch(text) {
         var url = '/patient/search/fuzzy/';
-        return $http.get(url + text)
+        return $http.get(url + text.toLowerCase())
         .then(function (response) {
-          console.log('Got response:', response);
+          return response.data;
         });
       }
 
@@ -60,10 +60,12 @@ angular.module('bhima.directives')
       cache.fetch('state')
       .then(loadDefaultState);
 
-      // once fuzzy search finds something,
-      // this is called
+      // this is called after $http requests are made,
       function selectPatient(patient) {
         scope.patient = patient;
+
+        // flush input away
+        scope.input = {};
 
         // show success ui response
         session.valid = true;
@@ -85,6 +87,7 @@ angular.module('bhima.directives')
         return current.getFullYear() - dob.getFullYear() - Math.round(current.getMonth() / 12 + dob.getMonth() / 12);
       }
 
+      // value is the selected typeahead model
       function validateNameSearch(value) {
         if (!value) { return true; }
 
@@ -113,6 +116,7 @@ angular.module('bhima.directives')
 
       scope.validateNameSearch = validateNameSearch;
       scope.refresh = refresh;
+      scope.selectPatient = selectPatient;
     }
   };
 }]);

--- a/client/src/js/directives/findpatient.js
+++ b/client/src/js/directives/findpatient.js
@@ -38,7 +38,7 @@ angular.module('bhima.directives')
       }
       
       function toggleSearch(s) {
-        session.method = s;
+        session.state = s;
       }
 
       // expose to view
@@ -57,12 +57,6 @@ angular.module('bhima.directives')
       cache.fetch('state')
       .then(loadDefaultState);
 
-      function searchUuid(value) {
-        dependencies.debtor.query.where = [
-          'patient.uuid=' + value
-        ];
-        validate.refresh(dependencies, ['debtor']).then(handleIdRequest);
-      }
 
       // TODO should this be temporary?
       function parseId(idString) {

--- a/client/src/partials/patient/group/assignment.html
+++ b/client/src/partials/patient/group/assignment.html
@@ -48,11 +48,3 @@
     </div>
   </div>
 </main>
-
-<script type="text/ng-template" id="debtorListItem.html">
-  <a>
-    <span bind-html-unsafe="match.label | typeaheadHighlight:query"></span>
-    <span><b>[{{match.model.uuid}}]</b></span>
-  </a>
-</script>
-

--- a/client/src/partials/patient/group/assignment.html
+++ b/client/src/partials/patient/group/assignment.html
@@ -1,5 +1,5 @@
 <header>
-  <span>{{ "PATIENT_GRP_ASSIGNMENT.TITLE" | translate }}</span>
+  {{ "PATIENT_GRP_ASSIGNMENT.TITLE" | translate }}
 </header>
 
 <nav>
@@ -9,17 +9,12 @@
       <li class="active">{{ "PATIENT_GRP_ASSIGNMENT.TITLE" | translate }}</li>
     </ol>
   </div>
-
-  <!-- FIXME not usefull input zone -->
-  <!-- <div class="pull-left ">
-    <input type="search" ng-model="flags.search" placeholder="Filter Debitor" class="form-bhima" size="25">
-  </div> -->
 </nav>
 
 <main>
   <div class="row margin-top-10">
     <div class="col-xs-7">
-      <div find-patient data-on-search-complete="loadPatientGroups"></div>
+      <find-patient on-search-complete="loadPatientGroups(patient)" enable-refresh="true"></find-patient>
     </div> 
   </div>
   <div class="row">

--- a/client/src/partials/patient/group/assignment.js
+++ b/client/src/partials/patient/group/assignment.js
@@ -66,7 +66,8 @@ angular.module('bhima.controllers')
       });
     }
 
-    function loadPatientGroups (patient) {
+    function loadPatientGroups(patient) {
+      console.log('Load Patient Groups:', patient);
       transformDatas(false);
       $scope.patient = patient;
       $scope.print = true;

--- a/client/src/partials/templates/debtorListItem.tmpl.html
+++ b/client/src/partials/templates/debtorListItem.tmpl.html
@@ -1,4 +1,3 @@
 <a>
   <span bind-html-unsafe="match.label | typeaheadHighlight:query"></span>
-  <span><b>[{{match.model.uuid}}]</b></span>
 </a>

--- a/client/src/partials/templates/findpatient.tmpl.html
+++ b/client/src/partials/templates/findpatient.tmpl.html
@@ -30,18 +30,19 @@
       <div ng-switch-when="name">
         <div class="input-group">
           <input
-          id="findSearch"
           type="text"
-          ng-model="findPatient.selectedDebtor"
-          typeahead="patient as patient.name for patient in fuzzyNameSearch($viewValue)"
+          class="form-bhima"
+          ng-model="input.model"
+          typeahead="patient as fmtPatient(patient) for patient in fuzzyNameSearch($viewValue)"
           placeholder="{{ 'FIND.PATIENT_NAME' | translate }}"
-          typeahead-wait-ms="200"
+          typeahead-wait-ms="100"
           typeahead-on-select="loadDebitor(debitor.id)"
           typeahead-template-url="/partials/templates/debtorListItem.tmpl.html"
-          class="form-bhima"
           size="25">
           <span class="input-group-btn">
-            <button id="submitSearch" ng-disabled="validateNameSearch(findPatient.selectedDebtor)" ng-click="submitDebtor(findPatient.selectedDebtor)" class="btn btn-sm btn-default"> {{ "FORM.SUBMIT" | translate }}</button>
+            <button ng-disabled="validateNameSearch(findPatient.selectedDebtor)" ng-click="selectPatient(input.model)" class="btn btn-sm btn-default">
+              {{ "FORM.SUBMIT" | translate }}
+            </button>
           </span>
         </div>
       </div> <!-- End searchName component -->
@@ -51,11 +52,13 @@
         <div class="input-group">
           <input
           type="text"
-          ng-model="findPatient.debtorId"
           class="form-bhima"
+          ng-model="input.term"
           placeholder="{{ 'FIND.PATIENT_ID' | translate }}">
           <span class="input-group-btn">
-            <button ng-click="uuidSearch(findPatient.debtorId)" class="btn btn-sm btn-default"> {{ "FORM.SUBMIT" | translate }} </button>
+            <button ng-click="searchReference(input.term)" class="btn btn-sm btn-default">
+              {{ "FORM.SUBMIT" | translate }}
+            </button>
           </span>
         </div>
       </div>

--- a/client/src/partials/templates/findpatient.tmpl.html
+++ b/client/src/partials/templates/findpatient.tmpl.html
@@ -1,24 +1,28 @@
-<div id="findPatient" class="panel panel-default" ng-class="{'panel-success': findPatient.valid, 'panel-danger': findPatient.valid===false}">
+<div id="findPatient" class="panel panel-default" ng-class="{'panel-success': findPatient.valid, 'panel-danger': findPatient.valid === false}">
   <div class="panel-heading ">
     <div ng-switch="findPatient.submitSuccess">
+
      <div ng-switch-when="false">
-       <span class="glyphicon glyphicon-search"></span> {{ "FIND.TITLE" | translate }}
+       <i class="glyphicon glyphicon-search"></i> {{ "FIND.TITLE" | translate }}
        <div class="pull-right">
          <a id="findById" style="cursor:pointer;" ng-class="{'link-selected': findPatient.state==='id'}" ng-click="findPatient.updateState('id')" class="patient-find"><span class="glyphicon glyphicon-pencil"></span> {{ "FIND.SEARCH_PATIENT_ID" | translate }} </a>
          <a id="findByName" style="cursor:pointer;" ng-class="{'link-selected': findPatient.state==='name'}" ng-click="findPatient.updateState('name')" class="patient-find"><span class="glyphicon glyphicon-user"></span> {{ "FIND.SEARCH_NAME" | translate }} </a>
        </div>
      </div>
+
      <div ng-switch-when="true">
        <!-- Style hack -->
-       <span style="margin-right: 5px;" class="glyphicon glyphicon-user"> </span> {{findPatient.debtor.name}} <small>({{findPatient.debtor.sex}} {{findPatient.debtor.age}})</small>
+       <i style="margin-right: 5px;" class="glyphicon glyphicon-user"></i> {{findPatient.debtor.name}} <small>({{findPatient.debtor.sex}} {{findPatient.debtor.age}})</small>
        <div class="pull-right" ng-if="findPatient.enableRefresh">
          <span ng-click="findPatient.refresh()" class="glyphicon glyphicon-repeat"></span>
        </div>
      </div>
     </div>
   </div>
+
   <div class="panel-body find-collapse" ng-show="!findPatient.submitSuccess">
     <div ng-switch on="findPatient.state">
+
       <div ng-switch-when="name">
         <div class="input-group">
           <input
@@ -36,15 +40,16 @@
           </span>
         </div>
       </div> <!-- End searchName component -->
+
       <div ng-switch-when="id">
         <div class="input-group">
           <input
-            type="text"
-            ng-model="findPatient.debtorId"
-            class="form-bhima"
-            placeholder="{{ 'FIND.PATIENT_ID' | translate }}">
+          type="text"
+          ng-model="findPatient.debtorId"
+          class="form-bhima"
+          placeholder="{{ 'FIND.PATIENT_ID' | translate }}">
           <span class="input-group-btn">
-            <button ng-click="submitDebtor(findPatient.debtorId)" class="btn btn-sm btn-default"> {{ "FORM.SUBMIT" | translate }} </button>
+            <button ng-click="uuidSearch(findPatient.debtorId)" class="btn btn-sm btn-default"> {{ "FORM.SUBMIT" | translate }} </button>
           </span>
         </div>
       </div>

--- a/client/src/partials/templates/findpatient.tmpl.html
+++ b/client/src/partials/templates/findpatient.tmpl.html
@@ -23,7 +23,7 @@
     </div>
   </div>
 
-  <div class="panel-body find-collapse" ng-hide="session.submitted && session.valid">
+  <div class="panel-body find-collapse" ng-if="!(session.submitted && session.valid)">
     <div ng-switch="session.state">
 
       <!-- search by name -->
@@ -35,12 +35,11 @@
           ng-model="input.model"
           typeahead="patient as fmtPatient(patient) for patient in fuzzyNameSearch($viewValue)"
           placeholder="{{ 'FIND.PATIENT_NAME' | translate }}"
-          typeahead-wait-ms="100"
-          typeahead-on-select="loadDebitor(debitor.id)"
+          typeahead-wait-ms="150"
           typeahead-template-url="/partials/templates/debtorListItem.tmpl.html"
           size="25">
           <span class="input-group-btn">
-            <button ng-disabled="validateNameSearch(findPatient.selectedDebtor)" ng-click="selectPatient(input.model)" class="btn btn-sm btn-default">
+            <button ng-disabled="validateNameSearch(input.model)" ng-click="selectPatient(input.model)" class="btn btn-sm btn-default">
               {{ "FORM.SUBMIT" | translate }}
             </button>
           </span>

--- a/client/src/partials/templates/findpatient.tmpl.html
+++ b/client/src/partials/templates/findpatient.tmpl.html
@@ -1,22 +1,24 @@
-<div id="findPatient" class="panel panel-default" ng-class="{'panel-success': findPatient.valid, 'panel-danger': findPatient.valid === false}">
-  <div class="panel-heading ">
-    <div ng-switch="findPatient.submitSuccess">
+<div class="panel panel-default" ng-class="{'panel-success': session.valid === true, 'panel-danger': session.valid === false }">
+  <div class="panel-heading">
 
-     <div ng-switch-when="false">
-       <i class="glyphicon glyphicon-search"></i> {{ "FIND.TITLE" | translate }}
-       <div class="pull-right">
-         <a id="findById" style="cursor:pointer;" ng-class="{'link-selected': findPatient.state==='id'}" ng-click="findPatient.updateState('id')" class="patient-find"><span class="glyphicon glyphicon-pencil"></span> {{ "FIND.SEARCH_PATIENT_ID" | translate }} </a>
-         <a id="findByName" style="cursor:pointer;" ng-class="{'link-selected': findPatient.state==='name'}" ng-click="findPatient.updateState('name')" class="patient-find"><span class="glyphicon glyphicon-user"></span> {{ "FIND.SEARCH_NAME" | translate }} </a>
-       </div>
-     </div>
+    <div ng-if="!session.submitted">
+      <i class="glyphicon glyphicon-search"></i> {{ "FIND.TITLE" | translate }}
+      <div class="pull-right">
+        <a style="cursor:pointer;" ng-class="{'link-selected': findPatient.state==='id'}" ng-click="toggleSearch('id')">
+          <i class="glyphicon glyphicon-pencil"></i> {{ "FIND.SEARCH_PATIENT_ID" | translate }}
+        </a>
+        <a style="cursor:pointer;" ng-class="{'link-selected': findPatient.state==='name'}" ng-click="toggleSearch('name')">
+          <i class="glyphicon glyphicon-user"></i> {{ "FIND.SEARCH_NAME" | translate }}
+        </a>
+      </div>
+    </div>
 
-     <div ng-switch-when="true">
-       <!-- Style hack -->
-       <i style="margin-right: 5px;" class="glyphicon glyphicon-user"></i> {{findPatient.debtor.name}} <small>({{findPatient.debtor.sex}} {{findPatient.debtor.age}})</small>
-       <div class="pull-right" ng-if="findPatient.enableRefresh">
-         <span ng-click="findPatient.refresh()" class="glyphicon glyphicon-repeat"></span>
-       </div>
-     </div>
+    <div ng-if="session.submitted">
+      <!-- Style hack -->
+      <i style="margin-right: 5px;" class="glyphicon glyphicon-user"></i> {{findPatient.debtor.name}} <small>({{findPatient.debtor.sex}} {{findPatient.debtor.age}})</small>
+      <div class="pull-right" ng-if="enableRefresh">
+        <i ng-click="refresh()" class="glyphicon glyphicon-repeat"></i>
+      </div>
     </div>
   </div>
 
@@ -29,8 +31,9 @@
           id="findSearch"
           type="text"
           ng-model="findPatient.selectedDebtor"
-          typeahead="patient as patient.name for patient in debtorList | filter:$viewValue | limitTo:8"
+          typeahead="patient as patient.name for patient in fuzzyNameSearch($viewValue)"
           placeholder="{{ 'FIND.PATIENT_NAME' | translate }}"
+          typeahead-wait-ms="200"
           typeahead-on-select="loadDebitor(debitor.id)"
           typeahead-template-url="/partials/templates/debtorListItem.tmpl.html"
           class="form-bhima"

--- a/client/src/partials/templates/findpatient.tmpl.html
+++ b/client/src/partials/templates/findpatient.tmpl.html
@@ -16,8 +16,8 @@
 
     <!-- banner after submission -->
     <div ng-if="session.submitted">
-      <i style="margin-right: 5px;" class="glyphicon glyphicon-user"></i> {{findPatient.debtor.name}} <small>({{findPatient.debtor.sex}} {{findPatient.debtor.age}})</small>
-      <div class="pull-right" ng-if="enableRefresh">
+      <i style="margin-right: 5px;" class="glyphicon glyphicon-user"></i> {{ patient.name }} <small>({{ patient.sex }} {{ patient.age }})</small>
+      <div class="pull-right" ng-if="enableRefresh" style="cursor:pointer;">
         <i ng-click="refresh()" class="glyphicon glyphicon-repeat"></i>
       </div>
     </div>

--- a/client/src/partials/templates/findpatient.tmpl.html
+++ b/client/src/partials/templates/findpatient.tmpl.html
@@ -1,20 +1,21 @@
 <div class="panel panel-default" ng-class="{'panel-success': session.valid === true, 'panel-danger': session.valid === false }">
   <div class="panel-heading">
 
+    <!-- banner before submission -->
     <div ng-if="!session.submitted">
       <i class="glyphicon glyphicon-search"></i> {{ "FIND.TITLE" | translate }}
       <div class="pull-right">
-        <a style="cursor:pointer;" ng-class="{'link-selected': findPatient.state==='id'}" ng-click="toggleSearch('id')">
+        <a style="cursor:pointer;" ng-class="{'link-selected': session.state === 'id' }" ng-click="toggleSearch('id')">
           <i class="glyphicon glyphicon-pencil"></i> {{ "FIND.SEARCH_PATIENT_ID" | translate }}
         </a>
-        <a style="cursor:pointer;" ng-class="{'link-selected': findPatient.state==='name'}" ng-click="toggleSearch('name')">
+        <a style="cursor:pointer;" ng-class="{'link-selected': session.state === 'name' }" ng-click="toggleSearch('name')">
           <i class="glyphicon glyphicon-user"></i> {{ "FIND.SEARCH_NAME" | translate }}
         </a>
       </div>
     </div>
 
+    <!-- banner after submission -->
     <div ng-if="session.submitted">
-      <!-- Style hack -->
       <i style="margin-right: 5px;" class="glyphicon glyphicon-user"></i> {{findPatient.debtor.name}} <small>({{findPatient.debtor.sex}} {{findPatient.debtor.age}})</small>
       <div class="pull-right" ng-if="enableRefresh">
         <i ng-click="refresh()" class="glyphicon glyphicon-repeat"></i>
@@ -22,9 +23,10 @@
     </div>
   </div>
 
-  <div class="panel-body find-collapse" ng-show="!findPatient.submitSuccess">
-    <div ng-switch on="findPatient.state">
+  <div class="panel-body find-collapse" ng-hide="session.submitted && session.valid">
+    <div ng-switch="session.state">
 
+      <!-- search by name -->
       <div ng-switch-when="name">
         <div class="input-group">
           <input
@@ -44,6 +46,7 @@
         </div>
       </div> <!-- End searchName component -->
 
+      <!-- search by uuid -->
       <div ng-switch-when="id">
         <div class="input-group">
           <input
@@ -56,6 +59,7 @@
           </span>
         </div>
       </div>
-    </div> <!--End find patient switch -->
+
+    </div>
   </div>
 </div>

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -198,7 +198,8 @@ exports.initialise = function (app) {
   app.get('/ledgers/general', gl.route);
 
   // search stuff
-  app.get('/search/patient/:uuid', patient.search);
-  app.get('/search/patient', patient.fuzzySearch);
+  app.get('/patient/:uuid', patient.searchUuid);
+  app.get('/patient/search/fuzzy/:match', patient.searchFuzzy);
+  app.get('/patient/search/reference/:reference', patient.searchReference);
 
 };

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -34,7 +34,7 @@ var extra           = require('../controllers/extraPayment');
 var gl              = require('../controllers/ledgers/general');
 
 
-var search          = require('../controllers/search');
+var patient = require('../controllers/patient');
 
 
 
@@ -198,7 +198,7 @@ exports.initialise = function (app) {
   app.get('/ledgers/general', gl.route);
 
   // search stuff
-  app.get('/search/patient/:uuid', search.patient);
-  app.get('/search/patient', search.patientFuzzy);
+  app.get('/search/patient/:uuid', patient.search);
+  app.get('/search/patient', patient.fuzzySearch);
 
 };

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -34,6 +34,9 @@ var extra           = require('../controllers/extraPayment');
 var gl              = require('../controllers/ledgers/general');
 
 
+var search          = require('../controllers/search');
+
+
 
 exports.initialise = function (app) {
   console.log('[config/routes] Configure routes');
@@ -193,5 +196,9 @@ exports.initialise = function (app) {
   // general ledger controller
   // transitioning to a more traditional angular application architecture
   app.get('/ledgers/general', gl.route);
+
+  // search stuff
+  app.get('/search/patient/:uuid', search.patient);
+  app.get('/search/patient', search.patientFuzzy);
 
 };

--- a/server/controllers/patient.js
+++ b/server/controllers/patient.js
@@ -17,11 +17,11 @@ exports.searchUuid = function (req, res, next) {
 
   // compose the sql query
   sql =
-    'SELECT p.uuid, p.project_id, p.debitor_uuid, p.first_name, p.last_name ' +
+    'SELECT p.uuid, p.project_id, p.debitor_uuid, p.first_name, p.last_name, ' +
       'p.sex, p.dob, p.origin_location_id, p.reference, proj.abbr, d.text, ' +
-      'dg.account_id, dg.price_list_uuid, d.is_convention, d.locked ' +
+      'dg.account_id, dg.price_list_uuid, dg.is_convention, dg.locked ' +
     'FROM patient AS p JOIN project AS proj JOIN debitor AS d JOIN debitor_group AS dg ' +
-    'ON p.debitor_uuid = d.uuid AND d.group_uuid = dg.uuid AND p.project_id = project.id' +
+    'ON p.debitor_uuid = d.uuid AND d.group_uuid = dg.uuid AND p.project_id = proj.id' +
     'WHERE p.uuid = ?;';
 
   db.exec(sql, [uuid])
@@ -50,21 +50,21 @@ exports.searchReference = function (req, res, next) {
   // use MYSQL to look up the reference
   // TODO This could probably be optimized
   sql =
-    'SELECT q.uuid, q.project_id, q.debitor_uuid, q.first_name, q.last_name ' +
-      'q.sex, q.dob, q.origin_location_id, q.reference, q.abbr, q.text, ' +
+    'SELECT q.uuid, q.project_id, q.debitor_uuid, q.first_name, q.last_name, ' +
+      'q.sex, q.dob, q.origin_location_id, q.reference, q.text, ' +
       'q.account_id, q.price_list_uuid, q.is_convention, q.locked ' +
     'FROM (' +
-      'SELECT p.uuid, p.project_id, p.debitor_uuid, p.first_name, p.last_name ' +
+      'SELECT p.uuid, p.project_id, p.debitor_uuid, p.first_name, p.last_name, ' +
       'p.sex, p.dob, CONCAT(proj.abbr, p.reference) AS reference, p.origin_location_id, d.text, ' +
-      'dg.account_id, dg.price_list_uuid, d.is_convention, d.locked ' +
+      'dg.account_id, dg.price_list_uuid, dg.is_convention, dg.locked ' +
       'FROM patient AS p JOIN project AS proj JOIN debitor AS d JOIN debitor_group AS dg ' +
-        'ON p.debitor_uuid = d.uuid AND d.group_uuid = dg.uuid AND p.project_id = project.id' +
+        'ON p.debitor_uuid = d.uuid AND d.group_uuid = dg.uuid AND p.project_id = proj.id' +
     ') AS q ' +
     'WHERE q.reference = ?;';
 
   db.exec(sql, [reference])
   .then(function (rows) {
-    
+
     if (empty(rows)) {
       res.status(404).send();
     } else {
@@ -88,11 +88,11 @@ exports.searchFuzzy = function (req, res, next) {
 
   // Do fuzzy searching on the match parameter
   sql =
-    'SELECT p.uuid, p.project_id, p.debitor_uuid, p.first_name, p.last_name ' +
+    'SELECT p.uuid, p.project_id, p.debitor_uuid, p.first_name, p.last_name, ' +
       'p.sex, p.dob, p.origin_location_id, p.reference, proj.abbr, d.text, ' +
-      'dg.account_id, dg.price_list_uuid, d.is_convention, d.locked ' +
+      'dg.account_id, dg.price_list_uuid, dg.is_convention, dg.locked ' +
     'FROM patient AS p JOIN project AS proj JOIN debitor AS d JOIN debitor_group AS dg ' +
-    'ON p.debitor_uuid = d.uuid AND d.group_uuid = dg.uuid AND p.project_id = project.id' +
+    'ON p.debitor_uuid = d.uuid AND d.group_uuid = dg.uuid AND p.project_id = proj.id' +
     'WHERE SOUNDEX(p.first_name) = SOUNDEX(?) OR ' +
       'SOUNDEX(p.last_name) = SOUNDEX(?) LIMIT 10;';
 

--- a/server/controllers/patient.js
+++ b/server/controllers/patient.js
@@ -92,11 +92,14 @@ exports.searchFuzzy = function (req, res, next) {
       'p.sex, p.dob, p.origin_location_id, p.reference, proj.abbr, d.text, ' +
       'dg.account_id, dg.price_list_uuid, dg.is_convention, dg.locked ' +
     'FROM patient AS p JOIN project AS proj JOIN debitor AS d JOIN debitor_group AS dg ' +
-    'ON p.debitor_uuid = d.uuid AND d.group_uuid = dg.uuid AND p.project_id = proj.id' +
-    'WHERE SOUNDEX(p.first_name) = SOUNDEX(?) OR ' +
-      'SOUNDEX(p.last_name) = SOUNDEX(?) LIMIT 10;';
+    'ON p.debitor_uuid = d.uuid AND d.group_uuid = dg.uuid AND p.project_id = proj.id ' +
+    'WHERE LEFT(LOWER(CONCAT(p.first_name, \' \', p.last_name)), CHAR_LENGTH(?)) = ? OR ' +
+      'SOUNDEX(p.first_name) = SOUNDEX(?) OR ' +
+      'SOUNDEX(p.last_name) = SOUNDEX(?) OR ' +
+      'SOUNDEX(CONCAT(p.first_name, \' \', p.last_name)) = SOUNDEX(?) ' +
+    'LIMIT 10;';
 
-  db.exec(sql, [match, match])
+  db.exec(sql, [match, match, match, match, match])
   .then(function (rows) {
     res.status(200).json(rows);
   })

--- a/server/controllers/patient.js
+++ b/server/controllers/patient.js
@@ -1,7 +1,9 @@
 // patient controller
 
 var db = require('../lib/db'),
-    uuid = require('../lib/uuid');
+    guid = require('../lib/guid');
+
+
 
 // GET /patient/search/:uuid
 // Performs a get on the patient uuid
@@ -43,7 +45,7 @@ exports.fuzzySearch = function (req, res, next) {
     'FROM patient as p JOIN project as proj JOIN debitor as d JOIN debitor_group as dg ' +
     'ON p.debitor_uuid = d.uuid AND d.group_uuid = dg.uuid AND p.project_id = project.id' +
     'WHERE SOUNDEX(p.first_name) = SOUNDEX(?) OR ' +
-      'SOUNDEX(p.last_name) = SOUNDEX(?);';
+      'SOUNDEX(p.last_name) = SOUNDEX(?) LIMIT 10;';
 
   db.exec(sql, [match, match])
   .then(res.json)
@@ -62,7 +64,7 @@ exports.startVisit = function (req, res, next) {
     'INSERT INTO patient_visit (uuid, patient_uuid, entry_date, registered_by) VALUES ' +
     '(?, ?, ?, ?);';
 
-  db.exec(sql, [uuid(), patientId, new Date(), req.session.user_id])
+  db.exec(sql, [guid(), patientId, new Date(), req.session.user_id])
   .then(function () {
     res.send();
   })

--- a/server/controllers/patient.js
+++ b/server/controllers/patient.js
@@ -5,9 +5,9 @@ var db = require('../lib/db'),
 
 
 
-// GET /patient/search/:uuid
-// Performs a get on the patient uuid
-exports.search = function (req, res, next) {
+// GET /patient/:uuid
+// Get a patient by uuid
+exports.searchUuid = function (req, res, next) {
   'use strict';
 
   var sql, uuid = req.params.uuid;
@@ -25,13 +25,24 @@ exports.search = function (req, res, next) {
   .then(res.json)
   .catch(next)
   .done();
+};
+
+// GET /patient/search/reference/:reference
+// Performs a search on the patient reference (e.g. HBB123)
+exports.searchReference = function (req, res, next) {
+  'use strict';
+
+  var sql, reference = req.params.reference;
+
+  sql =
+    'SELECT ';
 
 };
 
-
-// GET /patient/fuzzy/:match
+// GET /patient/search/fuzzy/:match
 // Performs fuzzy searching on patient names
-exports.fuzzySearch = function (req, res, next) {
+exports.searchFuzzy = function (req, res, next) {
+  'use strict';
 
   var sql, match = req.params.match;
 

--- a/server/controllers/patient.js
+++ b/server/controllers/patient.js
@@ -1,0 +1,72 @@
+// patient controller
+
+var db = require('../lib/db'),
+    uuid = require('../lib/uuid');
+
+// GET /patient/search/:uuid
+// Performs a get on the patient uuid
+exports.search = function (req, res, next) {
+  'use strict';
+
+  var sql, uuid = req.params.uuid;
+
+  // compose the sql query
+  sql =
+    'SELECT p.uuid, p.project_id, p.debitor_uuid, p.first_name, p.last_name ' +
+      'p.sex, p.dob, p.origin_location_id, p.reference, proj.abbr, d.text, ' +
+      'dg.account_id, dg.price_list_uuid, d.is_convention, d.locked ' +
+    'FROM patient as p JOIN project as proj JOIN debitor as d JOIN debitor_group as dg ' +
+    'ON p.debitor_uuid = d.uuid AND d.group_uuid = dg.uuid AND p.project_id = project.id' +
+    'WHERE p.uuid = ?;';
+
+  db.exec(sql, [uuid])
+  .then(res.json)
+  .catch(next)
+  .done();
+
+};
+
+
+// GET /patient/fuzzy/:match
+// Performs fuzzy searching on patient names
+exports.fuzzySearch = function (req, res, next) {
+
+  var sql, match = req.params.match;
+
+  if (!match) { next(new Error('No parameter provided!')); }
+
+  // Do fuzzy searching on the match parameter
+  sql =
+    'SELECT p.uuid, p.project_id, p.debitor_uuid, p.first_name, p.last_name ' +
+      'p.sex, p.dob, p.origin_location_id, p.reference, proj.abbr, d.text, ' +
+      'dg.account_id, dg.price_list_uuid, d.is_convention, d.locked ' +
+    'FROM patient as p JOIN project as proj JOIN debitor as d JOIN debitor_group as dg ' +
+    'ON p.debitor_uuid = d.uuid AND d.group_uuid = dg.uuid AND p.project_id = project.id' +
+    'WHERE SOUNDEX(p.first_name) = SOUNDEX(?) OR ' +
+      'SOUNDEX(p.last_name) = SOUNDEX(?);';
+
+  db.exec(sql, [match, match])
+  .then(res.json)
+  .catch(next)
+  .done();
+};
+
+
+// POST /patient/visit/start
+exports.startVisit = function (req, res, next) { 
+  'use strict';
+
+  var sql, patientId = req.params.patientId;
+
+  sql =
+    'INSERT INTO patient_visit (uuid, patient_uuid, entry_date, registered_by) VALUES ' +
+    '(?, ?, ?, ?);';
+
+  db.exec(sql, [uuid(), patientId, new Date(), req.session.user_id])
+  .then(function () {
+    res.send();
+  })
+  .catch(next)
+  .done();
+};
+


### PR DESCRIPTION
This PR completely re-writes the find-patient directive to be lighter weight.  It uses a series of GET requests on the input to download and filter the data from the database, rather than a single pull of all patients in the database and client-side filtering.  Only 10 values are sent by MySQL at a time.

Additionally, we compliment the results with the `SOUNDEX()` MySQL algorithm to match potentially misspelled words.  This is interesting, but may be confusing for users and will need to be reviewed in user trials.

**NOTE** This PR is for concept review only.  The way we handle authentication is thoroughly broken and sometimes logs a user out when they search for an invalid reference.