### PR TITLE
Enable programmatic find-patient search

### DIFF
--- a/client/src/js/directives/findpatient.js
+++ b/client/src/js/directives/findpatient.js
@@ -5,6 +5,7 @@ angular.module('bhima.directives')
     templateUrl : 'partials/templates/findpatient.tmpl.html',
     scope : {
       callback : '&onSearchComplete',
+      initLookup : '=?',
       enableRefresh : '=',
     },
     link : function(scope, element, attrs) {
@@ -37,6 +38,17 @@ angular.module('bhima.directives')
         .then(function (response) {
           return response.data;
         });
+      }
+
+      // calls bhima API with uuid
+      function searchByUuid(uuid) {
+        var url = '/patient/';
+        $http.get(url + uuid)
+        .success(selectPatient)
+        .error(function (err) {
+          console.error(err); 
+        })
+        .finally();
       }
 
       // make a pretty label
@@ -139,6 +151,12 @@ angular.module('bhima.directives')
       function saveState(dstate) {
         cache.put('state', dstate);
       }
+
+      // when the init-lookup value changes, force a refresh on that patient
+      // allows you to coerce the find patient to execute when recovering previous data
+      scope.$watch('initLookup', function (value) {
+        if (value) { searchByUuid(value); }
+      });
 
       scope.validateNameSearch = validateNameSearch;
       scope.refresh = refresh;

--- a/client/src/partials/sales/sales.html
+++ b/client/src/partials/sales/sales.html
@@ -25,7 +25,7 @@
 
   <div class="row margin-top-10">
     <div class="col-xs-12">
-      <div find-patient on-search-complete="initialiseSaleDetails(patient)" enable-refresh="false"></div>
+      <div find-patient init-lookup="session.findPatientId" on-search-complete="initialiseSaleDetails(patient)" enable-refresh="true"></div>
     </div>
   </div>
   <div

--- a/client/src/partials/sales/sales.js
+++ b/client/src/partials/sales/sales.js
@@ -499,12 +499,16 @@ angular.module('bhima.controllers')
     function selectRecover() {
       $scope.session.recovering = true;
 
-      $scope.findPatient.forceSelect($scope.session.recovered.patientId);
+      // FIXME
+      // This is a cheeky way to refresh the session by changing a value
+      // the find-patient directive is looking for.
+      $scope.session.findPatientId = $scope.session.recovered.patientId;
 
       serviceComponent.selected = $scope.session.recovered.service;
       assignService();
     }
 
+    // recover a patient's sale
     function recover() {
 
       invoice.service = $scope.session.recovered.service || null;
@@ -518,6 +522,7 @@ angular.module('bhima.controllers')
 
 
       // FIXME this is stupid
+      // @sfount -- jeez man, no need to be so hard on yourself.
       session.displayRecover = true;
 
       session.recovering = false;

--- a/server/controllers/patient.js
+++ b/server/controllers/patient.js
@@ -21,7 +21,7 @@ exports.searchUuid = function (req, res, next) {
       'p.sex, p.dob, p.origin_location_id, p.reference, proj.abbr, d.text, ' +
       'dg.account_id, dg.price_list_uuid, dg.is_convention, dg.locked ' +
     'FROM patient AS p JOIN project AS proj JOIN debitor AS d JOIN debitor_group AS dg ' +
-    'ON p.debitor_uuid = d.uuid AND d.group_uuid = dg.uuid AND p.project_id = proj.id' +
+    'ON p.debitor_uuid = d.uuid AND d.group_uuid = dg.uuid AND p.project_id = proj.id ' +
     'WHERE p.uuid = ?;';
 
   db.exec(sql, [uuid])
@@ -34,7 +34,6 @@ exports.searchUuid = function (req, res, next) {
     } else {
       res.status(200).json(rows[0]);
     }
-
   })
   .catch(next)
   .done();


### PR DESCRIPTION
This PR fixes #633 by implementing a new find-patient directive option: `init-lookup={uuid}`.  The find-patient directive listens for changes to this uuid and executes a search to `/patient/:uuid` when it changes.  This enables sale recovery to simply define the value as the old patient uuid, and that patient's information is loaded.