### PR TITLE
Required label for address area in supplier management

### DIFF
--- a/client/src/partials/creditor/creditor.html
+++ b/client/src/partials/creditor/creditor.html
@@ -62,7 +62,7 @@
               </div>
 
               <div class="form-group">
-                <label for="ad1" class="control-label required">{{ "SUPPLIER.ADDR_1" | translate }}</label>
+                <label for="ad1" class="required">{{ "SUPPLIER.ADDR_1" | translate }}</label>
                 <input required type="text" class="form-bhima" id="ad1ID" ng-model="session.supplier.address_1">
               </div>
                                       

--- a/client/src/partials/creditor/creditor.html
+++ b/client/src/partials/creditor/creditor.html
@@ -62,7 +62,7 @@
               </div>
 
               <div class="form-group">
-                <label for="ad1">{{ "SUPPLIER.ADDR_1" | translate }}</label>
+                <label for="ad1" class="control-label required">{{ "SUPPLIER.ADDR_1" | translate }}</label>
                 <input required type="text" class="form-bhima" id="ad1ID" ng-model="session.supplier.address_1">
               </div>
                                       


### PR DESCRIPTION
In this PR we have fixed label for an adress area in supplier management because when we try to edit a supplier we can't see that the address is required, and we cannot edit anything (the button is disabled).