### PR TITLE
Add `npm run app` to ease build process

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server/app.js",
   "scripts": {
     "test": "mocha server/test/",
-    "start": "cd client/ && gulp && cd .. && node server/app.js"
+    "app": "gulp build && cd bin && node server/app.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
You can now use `npm run app` from the top level to build and deploy build.  It's easier than lots of `cd`s.