### PR TITLE
FIX(travis): Make travis successfully build project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,32 @@
 sudo: false
 language: node_js
 node_js:
-  - "stable"
+  - "node"
+  - "iojs"
+  - "4.1"
+  - "4.0"
   - "0.12"
   - "0.11"
   - "0.10"
 
-env:
-  global:
-    - secure: VgYj3w6ztd5rU+XLGLUNYkqjv/GXxyYAuAzNbFhMzYARMF/Kxc6Znwh9RkmNuQjVhRE5ViWEX8Gb0GqFqcHf5jpOjC7DkrkZ0pppWkUqaMhh+IQiU9mqWRxSVLRme1NMSlnRTv6NKX8ezHHmXy/OpuMHyfUoWbVJErXjtkwZw/M=
-    - secure: SJrx53jlcIJpvWQFrxFHwNkVhanXNZo9LRZe39NCuRPjuhojkfpizRmD+ar/Ok1E6fA+FynSZEDOhahLLNgwFlUTOxtZ0RcRjAzaCQqaQN2u5keWe4DEh/7r6Db2rriuqRNcYpvKgZpAaGYLVunsMT8I21uClTXFxvABJ6GRFls=
-addons:
-  sauce_connect: true
+#addons:
+#  sauce_connect:
+#    username:
+#      secure: VgYj3w6ztd5rU+XLGLUNYkqjv/GXxyYAuAzNbFhMzYARMF/Kxc6Znwh9RkmNuQjVhRE5ViWEX8Gb0GqFqcHf5jpOjC7DkrkZ0pppWkUqaMhh+IQiU9mqWRxSVLRme1NMSlnRTv6NKX8ezHHmXy/OpuMHyfUoWbVJErXjtkwZw/M=
+#    access_key:
+#      secure: SJrx53jlcIJpvWQFrxFHwNkVhanXNZo9LRZe39NCuRPjuhojkfpizRmD+ar/Ok1E6fA+FynSZEDOhahLLNgwFlUTOxtZ0RcRjAzaCQqaQN2u5keWe4DEh/7r6Db2rriuqRNcYpvKgZpAaGYLVunsMT8I21uClTXFxvABJ6GRFls=
 
+# TODO -- find a better way to build the database
+# This hard-codes the bhima username and password.  How should we get around this?
+# Some thoughts:
+#   - have a temporary "installer" user that deletes itself after successful install
+#   - have the mysql -u root command read in a separate install mysql file with username from there
+#   - user a build script (.sh) to execute a build, which reads the config.js file to ascertain the username + password
 before_script:
-  - ./server/app.js &
-  - sleep 2
+  - npm install -g gulp bower
+  - bower install
+  - mysql -u root -e "CREATE DATABASE bhima;"
+  - mysql -u root -e "CREATE USER 'bhima'@'localhost' IDENTIFIED BY 'HISCongo2013';"
+  - mysql -u root -e "GRANT ALL PRIVILEGES ON *.* TO 'bhima'@'localhost' WITH GRANT OPTION;"
+  - mysql -u root < server/models/development/bhima_structure.sql
+

--- a/package.json
+++ b/package.json
@@ -15,10 +15,11 @@
     "bhima",
     "health",
     "HIS",
-    "hospital"
+    "hospital information system",
+    "rural accounting"
   ],
   "author": "IMA World Health Web Development Team",
-  "license": "Beerware",
+  "license": "GPLv2",
   "bugs": {
     "url": "https://github.com/IMA-WorldHealth/bhima/issues"
   },


### PR DESCRIPTION
We now build the database within the .travis.yml file using travis's
root user on MySQL.  Unfortunately, since our build process is not well
established, we have to hard-code the user and password into the
.travis.yml.  See this file for suggestions on how to improve our build
process.

Also included: before running, we install gulp & bower globally and run bower
install.