### PR TITLE
Fix cotisation creation

### DIFF
--- a/client/src/partials/cotisation/create/create_cotisation.html
+++ b/client/src/partials/cotisation/create/create_cotisation.html
@@ -18,7 +18,7 @@
   </div>
 </nav>
 
-<main>
+<main class="extend">
   <div class="row margin-top-10">
 
     <div class="col-xs-7">
@@ -87,14 +87,14 @@
           <div class="form-group">
             <label class="control-label col-xs-4">{{ "COLUMNS.STAFF_COST" | translate }}</label>
             <div class="col-xs-7">
-              <input type="checkbox" id="internationalID" ng-model="session.new.is_employee">
+              <input type="checkbox" id="internationalID" ng-model="session.new.is_employee" ng-true-value="1" ng-false-value="0">
             </div>
           </div>
 
           <div class="form-group">
             <label class="control-label col-xs-4">{{ "COLUMNS.IS_PERCENT" | translate }}</label>
             <div class="col-xs-7">
-              <input type="checkbox" id="internationalID" ng-model="session.new.is_percent">
+              <input type="checkbox" id="internationalID" ng-model="session.new.is_percent"  ng-true-value="1" ng-false-value="0">
             </div>
           </div>
 
@@ -108,8 +108,7 @@
           <div class="form-group">
             <label class="control-label col-xs-4 required">{{ "COLUMNS.FOUR_ACCOUNT" | translate }}</label>
             <div class="col-xs-7">
-              <select class="form-bhima" required ng-model="session.new.four_account_id">
-                <option ng-repeat="account in accounts.data | orderBy:'account_number'" ng-value="account.id">{{account.account_number}} --- {{account.account_txt}}</option>
+              <select class="form-bhima" required ng-model="session.new.four_account_id" ng-options="account.id as account.account_number + ' -- ' + account.account_txt for account in accounts.data | orderBy:'account_number'">
               </select>
             </div>
           </div>
@@ -117,8 +116,7 @@
           <div class="form-group">
             <label class="control-label col-xs-4 required">{{ "COLUMNS.SIX_ACCOUNT" | translate }}</label>
             <div class="col-xs-7">
-              <select class="form-bhima" required ng-model="session.new.six_Account_id">
-                <option ng-repeat="account in accounts.data | orderBy:'account_number' " ng-value="account.id">{{account.account_number}} --- {{account.account_txt}}</option>
+              <select class="form-bhima" required ng-model="session.new.six_account_id" ng-options="account.id as account.account_number + ' -- ' + account.account_txt for account in accounts.data | orderBy:'account_number'">
               </select>
             </div>
           </div>
@@ -131,7 +129,7 @@
       </div>
 
       <div ng-switch-when="edit">
-        <form novalidate class="form-horizontal" name="edit">
+        <form class="form-horizontal" name="edit" novalidate >
           <legend><h3>{{ "COTISATIONS.UPDATE" | translate }} </h3></legend>
 
           <div class="form-group">
@@ -151,14 +149,14 @@
           <div class="form-group">
             <label class="control-label col-xs-4">{{ "COLUMNS.STAFF_COST" | translate }}</label>
             <div class="col-xs-7">
-              <input type="checkbox" id="internationalID" ng-model="session.edit.is_employee">
+              <input type="checkbox" id="internationalID" ng-model="session.edit.is_employee"  ng-true-value="1" ng-false-value="0">
             </div>
           </div>
 
           <div class="form-group">
             <label class="control-label col-xs-4">{{ "COLUMNS.IS_PERCENT" | translate }}</label>
             <div class="col-xs-7">
-              <input type="checkbox" id="internationalID" ng-model="session.edit.is_percent">
+              <input type="checkbox" id="internationalID" ng-model="session.edit.is_percent"  ng-true-value="1" ng-false-value="0">
             </div>
           </div>
 
@@ -173,7 +171,6 @@
             <label class="control-label col-xs-4 required">{{ "COLUMNS.FOUR_ACCOUNT" | translate }}</label>
             <div class="col-xs-7">
               <select class="form-bhima" ng-model="session.edit.four_account_id" ng-options="account.id as account.account_number + ' -- ' + account.account_txt for account in accounts.data | orderBy:'account_number'">
-                <option></option>
               </select>
             </div>
           </div>
@@ -182,7 +179,6 @@
             <label class="control-label col-xs-4 required">{{ "COLUMNS.SIX_ACCOUNT" | translate }}</label>
             <div class="col-xs-7">
               <select class="form-bhima" ng-model="session.edit.six_account_id" ng-options="account.id as account.account_number + ' -- ' + account.account_txt for account in accounts.data | orderBy:'account_number'">
-                <option></option>
               </select>
             </div>
           </div>
@@ -196,5 +192,3 @@
     </div>
   </div>
 </main>
-
-

--- a/client/src/partials/cotisation/create/create_cotisation.js
+++ b/client/src/partials/cotisation/create/create_cotisation.js
@@ -67,8 +67,9 @@ angular.module('bhima.controllers')
     $scope.save = {};
 
     $scope.save.edit = function () {
-      $scope.session.edit.is_employee = ($scope.session.edit.is_employee)? 1 : 0;
-      $scope.session.edit.is_percent = ($scope.session.edit.is_percent)? 1 : 0;
+      console.log('$scope.session.edit', $scope.session.edit);
+      $scope.session.edit.is_employee = ($scope.session.edit.is_employee) ? 1 : 0;
+      $scope.session.edit.is_percent = ($scope.session.edit.is_percent) ? 1 : 0;
 
       var record = angular.copy(connect.clean(session.edit));
       delete record.reference;
@@ -98,6 +99,8 @@ angular.module('bhima.controllers')
     };
 
     $scope.save.new = function () {
+      console.log('$scope.session.new:', $scope.session.new);
+
       $scope.session.new.is_employee = ($scope.session.new.is_employee)? 1 : 0;
       $scope.session.new.is_percent = ($scope.session.new.is_percent)? 1 : 0;
       var record = connect.clean(session.new);

--- a/client/src/partials/cotisation/create/create_cotisation.js
+++ b/client/src/partials/cotisation/create/create_cotisation.js
@@ -67,10 +67,6 @@ angular.module('bhima.controllers')
     $scope.save = {};
 
     $scope.save.edit = function () {
-      console.log('$scope.session.edit', $scope.session.edit);
-      $scope.session.edit.is_employee = ($scope.session.edit.is_employee) ? 1 : 0;
-      $scope.session.edit.is_percent = ($scope.session.edit.is_percent) ? 1 : 0;
-
       var record = angular.copy(connect.clean(session.edit));
       delete record.reference;
       delete record.account_number;
@@ -99,31 +95,30 @@ angular.module('bhima.controllers')
     };
 
     $scope.save.new = function () {
-      console.log('$scope.session.new:', $scope.session.new);
-
-      $scope.session.new.is_employee = ($scope.session.new.is_employee)? 1 : 0;
-      $scope.session.new.is_percent = ($scope.session.new.is_percent)? 1 : 0;
       var record = connect.clean(session.new);
-      record.six_account_id = session.new.six_account_id;
-      
-      if(record.abbr){
-        if(record.abbr.length <= 4){
-          connect.basicPut('cotisation', [record])
-          .then(function (res) {
 
-            validate.refresh(dependencies)
-            .then(function (models) {
-              angular.extend($scope, models);
-            });
-            session.action = '';
-            session.new = {};
-          });
-        } else if (record.abbr.length > 4){
-          messenger.danger($translate.instant('COTISATIONS.NOT_SUP4'));
-        }
-      }  else {
-        messenger.danger($translate.instant('COTISATIONS.NOT_EMPTY'));
+      // fail if no abbreviation
+      if (!record.abbr) {
+        return messenger.danger($translate.instant('COTISATIONS.NOT_EMPTY'));
       }
+
+      // require small abbreviations
+      if (record.abbr.length > 4) {
+        return messenger.danger($translate.instant('COTISATIONS.NOT_SUP4'));
+      }
+      
+      // all checks pass, we are free to post to the server!
+      connect.basicPut('cotisation', [record])
+      .then(function (res) {
+
+        // reload data (TODO - make this a simple addition to the client store)
+        validate.refresh(dependencies)
+        .then(function (models) {
+          angular.extend($scope, models);
+        });
+        session.action = '';
+        session.new = {};
+      });
     };
   }
 ]);

--- a/client/src/partials/cotisation/create/create_cotisation.js
+++ b/client/src/partials/cotisation/create/create_cotisation.js
@@ -76,7 +76,7 @@ angular.module('bhima.controllers')
 
       if(record.abbr){
         if(record.abbr.length <= 4){
-          connect.basicPost('cotisation', [record], ['id'])
+          connect.put('cotisation', [record], ['id'])
           .then(function () {
             validate.refresh(dependencies)
             .then(function (models) {
@@ -108,7 +108,7 @@ angular.module('bhima.controllers')
       }
       
       // all checks pass, we are free to post to the server!
-      connect.basicPut('cotisation', [record])
+      connect.post('cotisation', [record])
       .then(function (res) {
 
         // reload data (TODO - make this a simple addition to the client store)


### PR DESCRIPTION
This PR fixes #683.  It cleans up the code slightly, allowing for fewer checks of data-types by enforcing existence and using 1/0 for checkbox true and false values.  The `<select>` statements for accounts have been optimized slightly.

Finally, it fixes a typo that prevented new cotisations from being created.