### PR TITLE
FIX(find-patient): remove SOUNDEX algorithm

### DIFF
--- a/server/controllers/patient.js
+++ b/server/controllers/patient.js
@@ -85,25 +85,24 @@ exports.searchFuzzy = function (req, res, next) {
 
   if (!match) { next(new Error('No parameter provided!')); }
 
-  // Do fuzzy searching on the match parameter
+  // search on the match parameter
   sql =
     'SELECT p.uuid, p.project_id, p.debitor_uuid, p.first_name, p.last_name,  p.middle_name, ' +
       'p.sex, p.dob, p.origin_location_id, p.reference, proj.abbr, d.text, ' +
       'dg.account_id, dg.price_list_uuid, dg.is_convention, dg.locked ' +
     'FROM patient AS p JOIN project AS proj JOIN debitor AS d JOIN debitor_group AS dg ' +
     'ON p.debitor_uuid = d.uuid AND d.group_uuid = dg.uuid AND p.project_id = proj.id ' +
-    'WHERE LEFT(LOWER(CONCAT(p.last_name, \' \', p.first_name )), CHAR_LENGTH(?)) = ? OR ' +
-      'SOUNDEX(p.first_name) = SOUNDEX(?) OR ' +
-      'SOUNDEX(p.last_name) = SOUNDEX(?) OR ' +
-      'SOUNDEX(p.middle_name) = SOUNDEX(?) OR ' +
-      'SOUNDEX(CONCAT(p.last_name, \' \', p.first_name)) = SOUNDEX(?) OR ' +
-      'SOUNDEX(CONCAT(p.first_name, \' \', p.last_name)) = SOUNDEX(?) OR ' +
-      'SOUNDEX(CONCAT(p.first_name, \' \', p.last_name, \' \', p.middle_name)) = SOUNDEX(?) OR ' +
-      'SOUNDEX(CONCAT(p.last_name, \' \', p.middle_name, \' \', p.first_name)) = SOUNDEX(?) OR ' +
-      'SOUNDEX(CONCAT(p.last_name, \' \', p.middle_name)) = SOUNDEX(?) ' +
+    'WHERE ' +
+      'LEFT(LOWER(CONCAT(p.last_name, \' \', p.middle_name, \' \', p.first_name )), CHAR_LENGTH(?)) = ? OR ' +
+      'LEFT(LOWER(CONCAT(p.last_name, \' \', p.first_name, \' \', p.middle_name)), CHAR_LENGTH(?)) = ? OR ' +
+      'LEFT(LOWER(CONCAT(p.first_name, \' \', p.middle_name, \' \', p.last_name)), CHAR_LENGTH(?)) = ? OR ' +
+      'LEFT(LOWER(CONCAT(p.first_name, \' \', p.last_name, \' \', p.middle_name)), CHAR_LENGTH(?)) = ? OR ' +
+      'LEFT(LOWER(CONCAT(p.middle_name, \' \', p.last_name, \' \', p.first_name)), CHAR_LENGTH(?)) = ? OR ' +
+      'LEFT(LOWER(CONCAT(p.middle_name, \' \', p.first_name, \' \', p.last_name)), CHAR_LENGTH(?)) = ? ' +
     'LIMIT 10;';
 
-  db.exec(sql, [match, match, match, match, match, match, match, match, match, match])
+  // man. That's a lot of matches
+  db.exec(sql, [match, match, match, match, match, match, match, match, match, match, match, match])
   .then(function (rows) {
     res.status(200).json(rows);
   })


### PR DESCRIPTION
I've updated the patient find directive to use strict matching on
first_name, last_name, middle_name.  We do all possible combinations of
matches (9 total) to ensure that we do not miss an data inserted in
incorrect order.

This commit also updates the find-patient directive to meet the styleguide
standards.

Fixes #708.