### PR TITLE
Run gulp watch by default

### DIFF
--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -90,5 +90,5 @@ gulp.task('i18n', function () {
 });
 
 gulp.task('default', [], function () {
-  gulp.start('i18n', 'scripts', 'styles', 'assets', 'vendor', 'jquery', 'slick', 'static');
+  gulp.start('i18n', 'scripts', 'styles', 'assets', 'vendor', 'jquery', 'slick', 'static', 'watch');
 });


### PR DESCRIPTION
This PR makes the default gulp command run gulp watch automatically.