### PR TITLE
FIX: purchase invoices render properly

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -1071,6 +1071,7 @@
    "NEW"                      : "New Enterprise",
    "PHONE"                    : "Phone",
    "PO_BOX"                   : "PO Box",
+   "POST_OFFICE_BOX"          : "Post Office Box",
    "REGISTERED_ENTERPRISE"    : "Registered Enterprises",
    "REGISTERED_RELATIONS"     : "Registered Relations",
    "TITLE"                    : "Enterprise Management"

--- a/client/src/i18n/fr.json
+++ b/client/src/i18n/fr.json
@@ -1071,6 +1071,7 @@
    "NEW"                      : "Nouvelle Entreprise",
    "PHONE"                    : "Telephone",
    "PO_BOX"                   : "B.P.",
+   "POST_OFFICE_BOX"          : "Boîte Postale",
    "REGISTERED_ENTERPRISE"    : "Entreprises Enregistrées",
    "REGISTERED_RELATIONS"     : "Relations Enregistrées",
    "TITLE"                    : "Gestion de l'Entreprise"

--- a/client/src/partials/receipts/receipt.purchase.js
+++ b/client/src/partials/receipts/receipt.purchase.js
@@ -1,136 +1,137 @@
 angular.module('bhima.controllers')
-.controller('receipt.purchase', [
-  '$scope',
-  'validate',
-  'appstate',
-  'messenger',
-  function ($scope, validate, appstate, messenger) {
-    var dependencies = {}, model = $scope.model = {common : {}};
+.controller('receipt.purchase', PurchaseReceiptController);
 
-    dependencies.indirectPurchases = {
-      query : {
-        identifier : 'uuid',
-        tables : {
-          'purchase' : {
-            columns : ['uuid', 'reference', 'project_id', 'cost', 'currency_id', 'creditor_uuid', 'purchase_date', 'note', 'purchaser_id', 'is_direct', 'is_authorized', 'is_validate']
-          },
-          'purchase_item' : {
-            columns : ['inventory_uuid', 'purchase_uuid', 'quantity', 'unit_price', 'total']
-          },
-          'inventory' : {
-            columns : ['code', 'text']
-          },
-          'creditor' : {
-            columns : ['group_uuid']
-          },
-          'supplier' : {
-            columns : ['email', 'phone']
-          },
-          'employee' : {
-            columns : ['prenom', 'name', 'postnom', 'creditor_uuid']
-          }
+PurchaseReceiptController = [
+  '$scope', 'validate', 'appstate', 'messenger',
+];
+
+function PurchaseReceiptController($scope, validate, appstate, messenger) {
+  var vm = this;
+  var dependencies = {}, model = $scope.model = {common : {}};
+
+  dependencies.indirectPurchases = {
+    query : {
+      identifier : 'uuid',
+      tables : {
+        'purchase' : {
+          columns : ['uuid', 'reference', 'project_id', 'cost', 'currency_id', 'creditor_uuid', 'purchase_date', 'note', 'purchaser_id', 'is_direct', 'is_authorized', 'is_validate']
         },
-        join : [
-          'purchase.uuid=purchase_item.purchase_uuid',
-          'purchase_item.inventory_uuid=inventory.uuid',
-          'purchase.creditor_uuid=creditor.uuid',
-          'creditor.uuid=supplier.creditor_uuid',
-          'purchase.purchaser_id=employee.id'
-        ]
-      }
-    };
-
-    dependencies.directPurchases = {
-      query : {
-        identifier : 'uuid',
-        tables : {
-          'purchase' : {
-            columns : ['uuid', 'reference', 'project_id', 'cost', 'currency_id', 'creditor_uuid', 'purchase_date', 'note', 'purchaser_id', 'is_direct', 'is_validate', 'is_authorized']
-          },
-          'purchase_item' : {
-            columns : ['inventory_uuid', 'purchase_uuid', 'quantity', 'unit_price', 'total']
-          },
-          'inventory' : {
-            columns : ['code', 'text']
-          },
-          'creditor' : {
-            columns : ['group_uuid']
-          },
-          'supplier' : {
-            columns : ['email', 'phone']
-          }
+        'purchase_item' : {
+          columns : ['inventory_uuid', 'purchase_uuid', 'quantity', 'unit_price', 'total']
         },
-        join : [
-          'purchase.uuid=purchase_item.purchase_uuid',
-          'purchase_item.inventory_uuid=inventory.uuid',
-          'purchase.creditor_uuid=creditor.uuid',
-          'creditor.uuid=supplier.creditor_uuid'
-        ]
-      }
-    };
-
-    dependencies.supplier = {
-      query : {
-        tables : {
-          'purchase' : {
-            columns : ['creditor_uuid']
-          },
-          'creditor' : {
-            columns : ['text']
-          },
-          'supplier' : {
-            columns : ['name', 'email', 'phone']
-          }
+        'inventory' : {
+          columns : ['code', 'text']
         },
-        join : [
-          'purchase.creditor_uuid=creditor.uuid',
-          'creditor.uuid=supplier.creditor_uuid'
-        ]
-      }
-    };
-
-    dependencies.header = {
-      query : {
-        tables : {
-          'purchase' : {
-            columns : ['uuid', 'receiver_id', 'emitter_id']
-          },
-          'employee' : {
-            columns : ['prenom', 'name', 'postnom', 'creditor_uuid']
-          },
-          'user' : {
-            columns : ['first', 'last']
-          }
+        'creditor' : {
+          columns : ['group_uuid']
         },
-        join : [
-          'purchase.receiver_id=employee.id',
-          'purchase.emitter_id=user.id'
-        ]
-      }
-    };
-
-    function buildInvoice (res) {
-      model.common.header = res.header.data;
-      model.common.purchases = (res.indirectPurchases.data.length) ? res.indirectPurchases.data : res.directPurchases.data;
-      model.common.supplier = res.supplier.data;
+        'supplier' : {
+          columns : ['email', 'phone']
+        },
+        'employee' : {
+          columns : ['prenom', 'name', 'postnom', 'creditor_uuid']
+        }
+      },
+      join : [
+        'purchase.uuid=purchase_item.purchase_uuid',
+        'purchase_item.inventory_uuid=inventory.uuid',
+        'purchase.creditor_uuid=creditor.uuid',
+        'creditor.uuid=supplier.creditor_uuid',
+        'purchase.purchaser_id=employee.id'
+      ]
     }
+  };
 
-  	appstate.register('receipts.commonData', function (commonData) {
-  		commonData.then(function (values) {
-        model.common.location = values.location.data.pop();
-        model.common.enterprise = values.enterprise.data.pop();
+  dependencies.directPurchases = {
+    query : {
+      identifier : 'uuid',
+      tables : {
+        'purchase' : {
+          columns : ['uuid', 'reference', 'project_id', 'cost', 'currency_id', 'creditor_uuid', 'purchase_date', 'note', 'purchaser_id', 'is_direct', 'is_validate', 'is_authorized']
+        },
+        'purchase_item' : {
+          columns : ['inventory_uuid', 'purchase_uuid', 'quantity', 'unit_price', 'total']
+        },
+        'inventory' : {
+          columns : ['code', 'text']
+        },
+        'creditor' : {
+          columns : ['group_uuid']
+        },
+        'supplier' : {
+          columns : ['email', 'phone']
+        }
+      },
+      join : [
+        'purchase.uuid=purchase_item.purchase_uuid',
+        'purchase_item.inventory_uuid=inventory.uuid',
+        'purchase.creditor_uuid=creditor.uuid',
+        'creditor.uuid=supplier.creditor_uuid'
+      ]
+    }
+  };
 
-        dependencies.indirectPurchases.query.where =  ['purchase_item.purchase_uuid=' + values.invoiceId];
-        dependencies.directPurchases.query.where =  ['purchase_item.purchase_uuid=' + values.invoiceId,'AND','purchase.is_direct=1'];
-        dependencies.supplier.query.where =  ['purchase.uuid=' + values.invoiceId];
-        dependencies.header.query.where =  ['purchase.uuid=' + values.invoiceId];
+  dependencies.supplier = {
+    query : {
+      tables : {
+        'purchase' : {
+          columns : ['creditor_uuid']
+        },
+        'creditor' : {
+          columns : ['text']
+        },
+        'supplier' : {
+          columns : ['name', 'email', 'phone']
+        }
+      },
+      join : [
+        'purchase.creditor_uuid=creditor.uuid',
+        'creditor.uuid=supplier.creditor_uuid'
+      ]
+    }
+  };
 
-        validate.process(dependencies)
-        .then(buildInvoice)
-        .catch(function (err){
-          messenger.danger('error', err);
-        });
-  		});
-    });
+  dependencies.header = {
+    query : {
+      tables : {
+        'purchase' : {
+          columns : ['uuid', 'receiver_id', 'emitter_id']
+        },
+        'employee' : {
+          columns : ['prenom', 'name', 'postnom', 'creditor_uuid']
+        },
+        'user' : {
+          columns : ['first', 'last']
+        }
+      },
+      join : [
+        'purchase.receiver_id=employee.id',
+        'purchase.emitter_id=user.id'
+      ]
+    }
+  };
+
+  function buildInvoice (res) {
+    model.common.header = res.header.data;
+    model.common.purchases = (res.indirectPurchases.data.length) ? res.indirectPurchases.data : res.directPurchases.data;
+    model.common.supplier = res.supplier.data;
   }
-]);
+
+  appstate.register('receipts.commonData', function (commonData) {
+    commonData.then(function (values) {
+      model.common.location = values.location.data.pop();
+      model.common.enterprise = values.enterprise.data.pop();
+
+      dependencies.indirectPurchases.query.where =  ['purchase_item.purchase_uuid=' + values.invoiceId];
+      dependencies.directPurchases.query.where =  ['purchase_item.purchase_uuid=' + values.invoiceId,'AND','purchase.is_direct=1'];
+      dependencies.supplier.query.where =  ['purchase.uuid=' + values.invoiceId];
+      dependencies.header.query.where =  ['purchase.uuid=' + values.invoiceId];
+
+      validate.process(dependencies)
+      .then(buildInvoice)
+      .catch(function (err){
+        messenger.danger('error', err);
+      });
+    });
+  });
+}

--- a/client/src/partials/receipts/receipts.js
+++ b/client/src/partials/receipts/receipts.js
@@ -8,8 +8,7 @@ angular.module('bhima.controllers')
   'validate',
   'exchange',
   'appstate',
-  'connect',
-  function ($scope, $routeParams, $q, validate, exchange, appstate, connect) {
+  function ($scope, $routeParams, $q, validate, exchange, appstate) {
     var templates,
       dependencies = {},
       origin = $scope.origin = $routeParams.originId,

--- a/client/src/partials/receipts/templates/receipt_purchase.html
+++ b/client/src/partials/receipts/templates/receipt_purchase.html
@@ -1,28 +1,22 @@
 <!-- Purchase template -->
-<!--ng-class="{ 'hidden-print' : model.common.purchases[0].is_authorized == 0, 'visible-print':  model.common.purchases[0].is_authorized == 0 }"-->
-<div ng-controller="receipt.purchase">
+<div ng-controller="receipt.purchase as ReceiptCtrl">
   <div class="row customer-details">
     <div class="col-xs-12">
       <small style="float: right; color: grey; font-size: 14px"> {{ model.common.purchases[0].uuid }}</small>
-      <h4 class="invoice-header">{{ 'INVOICE.PURCHASE_ORDER' | translate }} : {{ model.common.enterprise.abbr + model.common.purchases[0].reference}}</h4>
+      <h4 class="invoice-header">{{ 'INVOICE.PURCHASE_ORDER' | translate }}: {{ model.common.enterprise.abbr + model.common.purchases[0].reference}}</h4>
     </div>
   </div>
 
   <div class="row customer-details">
     <div class="col-xs-4">
-      <span>
-        <b>{{model.common.enterprise.name}}</b>
-      </span>
-      <br>
-      {{model.common.location.name}}
-      <br>
-      {{ model.common.enterprise.po_box || 'B.P. 205'}}
-      <br>
-      {{model.common.location.sector_name}}
-      <br>
-      <i>TEL. : </i> {{model.common.enterprise.phone}}
-      <br>
-      <i>EMAIL : </i> {{model.common.enterprise.email}}
+      <address>
+        <strong>{{ model.common.enterprise.name }}</strong><br />
+        {{ model.common.location.name }} <br>
+        <abbr title="{{ 'ENTERPRISE.POST_OFFICE_BOX' | translate }}">{{ 'ENTERPRISE.PO_BOX' | translate }} :</abbr> {{ model.common.enterprise.po_box }}<br>
+        {{ model.common.location.sector_name }}<br>
+        <abbr title="{{ 'ENTERPRISE.PHONE' | translate }}">TEL. :</abbr> {{ model.common.enterprise.phone }}<br>
+        <i>EMAIL : </i> {{ model.common.enterprise.email }}
+      </address>
     </div>
     <div class="col-xs-4">
       <i>{{ "INVOICE.PURCHASE_RECIPIENT" | translate }}</i><br>
@@ -88,7 +82,7 @@
           <tr>
             <td colspan="4" class="no-border">{{'INVOICE.PURCHASE_TOTAL' | translate}}</td>
             <td>
-              {{ model.common.purchases[0].cost | currency:model.common.purchases[0].currency_id" }}
+              {{ model.common.purchases[0].cost | currency:model.common.purchases[0].currency_id }}
             </td>
           </tr>
         </tbody>


### PR DESCRIPTION
Purchase invoices were entirely broken due to an errant string.  This
string has been removed, as well as hard coded values in the purchase
template.  The following other changes have taken place:
 1. Controller abides by Angular Style Guide Syntax.
 2. Enterprise address uses <address> to be more semantic
 3. Added <abbr> for abbreviations and associated translations