### PR TITLE
Prioritize last name in find-patient directive

### DIFF
--- a/server/controllers/patient.js
+++ b/server/controllers/patient.js
@@ -93,10 +93,10 @@ exports.searchFuzzy = function (req, res, next) {
       'dg.account_id, dg.price_list_uuid, dg.is_convention, dg.locked ' +
     'FROM patient AS p JOIN project AS proj JOIN debitor AS d JOIN debitor_group AS dg ' +
     'ON p.debitor_uuid = d.uuid AND d.group_uuid = dg.uuid AND p.project_id = proj.id ' +
-    'WHERE LEFT(LOWER(CONCAT(p.first_name, \' \', p.last_name)), CHAR_LENGTH(?)) = ? OR ' +
+    'WHERE LEFT(LOWER(CONCAT(p.last_name, \' \', p.first_name )), CHAR_LENGTH(?)) = ? OR ' +
       'SOUNDEX(p.first_name) = SOUNDEX(?) OR ' +
       'SOUNDEX(p.last_name) = SOUNDEX(?) OR ' +
-      'SOUNDEX(CONCAT(p.first_name, \' \', p.last_name)) = SOUNDEX(?) ' +
+      'SOUNDEX(CONCAT(p.last_name, \' \', p.first_name)) = SOUNDEX(?) ' +
     'LIMIT 10;';
 
   db.exec(sql, [match, match, match, match, match])


### PR DESCRIPTION
As suggested by @lomamech, the find patient directive now prioritizes last names to be more culturally appropriate.