### PR TITLE
use rimraf instead of del for windows

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,7 +12,7 @@ var gulp       = require('gulp'),
     minifycss  = require('gulp-minify-css'),
     jshint     = require('gulp-jshint'),
     flatten    = require('gulp-flatten'),
-    del        = require('del'),
+    rimraf     = require('rimraf'),
 
     // mocha for server-side testing
     mocha      = require('gulp-mocha'),
@@ -83,7 +83,7 @@ var paths = {
 
 // removes files with del, and continues
 gulp.task('client-clean', function (cb) {
-  del([CLIENT_FOLDER], cb);
+  rimraf(CLIENT_FOLDER, cb);
 });
 
 // run jshint on the client javascript code
@@ -166,7 +166,9 @@ gulp.task('build-client', ['client-clean'], function () {
 */
 
 gulp.task('server-clean', function (cb) {
-  del([SERVER_FOLDER, PLUGIN_FOLDER], cb);
+  rimraf(SERVER_FOLDER, function () {
+    rimraf(PLUGIN_FOLDER, cb);
+  });
 });
 
 // run jshint on all server javascript files
@@ -212,7 +214,7 @@ gulp.task('build', ['build-client', 'build-server']);
 gulp.task('webdriver-standalone', webdriver);
 
 gulp.task('clean', function (cb) {
-  del(['./bin/'], cb);
+  rimraf('./bin/', cb);
 });
 
 gulp.task('build', ['clean'], function () {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "gulp-protractor": "^1.0.0",
     "gulp-uglify": "~1.2.0",
     "mocha": "^2.0.1",
-    "protractor": "^2.2.0"
+    "protractor": "^2.2.0",
+    "rimraf": "^2.4.3"
   }
 }


### PR DESCRIPTION
Potentially fixes #669.  According to [this SO question](http://stackoverflow.com/questions/28885074/running-del-npm-dependency-from-package-json-script-on-windows), the `del` npm module might have errors on windows.  This PR uses `rimraf` instead.