### PR TITLE
Demonstrating new ng-options tools

### DIFF
--- a/client/src/partials/reports/global_transaction/global_transaction.html
+++ b/client/src/partials/reports/global_transaction/global_transaction.html
@@ -15,17 +15,19 @@
                   <div class="col-xs-4">
                     <div class="form-group">
                       <label class="control-label col-xs-4 required">{{ "UTIL.ACCOUNT" | translate }}</label>
-                      <select required class="form-bhima" id="account" ng-model="model.account_id">
-                        <option value="0">-- {{"SELECT.ALL" | translate }} --</option>
-                        <option ng-repeat="acc in accounts.data | orderBy:'account_number'" value='{{acc.id}}' ng-disabled="acc.account_type_id==3">{{formatAccount(acc)}}</option>
+                    
+                      <!-- Select using ng-options vs. ng-repeat to reduce impact on DOM loading times -->
+                      <select ng-options="account.id as account.display disable when (account.account_type_id===3) for account in accounts.data" ng-model="model.account_id" class="form-bhima">
+                        <option value="">-- {{"SELECT.ALL" | translate }} --</option>
                       </select>
+                    
                     </div>
                   </div>
 
                   <div class="col-xs-4">
                     <label class="control-label col-xs-4 required">{{ "UTIL.SOURCE" | translate }}</label>
                     <select class="form-bhima" id="sources" ng-change="search()" ng-model="model.source_id">
-                      <option ng-repeat="source in model.sources" value='{{$index}}'>{{source}}</option>
+                      <option required ng-repeat="source in model.sources" value='{{$index}}'>{{source}}</option>
                     </select>
                   </div>
 

--- a/client/src/partials/reports/global_transaction/global_transaction.js
+++ b/client/src/partials/reports/global_transaction/global_transaction.js
@@ -60,6 +60,9 @@ angular.module('bhima.controllers')
 
       $scope.accounts.data.forEach(function (account) {
         account.account_number = String(account.account_number);
+        
+        // Define formatted account string at load time as this will never have to change again
+        account.display = formatAccount(account);
       });
       $scope.model.c = $scope.enterprise.currency_id;
       $scope.model.account_id = 0;


### PR DESCRIPTION
Using ng-options is **significantly** faster than using an ng-repeat on an <options> tag as discussed #701 and #700. 

This PR demonstrates this taking DOM load time from ~7 seconds to < 1 second. 

It also demonstrates the new ng-options API that allows the developer to specify when to disable options using the 'disable when' syntax 

```<select ng-options="account.displayString disable when (account.disabled) for account in accounts.data" ng-model="session.selectedAccount"></select>```
