### PR TITLE
Perf(general ledger report): Faster PDF rendering

### DIFF
--- a/server/controllers/reports_proposed/data/grand_livre.js
+++ b/server/controllers/reports_proposed/data/grand_livre.js
@@ -1,80 +1,61 @@
-// reports_proposed/data/balance_sheet.js
-// Collects and aggregates data for the enterprise balance sheet
-var q       = require('q');
-var db      = require('../../../lib/db');
-var numeral = require('numeral');
+/**
+* General Ledger Report
+*
+* Format the General Ledger PDF report.  Special care is taken to make sure the
+* trans_id is properly ordered.
+*/
 
+var db = require('../../../lib/db'),
+    numeral = require('numeral');
+
+// dollar formatting
 var formatDollar = '$0,0.00';
-var grandLivreDate = new Date();
-
-function splitByTransaction (gls) {
-  var tapon_gls = gls;
-  var formated_gls = [];
-  gls.forEach(function (gl){
-    var grouped_gls = getGroup(tapon_gls, gl.trans_id);
-    tapon_gls = refresh(tapon_gls, grouped_gls[0].trans_id); //removing selected elements
-    formated_gls.push(grouped_gls);
-  });
-  return formated_gls;
-}
-
-function refresh (tapon_gls, motif){
-  var arr = tapon_gls;
-  for(var i = 0; i<arr.length; i++){
-    arr[i].trans_date = new Date(arr[i].trans_date).toDateString();
-    if(arr[i].trans_id == motif) {arr.splice(i, 1); refresh(arr, motif);};
-  }
-  return arr;
-}
-
-function getGroup (tapon_gls, motif) {
-  var arr = [];
-  arr = tapon_gls.filter(function (item){
-    return item.trans_id == motif;
-  });
-  return arr;
-}
 
 // expose the http route
 exports.compile = function (options) {
   'use strict';
+  var sql,
+      context = {},
+      fiscalYearId = options.fy;
 
-  var deferred = q.defer();
-  var context = {};
-  var fiscalYearId = options.fy;
+  context.reportDate = new Date().toDateString();
 
-  context.reportDate = grandLivreDate.toDateString();
+  // This orders first by the numeric portion of the ID, then the text  portion.
+  // NOTE -- we expect all abbreviations to be 3 characters long.  Anything else
+  // will break this query.
+  sql =
+    'SELECT gl.trans_id, gl.trans_date, gl.description, ' +
+      'gl.debit_equiv, gl.credit_equiv, account.account_number, ' +
+      'fiscal_year.fiscal_year_txt, cost_center.text AS cc, profit_center.text AS pc ' +
+    'FROM general_ledger AS gl JOIN account ON account.id = gl.account_id ' +
+    'JOIN fiscal_year ON fiscal_year.id = gl.fiscal_year_id ' +
+    'LEFT JOIN cost_center ON cost_center.id = gl.cc_id ' +
+    'LEFT JOIN profit_center ON profit_center.id = gl.pc_id ' +
+    'WHERE gl.fiscal_year_id = ? ' +
+    'ORDER BY CAST(SUBSTRING(gl.trans_id FROM 4) AS unsigned), LEFT(gl.trans_id, 3);';
 
-  var sql =
-    'SELECT `general_ledger`.`trans_id`, `general_ledger`.`trans_date`, `general_ledger`.`description`, ' +
-    '`general_ledger`.`debit_equiv`, `general_ledger`.`credit_equiv`, `account`.`account_number`, ' +
-    '`fiscal_year`.`fiscal_year_txt`, `cost_center`.`text` AS `cc`, `profit_center`.`text` AS `pc` ' +
-    'FROM `general_ledger` JOIN `account` ON `account`.`id` = `general_ledger`.`account_id` JOIN ' +
-    '`fiscal_year` ON `fiscal_year`.`id` = `general_ledger`.`fiscal_year_id` LEFT JOIN `cost_center` ' +
-    ' ON `cost_center`.`id` = `general_ledger`.`cc_id` LEFT JOIN `profit_center` ON ' +
-    '`profit_center`.`id` = `general_ledger`.`pc_id` WHERE `general_ledger`.`fiscal_year_id` =?';
+  return db.exec(sql, [fiscalYearId])
+  .then(function (data) {
 
-  db.exec(sql, [fiscalYearId])
-  .then(function (gls) {
-    gls.sort(function (a, b) {
-      var x = parseInt(a.trans_id.substring(3, a.trans_id.length));
-      var xx = a.trans_id.substring(0, 3);
-      var y = parseInt(b.trans_id.substring(3, b.trans_id.length));
-      var yy = b.trans_id.substring(0, 3);
+    // group data by transaction using an object
+    // TODO -- is this the best idea?  It seems like this will block the server
+    context.data = data.reduce(function (transactions, row) {
+      var id = row.trans_id;
 
-      var d = x - y;
+      // format date string
+      row.trans_date = row.trans_date.toDateString();
+      row.debit_equiv = numeral(row.debit_equiv).format(formatDollar);
+      row.credit_equiv = numeral(row.credit_equiv).format(formatDollar);
 
-      if(d == 0){
-        (xx <= yy) ? d = -1 : 0;
-      }
-      return d;
-    });
-    var splited_gls = splitByTransaction(gls);
-    context.data = splited_gls;
-    deferred.resolve(context);
-  })
-  .catch(deferred.reject)
-  .done();
+      // create an array for transaction rows
+      if (!transactions[id]) { transactions[id] = []; }
 
-  return deferred.promise;
+      // push a new row onto the transaction
+      transactions[id].push(row);
+
+      return transactions;
+    }, {});
+
+    return context;
+  });
 };

--- a/server/controllers/reports_proposed/reports.js
+++ b/server/controllers/reports_proposed/reports.js
@@ -124,7 +124,7 @@ exports.build = function (req, res, next) {
 // Return configuration object for wkhtmltopdf process
 function buildConfiguration(hash, size) {
   var context = config[size] || config.standard;
-  var hash = hash || uuid();
+  hash = hash || uuid();
 
   context.output = writePath.concat(hash, '.pdf');
   return context;

--- a/server/controllers/reports_proposed/templates/grand_livre.dot
+++ b/server/controllers/reports_proposed/templates/grand_livre.dot
@@ -2,38 +2,39 @@
   <link rel="stylesheet" href="{{=it.path}}/templates/style/normalize.css">
   <link rel="stylesheet" href="{{=it.path}}/templates/style/skeleton.css">
   <link rel="stylesheet" href="{{=it.path}}/templates/style/reports.css">
+  <meta charset="utf-8" /> 
 </head>
 
 <body>
 
   <section id="title" class="center">
-      <h5>IMCK Hopital Bon Berger</h5>
-      <h5>Grand Livre</h5>
-      <h5>As of {{=it.reportDate}}</h5>
+      <h5 style="margin-bottom:0;">IMCK Hopital Bon Berger</h5>
+      <h5 style="margin-bottom:0;">Grand Livre</h5>
+      <h5 style="margin-bottom:0;">As of {{=it.reportDate}}</h5>
   </section>
 
   <section>
     <table class="balance" border="1">
       <thead>
-        <tr>
+        <tr style="font-size:0.85em;">
           <th>Date</th>
           <th>Description</th>
           <th>Compte</th>
           <th>Debit</th>
-          <th>credit</th>
+          <th>Credit</th>
           <th>Centre de cout</th>
           <th>Centre de profit</th>
         </tr>
       </thead>
-      <tbody>
-        {{~it.data : value : index}}
+      <tbody style="font-size:0.65em;">
+        {{ for (transaction in it.data) { }}
           <tr>
-            <td colspan="7"><b>Transaction : {{=value[0].trans_id}}</b></td>
+            <th colspan="7">Transaction: {{=transaction }}</th>
           </tr>
-          {{~value : v : i}}
+          {{~it.data[transaction] :v }}
             <tr class="contenu">
               <td>{{=v.trans_date}}</td>
-              <td>{{=v.description}}</td>
+              <td style="text-align:left; padding-left:2px;">{{=v.description}}</td>
               <td>{{=v.account_number}}</td>
               <td>{{=v.debit_equiv}}</td>
               <td>{{=v.credit_equiv}}</td>
@@ -41,7 +42,7 @@
               <td>{{?v.pc}}{{=v.pc}}{{?}}</td>
             </tr>
           {{~}}
-        {{~}}
+        {{ } }}
       </tbody>
     </table>
   </section>


### PR DESCRIPTION
I've increased the rendering speed of the PDF report by migrating all
the sorting and grouping logic from JS to SQL.  This results in much
cleaner code (if you read SQL).

Additional fixes include:
 - number formatting for debit/credit fields
 - date now established at request time, rather than at first run time

NOTE
Trying to print the entire general ledger still results in a broken
(timed out) HTTP request.  We need to disallow printing a max number of
transactions/rows/dates to avoid needlessly hanging the server.