### PR TITLE
Fix: Add connect-multiparty to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,18 +26,19 @@
   "dependencies": {
     "body-parser": "^1.2.2",
     "compression": "~1.5.1",
+    "connect-multiparty": "^2.0.0",
     "csv": "^0.4.1",
     "dot": "^1.0.3",
     "express": "4.x.x",
     "express-session": "^1.2.1",
-    "morgan": "^1.5.2",
+    "fast-csv": "^0.6.0",
     "later": "^1.1.6",
+    "morgan": "^1.5.2",
     "mysql": "2.x.x",
+    "numeral": "^1.5.3",
     "q": "~1.4.1",
     "session-file-store": "0.0.14",
-    "wkhtmltopdf": "^0.1.5",
-    "numeral": "^1.5.3",
-    "fast-csv": "^0.6.0"
+    "wkhtmltopdf": "^0.1.5"
   },
   "devDependencies": {
     "chai": "^3.2.0",


### PR DESCRIPTION
This PR fixes a bug where `npm install` does not install all dependencies.  It now installs connect-multiparty at the latest version.


**Edit** Apparently `npm install` reorders items in the package.json.  The changes haven't changed the package versions though.  The only change in here is the addition of connect-multiparty.  All other packages retain their original versions.