### PR TITLE
FIX: broken req.session references

### DIFF
--- a/client/src/partials/journal_voucher/journal_voucher.js
+++ b/client/src/partials/journal_voucher/journal_voucher.js
@@ -83,6 +83,8 @@ angular.module('bhima.controllers')
         return;
       }
 
+      console.log('Submitting...', $scope.master);
+
       // submit to the server
       $http.post('/finance/journalvoucher', { data : $scope.master })
 

--- a/server/app.js
+++ b/server/app.js
@@ -9,10 +9,6 @@ var privateKey    = fs.readFileSync(config.tls.key, 'utf8');
 var certificate   = fs.readFileSync(config.tls.cert, 'utf8');
 var credentials   = { key : privateKey, cert : certificate };
 
-// Set the appropriate timezone for interpretting the server's data
-// NOTE : In a proper installation, this should be an environmental variable
-process.env.TZ = 'UTC';
-
 // Session configuration
 var db            = require('./lib/db').initialise();
 

--- a/server/app.js
+++ b/server/app.js
@@ -32,7 +32,7 @@ function logApplicationStart() {
 }
 
 function forceExit(err) {
-  console.error('[uncaughtException]', err.message);
+  console.error('[uncaughtException]', err, err.message);
   console.error(err.stack);
   process.exit(1);
 }

--- a/server/controllers/finance.js
+++ b/server/controllers/finance.js
@@ -79,6 +79,8 @@ exports.postJournalVoucher = function (req, res, next) {
 
   // turn into date object
   var date = new Date(data.date);
+  console.log('DATA:', data);
+  console.log('date:', date);
 
   // is the date in the future?
   if (date > new Date()) {
@@ -158,11 +160,13 @@ exports.postJournalVoucher = function (req, res, next) {
     // exchange the debits and credits.  Otherwise, do nothing.
     sql =
       'SELECT enterprise_currency_id, foreign_currency_id, rate ' +
-      'FROM exchange_rate WHERE date = DATE(?);';
+      'FROM exchange_rate WHERE DATE(date) = DATE(?);';
 
     return db.exec(sql, [date]);
   })
   .then(function (rows) {
+    
+    console.log('ExchangeRows: ', rows);
 
     if (rows.length < 1) {
       throw 'ERR_NO_EXCHANGE_RATE';

--- a/server/controllers/finance.js
+++ b/server/controllers/finance.js
@@ -79,8 +79,6 @@ exports.postJournalVoucher = function (req, res, next) {
 
   // turn into date object
   var date = new Date(data.date);
-  console.log('DATA:', data);
-  console.log('date:', date);
 
   // is the date in the future?
   if (date > new Date()) {
@@ -166,8 +164,6 @@ exports.postJournalVoucher = function (req, res, next) {
   })
   .then(function (rows) {
     
-    console.log('ExchangeRows: ', rows);
-
     if (rows.length < 1) {
       throw 'ERR_NO_EXCHANGE_RATE';
     }
@@ -252,7 +248,7 @@ exports.postJournalVoucher = function (req, res, next) {
     res.status(200).send('POST_SUCCESSFUL');
   })
   .catch(function (error) {
-    res.status(400).send(error);
+    res.status(500).send(error);
   });
 };
 

--- a/server/controllers/uncategorised.js
+++ b/server/controllers/uncategorised.js
@@ -159,7 +159,7 @@ exports.currentProject = function (req, res, next) {
   var sql =
     'SELECT `project`.`id`, `project`.`name`, `project`.`abbr`, `project`.`enterprise_id`, `enterprise`.`currency_id`, `enterprise`.`location_id`, `enterprise`.`name` as \'enterprise_name\', `enterprise`.`phone`, `enterprise`.`email`, `village`.`name` as \'village\', `sector`.`name` as \'sector\' ' +
     'FROM `project` JOIN `enterprise` ON `project`.`enterprise_id`=`enterprise`.`id` JOIN `village` ON `enterprise`.`location_id`=`village`.`uuid` JOIN `sector` ON `village`.`sector_uuid`=`sector`.`uuid` ' +
-    'WHERE `project`.`id`=' + req.session.project_id + ';';
+    'WHERE `project`.`id`=' + req.session.project.id + ';';
   db.exec(sql)
   .then(function (result) {
     res.send(result[0]);

--- a/server/lib/db.js
+++ b/server/lib/db.js
@@ -55,9 +55,7 @@ function exec(sql, params) {
   con.getConnection(function (err, connection) {
     if (err) { return defer.reject(err); }
 
-    // this lets me log the actual request
     connection.query(sql, params, function (err, results) {
-
       if (err) { return defer.reject(err); }
       connection.release();
       defer.resolve(results);


### PR DESCRIPTION
This PR fixes a critical bug that halted journal vouchers from posting due to a broken reference to `req.session.project_id`.  It has been updated with the correct syntax.  Also, `getTransactionId()` has been greatly improved.