### PR TITLE
Localisation and reworking currency

### DIFF
--- a/client/src/i18n/currency/fc.json
+++ b/client/src/i18n/currency/fc.json
@@ -1,0 +1,29 @@
+{
+  "CURRENCY_SYM": "Fc",
+  "DECIMAL_SEP": ",",
+  "GROUP_SEP": "\u00a0",
+  "PATTERNS": [
+    {
+      "gSize": 3,
+      "lgSize": 3,
+      "maxFrac": 3,
+      "minFrac": 0,
+      "minInt": 1,
+      "negPre": "-",
+      "negSuf": "",
+      "posPre": "",
+      "posSuf": ""
+    },
+    {
+      "gSize": 3,
+      "lgSize": 3,
+      "maxFrac": 2,
+      "minFrac": 2,
+      "minInt": 1,
+      "negPre": "-",
+      "negSuf": "\u00a0\u00a4",
+      "posPre": "",
+      "posSuf": "\u00a0\u00a4"
+    }
+  ]
+}

--- a/client/src/i18n/currency/usd.json
+++ b/client/src/i18n/currency/usd.json
@@ -1,0 +1,29 @@
+{
+  "CURRENCY_SYM": "$",
+  "DECIMAL_SEP": ".",
+  "GROUP_SEP": ",",
+  "PATTERNS": [
+    {
+      "gSize": 3,
+      "lgSize": 3,
+      "maxFrac": 3,
+      "minFrac": 0,
+      "minInt": 1,
+      "negPre": "-",
+      "negSuf": "",
+      "posPre": "",
+      "posSuf": ""
+    },
+    {
+      "gSize": 3,
+      "lgSize": 3,
+      "maxFrac": 2,
+      "minFrac": 2,
+      "minInt": 1,
+      "negPre": "-\u00a4",
+      "negSuf": "",
+      "posPre": "\u00a4",
+      "posSuf": ""
+    }
+  ]
+}

--- a/client/src/i18n/locale/angular-locale_en-us.js
+++ b/client/src/i18n/locale/angular-locale_en-us.js
@@ -1,0 +1,128 @@
+'use strict';
+angular.module("ngLocale", [], ["$provide", function($provide) {
+var PLURAL_CATEGORY = {ZERO: "zero", ONE: "one", TWO: "two", FEW: "few", MANY: "many", OTHER: "other"};
+function getDecimals(n) {
+  n = n + '';
+  var i = n.indexOf('.');
+  return (i == -1) ? 0 : n.length - i - 1;
+}
+
+function getVF(n, opt_precision) {
+  var v = opt_precision;
+
+  if (undefined === v) {
+    v = Math.min(getDecimals(n), 3);
+  }
+
+  var base = Math.pow(10, v);
+  var f = ((n * base) | 0) % base;
+  return {v: v, f: f};
+}
+
+$provide.value("$locale", {
+  "DATETIME_FORMATS": {
+    "AMPMS": [
+      "AM",
+      "PM"
+    ],
+    "DAY": [
+      "Sunday",
+      "Monday",
+      "Tuesday",
+      "Wednesday",
+      "Thursday",
+      "Friday",
+      "Saturday"
+    ],
+    "ERANAMES": [
+      "Before Christ",
+      "Anno Domini"
+    ],
+    "ERAS": [
+      "BC",
+      "AD"
+    ],
+    "FIRSTDAYOFWEEK": 6,
+    "MONTH": [
+      "January",
+      "February",
+      "March",
+      "April",
+      "May",
+      "June",
+      "July",
+      "August",
+      "September",
+      "October",
+      "November",
+      "December"
+    ],
+    "SHORTDAY": [
+      "Sun",
+      "Mon",
+      "Tue",
+      "Wed",
+      "Thu",
+      "Fri",
+      "Sat"
+    ],
+    "SHORTMONTH": [
+      "Jan",
+      "Feb",
+      "Mar",
+      "Apr",
+      "May",
+      "Jun",
+      "Jul",
+      "Aug",
+      "Sep",
+      "Oct",
+      "Nov",
+      "Dec"
+    ],
+    "WEEKENDRANGE": [
+      5,
+      6
+    ],
+    "fullDate": "EEEE, MMMM d, y",
+    "longDate": "MMMM d, y",
+    "medium": "MMM d, y h:mm:ss a",
+    "mediumDate": "MMM d, y",
+    "mediumTime": "h:mm:ss a",
+    "short": "M/d/yy h:mm a",
+    "shortDate": "M/d/yy",
+    "shortTime": "h:mm a"
+  },
+  "NUMBER_FORMATS": {
+    "CURRENCY_SYM": "$",
+    "DECIMAL_SEP": ".",
+    "GROUP_SEP": ",",
+    "PATTERNS": [
+      {
+        "gSize": 3,
+        "lgSize": 3,
+        "maxFrac": 3,
+        "minFrac": 0,
+        "minInt": 1,
+        "negPre": "-",
+        "negSuf": "",
+        "posPre": "",
+        "posSuf": ""
+      },
+      {
+        "gSize": 3,
+        "lgSize": 3,
+        "maxFrac": 2,
+        "minFrac": 2,
+        "minInt": 1,
+        "negPre": "-\u00a4",
+        "negSuf": "",
+        "posPre": "\u00a4",
+        "posSuf": ""
+      }
+    ]
+  },
+  "id": "en-us",
+  "pluralCat": function(n, opt_precision) {  var i = n | 0;  var vf = getVF(n, opt_precision);  if (i == 1 && vf.v == 0) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+});
+}]);

--- a/client/src/i18n/locale/angular-locale_fr-cd.js
+++ b/client/src/i18n/locale/angular-locale_fr-cd.js
@@ -1,0 +1,110 @@
+'use strict';
+angular.module("ngLocale", [], ["$provide", function($provide) {
+var PLURAL_CATEGORY = {ZERO: "zero", ONE: "one", TWO: "two", FEW: "few", MANY: "many", OTHER: "other"};
+$provide.value("$locale", {
+  "DATETIME_FORMATS": {
+    "AMPMS": [
+      "AM",
+      "PM"
+    ],
+    "DAY": [
+      "dimanche",
+      "lundi",
+      "mardi",
+      "mercredi",
+      "jeudi",
+      "vendredi",
+      "samedi"
+    ],
+    "ERANAMES": [
+      "avant J\u00e9sus-Christ",
+      "apr\u00e8s J\u00e9sus-Christ"
+    ],
+    "ERAS": [
+      "av. J.-C.",
+      "ap. J.-C."
+    ],
+    "FIRSTDAYOFWEEK": 0,
+    "MONTH": [
+      "janvier",
+      "f\u00e9vrier",
+      "mars",
+      "avril",
+      "mai",
+      "juin",
+      "juillet",
+      "ao\u00fbt",
+      "septembre",
+      "octobre",
+      "novembre",
+      "d\u00e9cembre"
+    ],
+    "SHORTDAY": [
+      "dim.",
+      "lun.",
+      "mar.",
+      "mer.",
+      "jeu.",
+      "ven.",
+      "sam."
+    ],
+    "SHORTMONTH": [
+      "janv.",
+      "f\u00e9vr.",
+      "mars",
+      "avr.",
+      "mai",
+      "juin",
+      "juil.",
+      "ao\u00fbt",
+      "sept.",
+      "oct.",
+      "nov.",
+      "d\u00e9c."
+    ],
+    "WEEKENDRANGE": [
+      5,
+      6
+    ],
+    "fullDate": "EEEE d MMMM y",
+    "longDate": "d MMMM y",
+    "medium": "d MMM y HH:mm:ss",
+    "mediumDate": "d MMM y",
+    "mediumTime": "HH:mm:ss",
+    "short": "dd/MM/y HH:mm",
+    "shortDate": "dd/MM/y",
+    "shortTime": "HH:mm"
+  },
+  "NUMBER_FORMATS": {
+    "CURRENCY_SYM": "FrCD",
+    "DECIMAL_SEP": ",",
+    "GROUP_SEP": "\u00a0",
+    "PATTERNS": [
+      {
+        "gSize": 3,
+        "lgSize": 3,
+        "maxFrac": 3,
+        "minFrac": 0,
+        "minInt": 1,
+        "negPre": "-",
+        "negSuf": "",
+        "posPre": "",
+        "posSuf": ""
+      },
+      {
+        "gSize": 3,
+        "lgSize": 3,
+        "maxFrac": 2,
+        "minFrac": 2,
+        "minInt": 1,
+        "negPre": "-",
+        "negSuf": "\u00a0\u00a4",
+        "posPre": "",
+        "posSuf": "\u00a0\u00a4"
+      }
+    ]
+  },
+  "id": "fr-cd",
+  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+});
+}]);

--- a/client/src/i18n/locale/angular-locale_fr-fr.js
+++ b/client/src/i18n/locale/angular-locale_fr-fr.js
@@ -1,0 +1,110 @@
+'use strict';
+angular.module("ngLocale", [], ["$provide", function($provide) {
+var PLURAL_CATEGORY = {ZERO: "zero", ONE: "one", TWO: "two", FEW: "few", MANY: "many", OTHER: "other"};
+$provide.value("$locale", {
+  "DATETIME_FORMATS": {
+    "AMPMS": [
+      "AM",
+      "PM"
+    ],
+    "DAY": [
+      "dimanche",
+      "lundi",
+      "mardi",
+      "mercredi",
+      "jeudi",
+      "vendredi",
+      "samedi"
+    ],
+    "ERANAMES": [
+      "avant J\u00e9sus-Christ",
+      "apr\u00e8s J\u00e9sus-Christ"
+    ],
+    "ERAS": [
+      "av. J.-C.",
+      "ap. J.-C."
+    ],
+    "FIRSTDAYOFWEEK": 0,
+    "MONTH": [
+      "janvier",
+      "f\u00e9vrier",
+      "mars",
+      "avril",
+      "mai",
+      "juin",
+      "juillet",
+      "ao\u00fbt",
+      "septembre",
+      "octobre",
+      "novembre",
+      "d\u00e9cembre"
+    ],
+    "SHORTDAY": [
+      "dim.",
+      "lun.",
+      "mar.",
+      "mer.",
+      "jeu.",
+      "ven.",
+      "sam."
+    ],
+    "SHORTMONTH": [
+      "janv.",
+      "f\u00e9vr.",
+      "mars",
+      "avr.",
+      "mai",
+      "juin",
+      "juil.",
+      "ao\u00fbt",
+      "sept.",
+      "oct.",
+      "nov.",
+      "d\u00e9c."
+    ],
+    "WEEKENDRANGE": [
+      5,
+      6
+    ],
+    "fullDate": "EEEE d MMMM y",
+    "longDate": "d MMMM y",
+    "medium": "d MMM y HH:mm:ss",
+    "mediumDate": "d MMM y",
+    "mediumTime": "HH:mm:ss",
+    "short": "dd/MM/y HH:mm",
+    "shortDate": "dd/MM/y",
+    "shortTime": "HH:mm"
+  },
+  "NUMBER_FORMATS": {
+    "CURRENCY_SYM": "\u20ac",
+    "DECIMAL_SEP": ",",
+    "GROUP_SEP": "\u00a0",
+    "PATTERNS": [
+      {
+        "gSize": 3,
+        "lgSize": 3,
+        "maxFrac": 3,
+        "minFrac": 0,
+        "minInt": 1,
+        "negPre": "-",
+        "negSuf": "",
+        "posPre": "",
+        "posSuf": ""
+      },
+      {
+        "gSize": 3,
+        "lgSize": 3,
+        "maxFrac": 2,
+        "minFrac": 2,
+        "minInt": 1,
+        "negPre": "-",
+        "negSuf": "\u00a0\u00a4",
+        "posPre": "",
+        "posSuf": "\u00a0\u00a4"
+      }
+    ]
+  },
+  "id": "fr-fr",
+  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+});
+}]);

--- a/client/src/i18n/locale/angular-locale_ln-cd.js
+++ b/client/src/i18n/locale/angular-locale_ln-cd.js
@@ -1,0 +1,110 @@
+'use strict';
+angular.module("ngLocale", [], ["$provide", function($provide) {
+var PLURAL_CATEGORY = {ZERO: "zero", ONE: "one", TWO: "two", FEW: "few", MANY: "many", OTHER: "other"};
+$provide.value("$locale", {
+  "DATETIME_FORMATS": {
+    "AMPMS": [
+      "nt\u0254\u0301ng\u0254\u0301",
+      "mp\u00f3kwa"
+    ],
+    "DAY": [
+      "eyenga",
+      "mok\u0254l\u0254 mwa yambo",
+      "mok\u0254l\u0254 mwa m\u00edbal\u00e9",
+      "mok\u0254l\u0254 mwa m\u00eds\u00e1to",
+      "mok\u0254l\u0254 ya m\u00edn\u00e9i",
+      "mok\u0254l\u0254 ya m\u00edt\u00e1no",
+      "mp\u0254\u0301s\u0254"
+    ],
+    "ERANAMES": [
+      "Yambo ya Y\u00e9zu Kr\u00eds",
+      "Nsima ya Y\u00e9zu Kr\u00eds"
+    ],
+    "ERAS": [
+      "lib\u00f3so ya",
+      "nsima ya Y"
+    ],
+    "FIRSTDAYOFWEEK": 0,
+    "MONTH": [
+      "s\u00e1nz\u00e1 ya yambo",
+      "s\u00e1nz\u00e1 ya m\u00edbal\u00e9",
+      "s\u00e1nz\u00e1 ya m\u00eds\u00e1to",
+      "s\u00e1nz\u00e1 ya m\u00ednei",
+      "s\u00e1nz\u00e1 ya m\u00edt\u00e1no",
+      "s\u00e1nz\u00e1 ya mot\u00f3b\u00e1",
+      "s\u00e1nz\u00e1 ya nsambo",
+      "s\u00e1nz\u00e1 ya mwambe",
+      "s\u00e1nz\u00e1 ya libwa",
+      "s\u00e1nz\u00e1 ya z\u00f3mi",
+      "s\u00e1nz\u00e1 ya z\u00f3mi na m\u0254\u030ck\u0254\u0301",
+      "s\u00e1nz\u00e1 ya z\u00f3mi na m\u00edbal\u00e9"
+    ],
+    "SHORTDAY": [
+      "eye",
+      "ybo",
+      "mbl",
+      "mst",
+      "min",
+      "mtn",
+      "mps"
+    ],
+    "SHORTMONTH": [
+      "yan",
+      "fbl",
+      "msi",
+      "apl",
+      "mai",
+      "yun",
+      "yul",
+      "agt",
+      "stb",
+      "\u0254tb",
+      "nvb",
+      "dsb"
+    ],
+    "WEEKENDRANGE": [
+      5,
+      6
+    ],
+    "fullDate": "EEEE d MMMM y",
+    "longDate": "d MMMM y",
+    "medium": "d MMM y HH:mm:ss",
+    "mediumDate": "d MMM y",
+    "mediumTime": "HH:mm:ss",
+    "short": "d/M/y HH:mm",
+    "shortDate": "d/M/y",
+    "shortTime": "HH:mm"
+  },
+  "NUMBER_FORMATS": {
+    "CURRENCY_SYM": "FrCD",
+    "DECIMAL_SEP": ",",
+    "GROUP_SEP": ".",
+    "PATTERNS": [
+      {
+        "gSize": 3,
+        "lgSize": 3,
+        "maxFrac": 3,
+        "minFrac": 0,
+        "minInt": 1,
+        "negPre": "-",
+        "negSuf": "",
+        "posPre": "",
+        "posSuf": ""
+      },
+      {
+        "gSize": 3,
+        "lgSize": 3,
+        "maxFrac": 2,
+        "minFrac": 2,
+        "minInt": 1,
+        "negPre": "-",
+        "negSuf": "\u00a0\u00a4",
+        "posPre": "",
+        "posSuf": "\u00a0\u00a4"
+      }
+    ]
+  },
+  "id": "ln-cd",
+  "pluralCat": function(n, opt_precision) {  if (n >= 0 && n <= 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+});
+}]);

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -119,7 +119,8 @@
 <!-- BHIMA -->
 <script src="js/bhima.min.js"></script>
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/angular-i18n/1.4.4/angular-locale_en-us.js"></script>
+<!-- Legacy locale tests - remove as depreciated -->
+<!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/angular-i18n/1.4.4/angular-locale_en-us.js"></script> -->
 <!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/angular-i18n/1.4.4/angular-locale_fr-fr.js"></script> -->
 <!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/angular-i18n/1.4.4/angular-locale_fr-cd.js"></script> -->
 

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -109,6 +109,9 @@
 <script src="vendor/loader-static-files.min.js"></script>
 <script src="vendor/loader-url.min.js"></script>
 
+<!--locale-->
+<script type="text/javascript" src="vendor/tmhDynamicLocale.js"></script>
+
 <!--lib-->
 <script src="vendor/ui-bootstrap-tpls.js"></script>
 <script src="vendor/angular-localForage.min.js"></script>

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html>
 <head>
   <meta charset="utf-8"/>
   <title>BHIMA</title>
@@ -115,5 +115,10 @@
 
 <!-- BHIMA -->
 <script src="js/bhima.min.js"></script>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/angular-i18n/1.4.4/angular-locale_en-us.js"></script>
+<!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/angular-i18n/1.4.4/angular-locale_fr-fr.js"></script> -->
+<!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/angular-i18n/1.4.4/angular-locale_fr-cd.js"></script> -->
+
 </body>
 </html>

--- a/client/src/js/app.js
+++ b/client/src/js/app.js
@@ -1,7 +1,7 @@
 (function (angular) {
   'use strict';
 
-  var bhima = angular.module('bhima', ['bhima.controllers', 'bhima.services', 'bhima.directives', 'bhima.filters', 'ngRoute', 'ui.bootstrap', 'pascalprecht.translate', 'LocalForageModule', 'chart.js']);
+  var bhima = angular.module('bhima', ['bhima.controllers', 'bhima.services', 'bhima.directives', 'bhima.filters', 'ngRoute', 'ui.bootstrap', 'pascalprecht.translate', 'LocalForageModule', 'chart.js', 'tmh.dynamicLocale']);
 
   function bhimaconfig($routeProvider) {
     //TODO: Dynamic routes loaded from unit database?
@@ -749,9 +749,15 @@
     });
 
     $translateProvider.useSanitizeValueStrategy('escape');
-
-    //TODO Try and assign the previous sessions language key here
+  
     $translateProvider.preferredLanguage('fr');
+  }
+
+  function localeConfig(tmhDynamicLocaleProvider) { 
+
+    // TODO Hardcoded default translation/ localisation
+    tmhDynamicLocaleProvider.localeLocationPattern('/i18n/locale/angular-locale_{{locale}}.js');
+    tmhDynamicLocaleProvider.defaultLocale('fr-fr');
   }
 
   // Logs HTTP errors to the console, even if uncaught
@@ -781,6 +787,7 @@
   // configuration
   bhima.config(['$routeProvider', bhimaconfig]);
   bhima.config(['$translateProvider', translateConfig]);
+  bhima.config(['tmhDynamicLocaleProvider', localeConfig]);
   bhima.config(['$httpProvider', authConfig]);
   bhima.config(['$localForageProvider', localForageConfig]);
   // run

--- a/client/src/js/define.js
+++ b/client/src/js/define.js
@@ -1,3 +1,4 @@
 angular.module('bhima.controllers', []);
 angular.module('bhima.services', []);
 angular.module('bhima.directives', []);
+angular.module('bhima.filters', []);

--- a/client/src/js/filters/currency.js
+++ b/client/src/js/filters/currency.js
@@ -1,0 +1,198 @@
+/*
+ * BHIMA fork of native angular currency filter 
+ * https://github.com/angular/angular.js/blob/master/src/ng/filter/filters.js
+ * Built to support the following feature s
+ *  - Logically seperate locale and currency, accounting cannot be based on language preference 
+ *  - Accept currency key per individual filter
+ *  - Fetch and cache currencies and formats from system database
+ */
+console.log(angular);
+console.log(angular.module);
+angular.module('bhima.filters') 
+  
+  .filter('bhimaCurrency', [
+    '$locale',
+    '$http',
+    'store',
+    function ($locale, $http, Store) { 
+      var formats = $locale.NUMBER_FORMATS;
+
+      var currency = new Store({
+        data : [],
+        identifier : 'id'
+      });
+
+      $http.get('/finance/currencies')
+      .success(function (data) {
+        currency.setData(data);
+      })
+      .error(function (error) {
+        messenger.danger('An error occured:' + JSON.stringify(error));
+      });
+
+              
+      // targetLocale/ targetCurrency
+      return function(amount, targetLocale, currencySymbol, fractionSize) {
+        
+        if (angular.isUndefined(targetLocale)) { 
+          targetLocale = 1;
+        }
+
+        if (angular.isUndefined(currencySymbol)) {
+          currencySymbol = formats.CURRENCY_SYM;
+        }
+
+        if (angular.isUndefined(fractionSize)) {
+          fractionSize = formats.PATTERNS[1].maxFrac;
+        }
+        console.log(targetLocale);
+        
+        console.log('bhima currency');
+        console.log('patterns 1', formats.PATTERNS[1]);
+        console.log('group sep', formats.GROUP_SEP);
+        console.log('decimal sep', formats.DECIMAL_SEP);
+
+        // FIXME hack
+        if (currency.get(targetLocale)) { 
+          formats.DECIMAL_SEP = currency.get(targetLocale).decimal;
+          currencySymbol = currency.get(targetLocale).symbol; 
+        } 
+        // if null or undefined pass it through
+        return (amount == null)
+          ? amount
+          : formatNumber(amount, getLocaleCurrencyFormat(targetLocale), formats.GROUP_SEP, formats.DECIMAL_SEP, fractionSize).
+            replace(/\u00A4/g, currencySymbol);
+      };
+    }
+  ])
+
+// Utility methods
+// This method is copied directly from the angular repository. The method is
+// a utility used by the native currency filter. 
+var DECIMAL_SEP = '.';
+function formatNumber(number, pattern, groupSep, decimalSep, fractionSize) {
+  if (angular.isObject(number)) return '';
+
+  var isNegative = number < 0;
+  number = Math.abs(number);
+
+  var isInfinity = number === Infinity;
+  if (!isInfinity && !isFinite(number)) return '';
+
+  var numStr = number + '',
+      formatedText = '',
+      hasExponent = false,
+      parts = [];
+
+  if (isInfinity) formatedText = '\u221e';
+
+  if (!isInfinity && numStr.indexOf('e') !== -1) {
+    var match = numStr.match(/([\d\.]+)e(-?)(\d+)/);
+    if (match && match[2] == '-' && match[3] > fractionSize + 1) {
+      number = 0;
+    } else {
+      formatedText = numStr;
+      hasExponent = true;
+    }
+  }
+
+  if (!isInfinity && !hasExponent) {
+    var fractionLen = (numStr.split(DECIMAL_SEP)[1] || '').length;
+
+    // determine fractionSize if it is not specified
+    if (angular.isUndefined(fractionSize)) {
+      fractionSize = Math.min(Math.max(pattern.minFrac, fractionLen), pattern.maxFrac);
+    }
+
+    // safely round numbers in JS without hitting imprecisions of floating-point arithmetics
+    // inspired by:
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/round
+    number = +(Math.round(+(number.toString() + 'e' + fractionSize)).toString() + 'e' + -fractionSize);
+
+    var fraction = ('' + number).split(DECIMAL_SEP);
+    var whole = fraction[0];
+    fraction = fraction[1] || '';
+
+    var i, pos = 0,
+        lgroup = pattern.lgSize,
+        group = pattern.gSize;
+
+    if (whole.length >= (lgroup + group)) {
+      pos = whole.length - lgroup;
+      for (i = 0; i < pos; i++) {
+        if ((pos - i) % group === 0 && i !== 0) {
+          formatedText += groupSep;
+        }
+        formatedText += whole.charAt(i);
+      }
+    }
+
+    for (i = pos; i < whole.length; i++) {
+      if ((whole.length - i) % lgroup === 0 && i !== 0) {
+        formatedText += groupSep;
+      }
+      formatedText += whole.charAt(i);
+    }
+
+    // format fraction part.
+    while (fraction.length < fractionSize) {
+      fraction += '0';
+    }
+
+    if (fractionSize && fractionSize !== "0") formatedText += decimalSep + fraction.substr(0, fractionSize);
+  } else {
+    if (fractionSize > 0 && number < 1) {
+      formatedText = number.toFixed(fractionSize);
+      number = parseFloat(formatedText);
+    }
+  }
+
+  if (number === 0) {
+    isNegative = false;
+  }
+
+  parts.push(isNegative ? pattern.negPre : pattern.posPre,
+             formatedText,
+             isNegative ? pattern.negSuf : pattern.posSuf);
+  return parts.join('');
+} 
+
+// Temporary function to map locales to currencies 
+// TODO move all currency format information into currency table OR define 
+//      all currency formatting through locale 
+function getLocaleCurrencyFormat(currencyId) { 
+  
+  var en_us =
+  {
+    "gSize": 3,
+    "lgSize": 3,
+    "maxFrac": 2,
+    "minFrac": 2,
+    "minInt": 1,
+    "negPre": "-",
+    "negSuf": "\u00a0\u00a4",
+    "posPre": "",
+    "posSuf": "\u00a0\u00a4"
+  };
+
+  var fr_cd = 
+  {
+    "gSize": 3,
+    "lgSize": 3,
+    "maxFrac": 2,
+    "minFrac": 2,
+    "minInt": 1,
+    "negPre": "-\u00a4",
+    "negSuf": "",
+    "posPre": "\u00a4",
+    "posSuf": ""
+  };
+
+  var map = {
+    '1' : en_us, 
+    '2' : fr_cd
+  };
+
+  return map[currencyId];
+}
+

--- a/client/src/js/filters/currency.js
+++ b/client/src/js/filters/currency.js
@@ -1,4 +1,4 @@
-'use strict'
+'use strict';
 
 /** 
  * @description 
@@ -62,23 +62,24 @@ angular.module('bhima.filters')
   function formatError(message, amount) { 
     return message.concat('(', amount, ')');
   }
-
+  
+  // Formatting method directly from angular native filter - does not support BHIMA coding guidelines
   var DECIMAL_SEP = '.';
   function formatNumber(number, pattern, groupSep, decimalSep, fractionSize) {
-    if (angular.isObject(number)) return '';
+    if (angular.isObject(number)) return ''; // jshint ignore:line
 
     var isNegative = number < 0;
     number = Math.abs(number);
 
     var isInfinity = number === Infinity;
-    if (!isInfinity && !isFinite(number)) return '';
+    if (!isInfinity && !isFinite(number)) return '';// jshint ignore:line
 
     var numStr = number + '',
         formatedText = '',
         hasExponent = false,
         parts = [];
 
-    if (isInfinity) formatedText = '\u221e';
+    if (isInfinity) formatedText = '\u221e'; // jshint ignore:line
 
     if (!isInfinity && numStr.indexOf('e') !== -1) {
       var match = numStr.match(/([\d\.]+)e(-?)(\d+)/);
@@ -133,7 +134,7 @@ angular.module('bhima.filters')
         fraction += '0';
       }
 
-      if (fractionSize && fractionSize !== "0") formatedText += decimalSep + fraction.substr(0, fractionSize);
+      if (fractionSize && fractionSize !== "0") formatedText += decimalSep + fraction.substr(0, fractionSize); // jshint ignore:line
     } else {
       if (fractionSize > 0 && number < 1) {
         formatedText = number.toFixed(fractionSize);

--- a/client/src/js/filters/filters.js
+++ b/client/src/js/filters/filters.js
@@ -53,10 +53,12 @@
           console.log('patterns 1', formats.PATTERNS[1]);
           console.log('group sep', formats.GROUP_SEP);
           console.log('decimal sep', formats.DECIMAL_SEP);
-
-          formats.DECIMAL_SEP = currency.get(targetLocale).decimal;
-          currencySymbol = currency.get(targetLocale).symbol; 
-          
+  
+          // FIXME hack
+          if (currency.get(targetLocale)) { 
+            formats.DECIMAL_SEP = currency.get(targetLocale).decimal;
+            currencySymbol = currency.get(targetLocale).symbol; 
+          } 
           // if null or undefined pass it through
           return (amount == null)
             ? amount

--- a/client/src/js/filters/filters.js
+++ b/client/src/js/filters/filters.js
@@ -24,13 +24,13 @@ angular.module('bhima.filters')
         identifier : 'id'
       });
 
-      $http.get('/finance/currencies')
-      .success(function (data) {
-        currency.setData(data);
-      })
-      .error(function (error) {
-        messenger.danger('An error occured:' + JSON.stringify(error));
-      });
+      // $http.get('/finance/currencies')
+      // .success(function (data) {
+        // currency.setData(data);
+      // })
+      // .error(function (error) {
+        // messenger.danger('An error occured:' + JSON.stringify(error));
+      // });
 
       return function (value, id) {
         value = (value || 0).toFixed(2);
@@ -46,10 +46,11 @@ angular.module('bhima.filters')
           value = value.slice(0, value.indexOf('.'));
         }
 
-        var templ = value.replace(/(\d)(?=(\d\d\d)+(?!\d))/g, '$1'+currency.get(id).separator);
-        templ += '<span class="desc">' + currency.get(id).decimal + decimalDigits + '</span><span class="cur"> ' + currency.get(id).symbol +  '</span>';
+        // var templ = value.replace(/(\d)(?=(\d\d\d)+(?!\d))/g, '$1'+currency.get(id).separator);
+        // templ += '<span class="desc">' + currency.get(id).decimal + decimalDigits + '</span><span class="cur"> ' + currency.get(id).symbol +  '</span>';
 
-        return $sce.trustAsHtml(templ);
+        // return $sce.trustAsHtml(templ);
+        return $sce.trustAsHtml('<span style="color : red;">Filter Depriciated</span>');
       };
     }
   ])

--- a/client/src/js/filters/filters.js
+++ b/client/src/js/filters/filters.js
@@ -9,6 +9,63 @@
       };
     })
 
+    // Potential currency filter providing a specified locale 
+    // Ideally would leverage angular currency filter but this does NOT support
+    // passing through individual locale and doesn't expose utility methods
+    .filter('bhimaCurrency', [
+      '$locale',
+      '$http',
+      'store',
+      function ($locale, $http, Store) { 
+        var formats = $locale.NUMBER_FORMATS;
+
+        var currency = new Store({
+          data : [],
+          identifier : 'id'
+        });
+
+        $http.get('/finance/currencies')
+        .success(function (data) {
+          currency.setData(data);
+        })
+        .error(function (error) {
+          messenger.danger('An error occured:' + JSON.stringify(error));
+        });
+
+          
+        // targetLocale/ targetCurrency
+        return function(amount, targetLocale, currencySymbol, fractionSize) {
+          
+          if (angular.isUndefined(targetLocale)) { 
+            targetLocale = 1;
+          }
+
+          if (angular.isUndefined(currencySymbol)) {
+            currencySymbol = formats.CURRENCY_SYM;
+          }
+
+          if (angular.isUndefined(fractionSize)) {
+            fractionSize = formats.PATTERNS[1].maxFrac;
+          }
+          console.log(targetLocale);
+          
+          console.log('bhima currency');
+          console.log('patterns 1', formats.PATTERNS[1]);
+          console.log('group sep', formats.GROUP_SEP);
+          console.log('decimal sep', formats.DECIMAL_SEP);
+
+          formats.DECIMAL_SEP = currency.get(targetLocale).decimal;
+          currencySymbol = currency.get(targetLocale).symbol; 
+          
+          // if null or undefined pass it through
+          return (amount == null)
+            ? amount
+            : formatNumber(amount, getLocaleCurrencyFormat(targetLocale), formats.GROUP_SEP, formats.DECIMAL_SEP, fractionSize).
+              replace(/\u00A4/g, currencySymbol);
+        };
+      }
+    ])
+
     .filter('intlcurrency', [
       '$http',
       '$filter',
@@ -59,11 +116,11 @@
           return items;
         }
 
-        if ((filterOn || angular.isUndefined(filterOn)) && angular.isArray(items)) {
+        if ((filterOn || angular.angular.isUndefined(filterOn)) && angular.isArray(items)) {
           var newItems = [];
 
           var extractValueToCompare = function (item) {
-            if (angular.isObject(item) && angular.isString(filterOn)) {
+            if (angular.angular.isObject(item) && angular.isString(filterOn)) {
               return item[filterOn];
             } else {
               return item;
@@ -104,6 +161,137 @@
         return map ? precision.round(scalar*value, 2) : precision.round(value, 2);
       };
     }]);
+  
+    
+    // Utility methods
+    // This method is copied directly from the angular repository. The method is
+    // a utility used by the native currency filter. 
+    // https://github.com/angular/angular.js/blob/master/src/ng/filter/filters.js
+    var DECIMAL_SEP = '.';
+    function formatNumber(number, pattern, groupSep, decimalSep, fractionSize) {
+      if (angular.isObject(number)) return '';
 
+      var isNegative = number < 0;
+      number = Math.abs(number);
+
+      var isInfinity = number === Infinity;
+      if (!isInfinity && !isFinite(number)) return '';
+
+      var numStr = number + '',
+          formatedText = '',
+          hasExponent = false,
+          parts = [];
+
+      if (isInfinity) formatedText = '\u221e';
+
+      if (!isInfinity && numStr.indexOf('e') !== -1) {
+        var match = numStr.match(/([\d\.]+)e(-?)(\d+)/);
+        if (match && match[2] == '-' && match[3] > fractionSize + 1) {
+          number = 0;
+        } else {
+          formatedText = numStr;
+          hasExponent = true;
+        }
+      }
+
+      if (!isInfinity && !hasExponent) {
+        var fractionLen = (numStr.split(DECIMAL_SEP)[1] || '').length;
+
+        // determine fractionSize if it is not specified
+        if (angular.isUndefined(fractionSize)) {
+          fractionSize = Math.min(Math.max(pattern.minFrac, fractionLen), pattern.maxFrac);
+        }
+
+        // safely round numbers in JS without hitting imprecisions of floating-point arithmetics
+        // inspired by:
+        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/round
+        number = +(Math.round(+(number.toString() + 'e' + fractionSize)).toString() + 'e' + -fractionSize);
+
+        var fraction = ('' + number).split(DECIMAL_SEP);
+        var whole = fraction[0];
+        fraction = fraction[1] || '';
+
+        var i, pos = 0,
+            lgroup = pattern.lgSize,
+            group = pattern.gSize;
+
+        if (whole.length >= (lgroup + group)) {
+          pos = whole.length - lgroup;
+          for (i = 0; i < pos; i++) {
+            if ((pos - i) % group === 0 && i !== 0) {
+              formatedText += groupSep;
+            }
+            formatedText += whole.charAt(i);
+          }
+        }
+
+        for (i = pos; i < whole.length; i++) {
+          if ((whole.length - i) % lgroup === 0 && i !== 0) {
+            formatedText += groupSep;
+          }
+          formatedText += whole.charAt(i);
+        }
+
+        // format fraction part.
+        while (fraction.length < fractionSize) {
+          fraction += '0';
+        }
+
+        if (fractionSize && fractionSize !== "0") formatedText += decimalSep + fraction.substr(0, fractionSize);
+      } else {
+        if (fractionSize > 0 && number < 1) {
+          formatedText = number.toFixed(fractionSize);
+          number = parseFloat(formatedText);
+        }
+      }
+
+      if (number === 0) {
+        isNegative = false;
+      }
+
+      parts.push(isNegative ? pattern.negPre : pattern.posPre,
+                 formatedText,
+                 isNegative ? pattern.negSuf : pattern.posSuf);
+      return parts.join('');
+    } 
+
+    // Temporary function to map locales to currencies 
+    // TODO move all currency format information into currency table OR define 
+    //      all currency formatting through locale 
+    function getLocaleCurrencyFormat(currencyId) { 
+      
+      var en_us =
+      {
+        "gSize": 3,
+        "lgSize": 3,
+        "maxFrac": 2,
+        "minFrac": 2,
+        "minInt": 1,
+        "negPre": "-",
+        "negSuf": "\u00a0\u00a4",
+        "posPre": "",
+        "posSuf": "\u00a0\u00a4"
+      };
+    
+      var fr_cd = 
+      {
+        "gSize": 3,
+        "lgSize": 3,
+        "maxFrac": 2,
+        "minFrac": 2,
+        "minInt": 1,
+        "negPre": "-\u00a4",
+        "negSuf": "",
+        "posPre": "\u00a4",
+        "posSuf": ""
+      };
+
+      var map = {
+        '1' : en_us, 
+        '2' : fr_cd
+      };
+
+      return map[currencyId];
+    }
 })(angular);
 

--- a/client/src/js/filters/filters.js
+++ b/client/src/js/filters/filters.js
@@ -1,299 +1,110 @@
+// (function (angular) {
+'use strict';
 
-(function (angular) {
-  'use strict';
+angular.module('bhima.filters')
+  .filter('boolean', function() {
+    return function (input) {
+      return Boolean(Number(input));
+    };
+  })
 
-  angular.module('bhima.filters', [])
-    .filter('boolean', function() {
-      return function (input) {
-        return Boolean(Number(input));
-      };
-    })
+  // Potential currency filter providing a specified locale 
+  // Ideally would leverage angular currency filter but this does NOT support
+  // passing through individual locale and doesn't expose utility methods 
+  .filter('intlcurrency', [
+    '$http',
+    '$filter',
+    '$sce',
+    'store',
+    'messenger',
+    function ($http, $filter, $sce, Store, messenger) {
 
-    // Potential currency filter providing a specified locale 
-    // Ideally would leverage angular currency filter but this does NOT support
-    // passing through individual locale and doesn't expose utility methods
-    .filter('bhimaCurrency', [
-      '$locale',
-      '$http',
-      'store',
-      function ($locale, $http, Store) { 
-        var formats = $locale.NUMBER_FORMATS;
-
-        var currency = new Store({
-          data : [],
-          identifier : 'id'
-        });
-
-        $http.get('/finance/currencies')
-        .success(function (data) {
-          currency.setData(data);
-        })
-        .error(function (error) {
-          messenger.danger('An error occured:' + JSON.stringify(error));
-        });
-
-          
-        // targetLocale/ targetCurrency
-        return function(amount, targetLocale, currencySymbol, fractionSize) {
-          
-          if (angular.isUndefined(targetLocale)) { 
-            targetLocale = 1;
-          }
-
-          if (angular.isUndefined(currencySymbol)) {
-            currencySymbol = formats.CURRENCY_SYM;
-          }
-
-          if (angular.isUndefined(fractionSize)) {
-            fractionSize = formats.PATTERNS[1].maxFrac;
-          }
-          console.log(targetLocale);
-          
-          console.log('bhima currency');
-          console.log('patterns 1', formats.PATTERNS[1]);
-          console.log('group sep', formats.GROUP_SEP);
-          console.log('decimal sep', formats.DECIMAL_SEP);
-  
-          // FIXME hack
-          if (currency.get(targetLocale)) { 
-            formats.DECIMAL_SEP = currency.get(targetLocale).decimal;
-            currencySymbol = currency.get(targetLocale).symbol; 
-          } 
-          // if null or undefined pass it through
-          return (amount == null)
-            ? amount
-            : formatNumber(amount, getLocaleCurrencyFormat(targetLocale), formats.GROUP_SEP, formats.DECIMAL_SEP, fractionSize).
-              replace(/\u00A4/g, currencySymbol);
-        };
-      }
-    ])
-
-    .filter('intlcurrency', [
-      '$http',
-      '$filter',
-      '$sce',
-      'store',
-      'messenger',
-      function ($http, $filter, $sce, Store, messenger) {
-
-        var currency = new Store({
-          data : [],
-          identifier : 'id'
-        });
-
-        $http.get('/finance/currencies')
-        .success(function (data) {
-          currency.setData(data);
-        })
-        .error(function (error) {
-          messenger.danger('An error occured:' + JSON.stringify(error));
-        });
-
-        return function (value, id) {
-          value = (value || 0).toFixed(2);
-
-          if (!angular.isDefined(id) || !angular.isDefined(currency)) {
-            return $sce.trustAsHtml($filter('currency')(value));
-          }
-
-          // first, extract the decimal digits '0.xx'
-          var decimalDigits = value.slice(value.indexOf('.')+1, value.indexOf('.') + 3);
-
-          if (decimalDigits) {
-            value = value.slice(0, value.indexOf('.'));
-          }
-
-          var templ = value.replace(/(\d)(?=(\d\d\d)+(?!\d))/g, '$1'+currency.get(id).separator);
-          templ += '<span class="desc">' + currency.get(id).decimal + decimalDigits + '</span><span class="cur"> ' + currency.get(id).symbol +  '</span>';
-
-          return $sce.trustAsHtml(templ);
-        };
-      }
-    ])
-    .filter('unique', function () {
-      return function (items, filterOn) {
-        console.log('item est : ', items, 'filteron est ', filterOn);
-
-        if (filterOn === false) {
-          return items;
-        }
-
-        if ((filterOn || angular.angular.isUndefined(filterOn)) && angular.isArray(items)) {
-          var newItems = [];
-
-          var extractValueToCompare = function (item) {
-            if (angular.angular.isObject(item) && angular.isString(filterOn)) {
-              return item[filterOn];
-            } else {
-              return item;
-            }
-          };
-
-          angular.forEach(items, function (item) {
-            var isDuplicate = false;
-
-            for (var i = 0; i < newItems.length; i++) {
-              if (angular.equals(extractValueToCompare(newItems[i]), extractValueToCompare(item))) {
-                isDuplicate = true;
-                break;
-              }
-            }
-            if (!isDuplicate) {
-              newItems.push(item);
-            }
-          });
-          items = newItems;
-        }
-        return items;
-      };
-    })
-    .filter('exchange', ['appstate', 'precision', function (appstate, precision) {
-      var map;
-
-      appstate.register('exchange_rate', function (globalRates) {
-        // build rate map anytime the exchange rate changes.
-        globalRates.forEach(function (r) {
-          map[r.foreign_currency_id] = r.rate;
-        });
+      var currency = new Store({
+        data : [],
+        identifier : 'id'
       });
 
-      return function (value, currency_id) {
-        value = value || 0;
-        var scalar = map[currency_id] || 1;
-        return map ? precision.round(scalar*value, 2) : precision.round(value, 2);
+      $http.get('/finance/currencies')
+      .success(function (data) {
+        currency.setData(data);
+      })
+      .error(function (error) {
+        messenger.danger('An error occured:' + JSON.stringify(error));
+      });
+
+      return function (value, id) {
+        value = (value || 0).toFixed(2);
+
+        if (!angular.isDefined(id) || !angular.isDefined(currency)) {
+          return $sce.trustAsHtml($filter('currency')(value));
+        }
+
+        // first, extract the decimal digits '0.xx'
+        var decimalDigits = value.slice(value.indexOf('.')+1, value.indexOf('.') + 3);
+
+        if (decimalDigits) {
+          value = value.slice(0, value.indexOf('.'));
+        }
+
+        var templ = value.replace(/(\d)(?=(\d\d\d)+(?!\d))/g, '$1'+currency.get(id).separator);
+        templ += '<span class="desc">' + currency.get(id).decimal + decimalDigits + '</span><span class="cur"> ' + currency.get(id).symbol +  '</span>';
+
+        return $sce.trustAsHtml(templ);
       };
-    }]);
-  
-    
-    // Utility methods
-    // This method is copied directly from the angular repository. The method is
-    // a utility used by the native currency filter. 
-    // https://github.com/angular/angular.js/blob/master/src/ng/filter/filters.js
-    var DECIMAL_SEP = '.';
-    function formatNumber(number, pattern, groupSep, decimalSep, fractionSize) {
-      if (angular.isObject(number)) return '';
-
-      var isNegative = number < 0;
-      number = Math.abs(number);
-
-      var isInfinity = number === Infinity;
-      if (!isInfinity && !isFinite(number)) return '';
-
-      var numStr = number + '',
-          formatedText = '',
-          hasExponent = false,
-          parts = [];
-
-      if (isInfinity) formatedText = '\u221e';
-
-      if (!isInfinity && numStr.indexOf('e') !== -1) {
-        var match = numStr.match(/([\d\.]+)e(-?)(\d+)/);
-        if (match && match[2] == '-' && match[3] > fractionSize + 1) {
-          number = 0;
-        } else {
-          formatedText = numStr;
-          hasExponent = true;
-        }
-      }
-
-      if (!isInfinity && !hasExponent) {
-        var fractionLen = (numStr.split(DECIMAL_SEP)[1] || '').length;
-
-        // determine fractionSize if it is not specified
-        if (angular.isUndefined(fractionSize)) {
-          fractionSize = Math.min(Math.max(pattern.minFrac, fractionLen), pattern.maxFrac);
-        }
-
-        // safely round numbers in JS without hitting imprecisions of floating-point arithmetics
-        // inspired by:
-        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/round
-        number = +(Math.round(+(number.toString() + 'e' + fractionSize)).toString() + 'e' + -fractionSize);
-
-        var fraction = ('' + number).split(DECIMAL_SEP);
-        var whole = fraction[0];
-        fraction = fraction[1] || '';
-
-        var i, pos = 0,
-            lgroup = pattern.lgSize,
-            group = pattern.gSize;
-
-        if (whole.length >= (lgroup + group)) {
-          pos = whole.length - lgroup;
-          for (i = 0; i < pos; i++) {
-            if ((pos - i) % group === 0 && i !== 0) {
-              formatedText += groupSep;
-            }
-            formatedText += whole.charAt(i);
-          }
-        }
-
-        for (i = pos; i < whole.length; i++) {
-          if ((whole.length - i) % lgroup === 0 && i !== 0) {
-            formatedText += groupSep;
-          }
-          formatedText += whole.charAt(i);
-        }
-
-        // format fraction part.
-        while (fraction.length < fractionSize) {
-          fraction += '0';
-        }
-
-        if (fractionSize && fractionSize !== "0") formatedText += decimalSep + fraction.substr(0, fractionSize);
-      } else {
-        if (fractionSize > 0 && number < 1) {
-          formatedText = number.toFixed(fractionSize);
-          number = parseFloat(formatedText);
-        }
-      }
-
-      if (number === 0) {
-        isNegative = false;
-      }
-
-      parts.push(isNegative ? pattern.negPre : pattern.posPre,
-                 formatedText,
-                 isNegative ? pattern.negSuf : pattern.posSuf);
-      return parts.join('');
-    } 
-
-    // Temporary function to map locales to currencies 
-    // TODO move all currency format information into currency table OR define 
-    //      all currency formatting through locale 
-    function getLocaleCurrencyFormat(currencyId) { 
-      
-      var en_us =
-      {
-        "gSize": 3,
-        "lgSize": 3,
-        "maxFrac": 2,
-        "minFrac": 2,
-        "minInt": 1,
-        "negPre": "-",
-        "negSuf": "\u00a0\u00a4",
-        "posPre": "",
-        "posSuf": "\u00a0\u00a4"
-      };
-    
-      var fr_cd = 
-      {
-        "gSize": 3,
-        "lgSize": 3,
-        "maxFrac": 2,
-        "minFrac": 2,
-        "minInt": 1,
-        "negPre": "-\u00a4",
-        "negSuf": "",
-        "posPre": "\u00a4",
-        "posSuf": ""
-      };
-
-      var map = {
-        '1' : en_us, 
-        '2' : fr_cd
-      };
-
-      return map[currencyId];
     }
-})(angular);
+  ])
+  .filter('unique', function () {
+    return function (items, filterOn) {
+      console.log('item est : ', items, 'filteron est ', filterOn);
+
+      if (filterOn === false) {
+        return items;
+      }
+
+      if ((filterOn || angular.angular.isUndefined(filterOn)) && angular.isArray(items)) {
+        var newItems = [];
+
+        var extractValueToCompare = function (item) {
+          if (angular.angular.isObject(item) && angular.isString(filterOn)) {
+            return item[filterOn];
+          } else {
+            return item;
+          }
+        };
+
+        angular.forEach(items, function (item) {
+          var isDuplicate = false;
+
+          for (var i = 0; i < newItems.length; i++) {
+            if (angular.equals(extractValueToCompare(newItems[i]), extractValueToCompare(item))) {
+              isDuplicate = true;
+              break;
+            }
+          }
+          if (!isDuplicate) {
+            newItems.push(item);
+          }
+        });
+        items = newItems;
+      }
+      return items;
+    };
+  })
+  .filter('exchange', ['appstate', 'precision', function (appstate, precision) {
+    var map;
+
+    appstate.register('exchange_rate', function (globalRates) {
+      // build rate map anytime the exchange rate changes.
+      globalRates.forEach(function (r) {
+        map[r.foreign_currency_id] = r.rate;
+      });
+    });
+
+    return function (value, currency_id) {
+      value = value || 0;
+      var scalar = map[currency_id] || 1;
+      return map ? precision.round(scalar*value, 2) : precision.round(value, 2);
+    };
+  }]); 
+  // })(angular);
 

--- a/client/src/js/services/currencyFormat.js
+++ b/client/src/js/services/currencyFormat.js
@@ -1,4 +1,4 @@
-'use strict'
+'use strict';
 
 /**
  * @description
@@ -26,6 +26,7 @@ angular.module('bhima.services')
     
   // Requests individual currency configurations
   function fetchFormatConfiguration(key) { 
+    var formatObject = null;
     fetchingKeys[key] = true;
     
     $http.get(currencyConfigurationPath.concat(key, '.json'))

--- a/client/src/js/services/currencyFormat.js
+++ b/client/src/js/services/currencyFormat.js
@@ -1,0 +1,95 @@
+'use strict'
+
+/**
+ * @description
+ * Provides asynchronous GET requests for currency configuration files, fetched 
+ * configurations are cached and served directly to subsequent requests.
+ *
+ * @returns {object} Wrapper object exposing request configuration method
+ */
+
+angular.module('bhima.services')
+.factory('currencyFormat', ['$http', 'store', function ($http, Store) { 
+  var currencyConfigurationPath = '/i18n/currency/';
+  var loadedSupportedCurrencies = false;
+  var supportedCurrencies = new Store({identifier : 'id'});
+  var currentFormats = new Store({identifier : 'format_key'});
+  var fetchingKeys = [];
+  var invalidCurrency = { supported : false };
+  
+  // Request all defined BHIMA currencies
+  $http.get('/finance/currencies')
+  .success(function (currencyList) {
+    supportedCurrencies.setData(currencyList);
+    loadedSupportedCurrencies = true;
+  });
+    
+  // Requests individual currency configurations
+  function fetchFormatConfiguration(key) { 
+    fetchingKeys[key] = true;
+    
+    $http.get(currencyConfigurationPath.concat(key, '.json'))
+      .success(function (result) { 
+        
+        // Add configuration to local cache
+        formatObject = result;
+        formatObject.supported = true;
+        formatObject.format_key = key;
+        addFormat(formatObject);      
+      })
+      .catch(function (err) { 
+        
+        // Deny future attempts to request this configuration
+        formatObject = invalidCurrency;
+        formatObject.format_key = key;
+        addFormat(formatObject);
+      });
+  }
+
+  function addFormat(formatObject) { 
+
+    // FIXME Resolve issue with initial Store data to just allow post. Github Ref: #
+    if (angular.isUndefined(currentFormats.data.length)) { 
+      currentFormats.setData([formatObject]);
+    } else { 
+      currentFormats.post(formatObject);
+    }
+  }
+  
+  /**
+   * @param {number} currencyId ID of currency to be checked against BHIMA's database
+   *
+   * @returns {object} Returns format configuration if it has been found and fetched, 
+   * objects reporting unsupported status if configuration or currency cannot be found
+   */
+  function searchFormatConfiguration(currencyId) {
+    var supportedCurrency = supportedCurrencies.get(currencyId);
+
+    if (angular.isUndefined(supportedCurrency)) { 
+      return invalidCurrency;
+    }
+  
+    // currency has been identified - search for configuration 
+    var formatKey = supportedCurrency.format_key;
+    var progress = fetchingKeys[formatKey];
+
+    // initial for request for currency with this key - initialise configuration request
+    if (!angular.isDefined(progress)) { 
+      fetchFormatConfiguration(formatKey);
+    }
+    
+    return currentFormats.get(formatKey);
+  }
+  
+  /**
+   * @returns {boolean} Exposes status of initial currency index cache request
+   */
+  function reportStatus() { 
+    return loadedSupportedCurrencies;
+  }
+
+  return { 
+    request : searchFormatConfiguration,
+    indexReady : reportStatus
+  };
+}]);

--- a/client/src/partials/bhima/application.js
+++ b/client/src/partials/bhima/application.js
@@ -8,7 +8,8 @@ angular.module('bhima.controllers')
   'connect',
   'util',
   'SessionService',
-  function ($location, $timeout, $translate, Appcache, appstate, connect, util, SessionService) {
+  'tmhDynamicLocale',
+  function ($location, $timeout, $translate, Appcache, appstate, connect, util, SessionService, tmhDynamicLocale) {
 
     // useful for loading the language
     var cache = new Appcache('preferences');
@@ -17,6 +18,10 @@ angular.module('bhima.controllers')
     .then(function (res) {
       if (res) {
         $translate.use(res.current);
+
+        console.log('settingLocale fr');
+        
+        tmhDynamicLocale.set('fr-fr');
       }
     });
 

--- a/client/src/partials/bhima/application.js
+++ b/client/src/partials/bhima/application.js
@@ -15,13 +15,10 @@ angular.module('bhima.controllers')
     var cache = new Appcache('preferences');
 
     cache.fetch('language')
-    .then(function (res) {
-      if (res) {
-        $translate.use(res.current);
-
-        console.log('settingLocale fr');
-        
-        tmhDynamicLocale.set('fr-fr');
+    .then(function (language) {
+      if (language) {
+        $translate.use(language.translateKey);
+        tmhDynamicLocale.set(language.localeKey);
       }
     });
 

--- a/client/src/partials/receipts/receipt.sale.js
+++ b/client/src/partials/receipts/receipt.sale.js
@@ -9,8 +9,6 @@ angular.module('bhima.controllers')
     var dependencies = {}, model = $scope.model = {common : {}, total : {}};
     $scope.updateCurrency = updateCurrency;
   
-    $scope.thisvariable = '#';
-    
     dependencies.recipient = {
       required: true,
       query : {
@@ -97,9 +95,6 @@ angular.module('bhima.controllers')
         ledgers = model.ledger;
 
       
-
-      $scope.thisvariable = $scope.thisvariable + '#';  
-      console.log(model.selectedCurrency.id);
 
       totals.localeCost = doConvert(saleRecords.cost, currency, saleRecords.invoice_date);
 

--- a/client/src/partials/receipts/receipt.sale.js
+++ b/client/src/partials/receipts/receipt.sale.js
@@ -1,13 +1,16 @@
 angular.module('bhima.controllers')
 .controller('receipt.sale', [
   '$scope',
+  '$locale',
   'validate',
   'appstate',
   'messenger',
-  function ($scope, validate, appstate, messenger) {
+  function ($scope, $locale, validate, appstate, messenger) {
     var dependencies = {}, model = $scope.model = {common : {}, total : {}};
     $scope.updateCurrency = updateCurrency;
-
+  
+    $scope.thisvariable = '#';
+    
     dependencies.recipient = {
       required: true,
       query : {
@@ -94,6 +97,10 @@ angular.module('bhima.controllers')
         ledgers = model.ledger;
 
       
+
+      $scope.thisvariable = $scope.thisvariable + '#';  
+      console.log(model.selectedCurrency.id);
+
       totals.localeCost = doConvert(saleRecords.cost, currency, saleRecords.invoice_date);
 
       if (ledgers)  {

--- a/client/src/partials/receipts/templates/receipt_sale.html
+++ b/client/src/partials/receipts/templates/receipt_sale.html
@@ -49,6 +49,8 @@
       <i>{{ 'INVOICE.DATE_RECEIPT' | translate }}</i>
       <br>
       {{model.saleRecords[0].invoice_date | date}}
+      {{ 300.45 | currency:thisvariable }}
+      <p style="color : red;">{{ 93000 | bhimaCurrency:model.selectedCurrency.id}}</p>
       <br>
     </div>
   </div>

--- a/client/src/partials/receipts/templates/receipt_sale.html
+++ b/client/src/partials/receipts/templates/receipt_sale.html
@@ -49,8 +49,7 @@
       <i>{{ 'INVOICE.DATE_RECEIPT' | translate }}</i>
       <br>
       {{model.saleRecords[0].invoice_date | date}}
-      {{ 300.45 | currency:thisvariable }}
-      <p style="color : red;">{{ 93000 | bhimaCurrency:model.selectedCurrency.id}}</p>
+      <p style="color : red;">{{ 93000 | currency:model.selectedCurrency.id}}</p>
       <br>
     </div>
   </div>
@@ -74,8 +73,10 @@
             <td>{{ item.text }}</td>
             <td>{{ item.quantity }}</td>
 
-            <td><span ng-bind-html="item.localeTransaction | intlcurrency:model.selectedCurrency.id"></span></td>
-            <td><span ng-bind-html="item.localeCost| intlcurrency:model.selectedCurrency.id"></span></td>
+            <!-- <td><span ng-bind-html="item.localeTransaction | intlcurrency:model.selectedCurrency.id"></span></td> -->
+            <!-- <td><span ng-bind-html="item.localeCost| intlcurrency:model.selectedCurrency.id"></span></td> -->
+            <td>{{ item.localeTransaction | currency:model.selectedCurrency.id }}</td>
+            <td>{{ item.localeCost | currency:model.selectedCurrency.id }}</td>
           </tr>
           <tr ng-show="model.saleSubsidies.length" ng-repeat="subsidy in model.saleSubsidies">
             <td colspan="2">{{subsidy.text}}</td>
@@ -83,9 +84,9 @@
           </tr>
         </tbody>
         <tbody class="totals">
-          <tr><td colspan="4" class="no-border">{{'INVOICE.TOTAL' | translate}}</td><td><span ng-bind-html="model.total.localeCost | intlcurrency:model.selectedCurrency.id"></span></td></tr>
-          <tr><td colspan="4" class="no-border">{{'INVOICE.AMOUNT_RECEIVED' | translate}}</td><td><span ng-bind-html="model.ledger.localeCredit | intlcurrency:model.selectedCurrency.id"></span></td></tr>
-          <tr><td colspan="4" class="no-border">{{'INVOICE.BALANCE_DUE' | translate}}</td><td><span ng-bind-html="model.total.localeBalance | intlcurrency:model.selectedCurrency.id"></span></td></tr>
+          <tr><td colspan="4" class="no-border">{{'INVOICE.TOTAL' | translate}}</td><td>{{ model.total.localeCost | currency:model.selectedCurrency.id }}</td></tr>
+          <tr><td colspan="4" class="no-border">{{'INVOICE.AMOUNT_RECEIVED' | translate}}</td><td>{{model.ledger.localeCredit | currency:model.selectedCurrency.id}}</td></tr>
+          <tr><td colspan="4" class="no-border">{{'INVOICE.BALANCE_DUE' | translate}}</td><td>{{model.total.localeBalance | currency:model.selectedCurrency.id}}</td></tr>
         </tbody>
       </table>
     </div>

--- a/client/src/partials/receipts/templates/receipt_sale.html
+++ b/client/src/partials/receipts/templates/receipt_sale.html
@@ -49,7 +49,6 @@
       <i>{{ 'INVOICE.DATE_RECEIPT' | translate }}</i>
       <br>
       {{model.saleRecords[0].invoice_date | date}}
-      <p style="color : red;">{{ 93000 | currency:model.selectedCurrency.id}}</p>
       <br>
     </div>
   </div>
@@ -73,8 +72,6 @@
             <td>{{ item.text }}</td>
             <td>{{ item.quantity }}</td>
 
-            <!-- <td><span ng-bind-html="item.localeTransaction | intlcurrency:model.selectedCurrency.id"></span></td> -->
-            <!-- <td><span ng-bind-html="item.localeCost| intlcurrency:model.selectedCurrency.id"></span></td> -->
             <td>{{ item.localeTransaction | currency:model.selectedCurrency.id }}</td>
             <td>{{ item.localeCost | currency:model.selectedCurrency.id }}</td>
           </tr>

--- a/client/src/partials/settings/settings.js
+++ b/client/src/partials/settings/settings.js
@@ -6,23 +6,48 @@ angular.module('bhima.controllers')
   '$location',
   'appcache',
   'messenger',
-  function($scope, $routeParams, $translate, $location, Appcache, messenger) {
-
+  'tmhDynamicLocale',
+  'store',
+  function($scope, $routeParams, $translate, $location, Appcache, messenger, tmhDynamicLocale, Store) {
+    
+    // TODO issue discussing DB modelling of languages, quick suggestion (id, label, translateKey, localeKey)
+    var languageStore = new Store({identifier : 'translateKey'});
+    var languages = [
+      {
+        translateKey : 'en',
+        localeKey : 'en-us',
+        label : 'English'
+      },
+      {
+        translateKey : 'fr',
+        localeKey : 'fr-fr',
+        label : 'French'
+      },
+      {
+        translateKey : 'ln',
+        localeKey : 'fr-cd',
+        label : 'Lingala'
+      }
+    ];
+    languageStore.setData(languages);
+    
     $scope.url = $routeParams.url || '';
     var cache = new Appcache('preferences');
 
     cache.fetch('language')
     .then(function (res) {
       if (res) {
-        $scope.settings = { language: res.current };
+        $scope.settings = { language: res.translateKey };
       }
     });
 
     $scope.updateLanguage = function updateLanuage(key) {
-      $translate.use(key);
-      cache.put('language', {current: key});
+      var language = languageStore.get(key);
+      
+      $translate.use(language.translateKey);
+      tmhDynamicLocale.set(language.localeKey);
 
-      messenger.primary({ namespace : 'SETTINGS', description : 'Language preference updated : ' + key });
+      cache.put('language', language);
     };
 
     $scope.back = function () {

--- a/client/vendor/angular-dynamic-locale/tmhDynamicLocale.js
+++ b/client/vendor/angular-dynamic-locale/tmhDynamicLocale.js
@@ -1,0 +1,220 @@
+/**
+ * Angular Dynamic Locale - 0.1.27
+ * https://github.com/lgalfaso/angular-dynamic-locale
+ * License: MIT
+ */
+(function(window) {
+'use strict';
+angular.module('tmh.dynamicLocale', []).config(['$provide', function ($provide) {
+  function makeStateful($delegate) {
+    $delegate.$stateful = true;
+    return $delegate;
+  }
+
+  $provide.decorator('dateFilter', ['$delegate', makeStateful]);
+  $provide.decorator('numberFilter', ['$delegate', makeStateful]);
+  $provide.decorator('currencyFilter', ['$delegate', makeStateful]);
+
+}])
+.constant('tmhDynamicLocale.STORAGE_KEY', 'tmhDynamicLocale.locale')
+.provider('tmhDynamicLocale', ['tmhDynamicLocale.STORAGE_KEY', function(STORAGE_KEY) {
+
+  var defaultLocale,
+    localeLocationPattern = 'angular/i18n/angular-locale_{{locale}}.js',
+    storageFactory = 'tmhDynamicLocaleStorageCache',
+    storage,
+    storageKey = STORAGE_KEY,
+    promiseCache = {},
+    activeLocale;
+
+  /**
+   * Loads a script asynchronously
+   *
+   * @param {string} url The url for the script
+   * @param {function) callback A function to be called once the script is loaded
+   */
+  function loadScript(url, callback, errorCallback, $timeout) {
+    var script = document.createElement('script'),
+      body = document.getElementsByTagName('body')[0],
+      removed = false;
+
+    script.type = 'text/javascript';
+    if (script.readyState) { // IE
+      script.onreadystatechange = function () {
+        if (script.readyState === 'complete' ||
+            script.readyState === 'loaded') {
+          script.onreadystatechange = null;
+          $timeout(
+            function () {
+              if (removed) return;
+              removed = true;
+              body.removeChild(script);
+              callback();
+            }, 30, false);
+        }
+      };
+    } else { // Others
+      script.onload = function () {
+        if (removed) return;
+        removed = true;
+        body.removeChild(script);
+        callback();
+      };
+      script.onerror = function () {
+        if (removed) return;
+        removed = true;
+        body.removeChild(script);
+        errorCallback();
+      };
+    }
+    script.src = url;
+    script.async = false;
+    body.appendChild(script);
+  }
+
+  /**
+   * Loads a locale and replaces the properties from the current locale with the new locale information
+   *
+   * @param localeUrl The path to the new locale
+   * @param $locale The locale at the curent scope
+   */
+  function loadLocale(localeUrl, $locale, localeId, $rootScope, $q, localeCache, $timeout) {
+
+    function overrideValues(oldObject, newObject) {
+      if (activeLocale !== localeId) {
+        return;
+      }
+      angular.forEach(oldObject, function(value, key) {
+        if (!newObject[key]) {
+          delete oldObject[key];
+        } else if (angular.isArray(newObject[key])) {
+          oldObject[key].length = newObject[key].length;
+        }
+      });
+      angular.forEach(newObject, function(value, key) {
+        if (angular.isArray(newObject[key]) || angular.isObject(newObject[key])) {
+          if (!oldObject[key]) {
+            oldObject[key] = angular.isArray(newObject[key]) ? [] : {};
+          }
+          overrideValues(oldObject[key], newObject[key]);
+        } else {
+          oldObject[key] = newObject[key];
+        }
+      });
+    }
+
+
+    if (promiseCache[localeId]) return promiseCache[localeId];
+
+    var cachedLocale,
+      deferred = $q.defer();
+    if (localeId === activeLocale) {
+      deferred.resolve($locale);
+    } else if ((cachedLocale = localeCache.get(localeId))) {
+      activeLocale = localeId;
+      $rootScope.$evalAsync(function() {
+        overrideValues($locale, cachedLocale);
+        $rootScope.$broadcast('$localeChangeSuccess', localeId, $locale);
+        storage.put(storageKey, localeId);
+        deferred.resolve($locale);
+      });
+    } else {
+      activeLocale = localeId;
+      promiseCache[localeId] = deferred.promise;
+      loadScript(localeUrl, function () {
+        // Create a new injector with the new locale
+        var localInjector = angular.injector(['ngLocale']),
+          externalLocale = localInjector.get('$locale');
+
+        overrideValues($locale, externalLocale);
+        localeCache.put(localeId, externalLocale);
+        delete promiseCache[localeId];
+
+        $rootScope.$apply(function () {
+          $rootScope.$broadcast('$localeChangeSuccess', localeId, $locale);
+          storage.put(storageKey, localeId);
+          deferred.resolve($locale);
+        });
+      }, function () {
+        delete promiseCache[localeId];
+
+        $rootScope.$apply(function () {
+          if (activeLocale === localeId) activeLocale = $locale.id;
+          $rootScope.$broadcast('$localeChangeError', localeId);
+          deferred.reject(localeId);
+        });
+      }, $timeout);
+    }
+    return deferred.promise;
+  }
+
+  this.localeLocationPattern = function(value) {
+    if (value) {
+      localeLocationPattern = value;
+      return this;
+    } else {
+      return localeLocationPattern;
+    }
+  };
+
+  this.useStorage = function(storageName) {
+    storageFactory = storageName;
+  };
+
+  this.useCookieStorage = function() {
+    this.useStorage('$cookieStore');
+  };
+
+  this.defaultLocale = function (value) {
+    defaultLocale = value;
+  };
+
+  this.storageKey = function (value) {
+    if (value) {
+      storageKey = value;
+      return this;
+    } else {
+      return storageKey;
+    }
+  };
+
+  this.$get = ['$rootScope', '$injector', '$interpolate', '$locale', '$q', 'tmhDynamicLocaleCache', '$timeout', function($rootScope, $injector, interpolate, locale, $q, tmhDynamicLocaleCache, $timeout) {
+    var localeLocation = interpolate(localeLocationPattern);
+
+    storage = $injector.get(storageFactory);
+    $rootScope.$evalAsync(function () {
+      var initialLocale;
+      if ((initialLocale = (storage.get(storageKey) || defaultLocale))) {
+        loadLocale(localeLocation({locale: initialLocale}), locale, initialLocale, $rootScope, $q, tmhDynamicLocaleCache, $timeout);
+      }
+    });
+    return {
+      /**
+       * @ngdoc method
+       * @description
+       * @param {string=} value Sets the locale to the new locale. Changing the locale will trigger
+       *    a background task that will retrieve the new locale and configure the current $locale
+       *    instance with the information from the new locale
+       */
+      set: function(value) {
+        return loadLocale(localeLocation({locale: value}), locale, value, $rootScope, $q, tmhDynamicLocaleCache, $timeout);
+      },
+      /**
+       * @ngdoc method
+       * @description Returns the configured locale
+       */
+      get: function() {
+        return activeLocale;
+      }
+    };
+  }];
+}]).provider('tmhDynamicLocaleCache', function() {
+  this.$get = ['$cacheFactory', function($cacheFactory) {
+    return $cacheFactory('tmh.dynamicLocales');
+  }];
+}).provider('tmhDynamicLocaleStorageCache', function() {
+  this.$get = ['$cacheFactory', function($cacheFactory) {
+    return $cacheFactory('tmh.dynamicLocales.store');
+  }];
+}).run(['tmhDynamicLocale', angular.noop]);
+}(window));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -45,12 +45,12 @@ var UGLIFY = false,
 // resource paths
 var paths = {
   client : {
-    javascript : ['client/src/js/define.js', 'client/src/js/app.js', 'client/src/**/*.js'],
+    javascript : ['client/src/js/define.js', 'client/src/js/app.js', 'client/src/**/*.js', '!client/src/i18n/**/*.js'],
     css        : ['client/src/partials/**/*.css', 'client/src/css/*.css'],
     vendor     : ['client/vendor/*.js', 'client/vendor/**/*.js'],
 
     // these must be globs ("**" syntax) to retain their folder structures
-    static     : ['client/src/index.html', 'client/src/js/app.js', 'client/src/**/*', '!client/src/**/*.js', '!client/src/**/*.css']
+    static     : ['client/src/index.html', 'client/src/js/app.js', 'client/src/**/*', '!client/src/js/**/*.js', '!client/src/partials/**/*.js', '!client/src/**/*.css']
   },
   server : {
     javascript : ['server/*.js', 'server/**/*.js'],

--- a/server/controllers/finance.js
+++ b/server/controllers/finance.js
@@ -272,7 +272,7 @@ exports.getCurrencies = function (req, res, next) {
   'use strict';
 
   var sql =
-    'SELECT c.id, c.name, c.symbol, c.decimal, c.separator, c.note ' +
+    'SELECT c.id, c.name, c.note, c.format_key ' +
     'FROM currency AS c;';
 
   db.exec(sql)

--- a/server/models/development/update/synt.sql
+++ b/server/models/development/update/synt.sql
@@ -123,10 +123,20 @@ UPDATE  `bhima`.`transaction_type` SET  `service_txt` =  'group_deb_invoice' WHE
 UPDATE  `bhima`.`transaction_type` SET  `service_txt` =  'stock_loss' WHERE  `transaction_type`.`id` =13;
 UPDATE  `bhima`.`transaction_type` SET  `service_txt` =  'reversing_stock' WHERE  `transaction_type`.`id` =28;
 
-
 -- rm unused currency tree node
 --
 -- Date: 2015-08-31
 -- By: jniles
 
 DELETE FROM `unit` WHERE id = 33;
+
+-- Update currency, decoupling format and definition to utilise locale format 
+-- 
+-- Date : 2015-09-01
+-- @sfount
+ALTER TABLE `currency` DROP COLUMN `separator`;
+ALTER TABLE `currency` DROP COLUMN `decimal`;
+ALTER TABLE `currency` ADD `format_key` VARCHAR(20) AFTER `name`;
+UPDATE `currency` SET `format_key` = 'fc' WHERE id = 1;
+UPDATE `currency` SET `format_key` = 'usd' WHERE `id` = 2;
+ALTER TABLE `currency` MODIFY `format_key` VARCHAR(20) NOT NULL;


### PR DESCRIPTION
In this PR:

1. Localisation using ngLocale, configures angular filters based on locale - the primary change has been updating dates from only US format to respecting the user language. _(Note: this does not apply to the currency filter - as described in this pull request)__

2. Forked the native angular currency filter - it is essential that currencies in BHIMA are __not__ dependent on locale, they must respect the original transactions currency. This filter enables:
* Safe alternative to the current intlcurrency filter - no unsafe data binding 
* Specify BHIMA currency to request correct formatting 
* 
