### PR TITLE
Rewrite Group Invoice

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -367,11 +367,11 @@
     "DAY"    : "Day",
     "MONTH"  : "Month",
     "PERIOD" : "Period",
-    "TITLE"  : "Grouping",    
-    "WEEK"   : "Week",    
-    "YEAR"   : "Year"    
+    "TITLE"  : "Grouping",
+    "WEEK"   : "Week",
+    "YEAR"   : "Year"
   }
-},   
+},
 "COLUMNS": {
    "ABBR"                  : "Abbr",
    "ABBREVIATION"          : "Abreviation",
@@ -633,7 +633,7 @@
    "WORDING"               : "Wording",
    "WORKING_DAY"           : "Working day",
    "ZS"                    : "Health Zone"
-   
+
    },
 
 "CONFIG_ACCOUNTING": {
@@ -2388,7 +2388,7 @@
    "BALANCE_SECTION"       : "Select Balance Sheet Section",
    "CASH"                  : "Select a Cash",
    "COST_CENTER"           : "Select the cost center",
-   "COTISATION"            : "Select a Cotisation",   
+   "COTISATION"            : "Select a Cotisation",
    "COUNTRY"               : "Select a Country",
    "CREDITOR"              : "Select a creditor",
    "CREDITOR_GROUP"        : "Select a Creditor Group",
@@ -2883,7 +2883,7 @@
    "DASHBOARD" : {
       "FINANCE" : "Finance Dashboard",
       "TITLE"   : "Dashboards"
-   },   
+   },
    "DEBTOR_AGING"              : "Debtor Aging",
    "DEBTOR_GRP"                : "Debtor Group",
    "DEBITOR_GROUP_REPORT"      : "Debtor Group State",
@@ -3069,6 +3069,7 @@
    "MONTHS"            : "Months",
    "NAVIGATION"        : "Navigation",
    "NEW_SUCCESS"       : "Successfully added",
+   "NO_DATA"           : "The query did not return any data.",
    "OFF"               : "Off",
    "ON"                : "On",
    "PATIENT_EXIST_A"   : "Patient with file number [",

--- a/client/src/i18n/fr.json
+++ b/client/src/i18n/fr.json
@@ -3071,6 +3071,7 @@
    "MONTHS"            : "Mois",
    "NAVIGATION"        : "Navigation",
    "NEW_SUCCESS"       : "Ajout avec succès",
+   "NO_DATA"           : "La requette n'a pas des données",
    "OFF"               : "Off",
    "ON"                : "On",
    "PATIENT_EXIST_A"   : "Le patient ayant la fiche [",

--- a/client/src/js/app.js
+++ b/client/src/js/app.js
@@ -318,8 +318,8 @@ function bhimaconfig($routeProvider) {
     controller: 'patientGroup',
     templateUrl: 'partials/patient/group/groups.html'
   })
-  .when('/group_invoice/:id?', {
-    controller : 'groupInvoice',
+  .when('/group_invoice/', {
+    controller : 'GroupInvoiceController as InvoiceCtrl',
     templateUrl : 'partials/group_invoice/group_invoice.html'
   })
   .when('/support/:id?', {

--- a/client/src/partials/group_invoice/group_invoice.html
+++ b/client/src/partials/group_invoice/group_invoice.html
@@ -9,14 +9,14 @@
       <li class="active">{{ "GROUP_INVOICE.TITLE" | translate }}</li>
     </ol>
   </div>
-  <div class="pull-right" ng-if="selected.convention">
-    <button class="btn btn-default active" disabled>{{ selected.convention.name }}</button>
+  <div class="pull-right" ng-if="InvoiceCtrl.convention">
+    <button class="btn btn-default active" disabled>{{ InvoiceCtrl.convention.name }}</button>
   </div>
 </nav>
 
 <main>
   <div class="row margin-top-10">
-    <div class="col-xs-6" ng-switch="hasDebitor">
+    <div class="col-xs-6" ng-switch="InvoiceCtrl.showInvoices">
 
       <div ng-switch-default>
         <div class="panel panel-primary">
@@ -33,8 +33,8 @@
                     class="form-bhima"
                     type="text"
                     typeahead-template-url="ConventionList.html"
-                    ng-model="selected.convention"
-                    typeahead="group as group.name for group in conventions.data | filter:$viewValue | limitTo:8"
+                    ng-model="InvoiceCtrl.convention"
+                    typeahead="group as group.name for group in InvoiceCtrl.conventions.data | filter:$viewValue | limitTo:8"
                     placeholder="{{ 'SELECT.DEBITOR_GROUP' | translate }}"
                   >
                 </div>
@@ -43,22 +43,20 @@
               <div class="form-group">
                 <label class="control-label col-xs-2"> {{ "GROUP_INVOICE.DEBITOR" | translate }}:</label>
                 <div class="col-xs-8">
-
                   <input
                     class="form-bhima"
                     type="text"
                     typeahead-template-url="DebtorList.html"
-                    ng-model="selected.debitor"
-                    typeahead="debitor as debitor.text for debitor in debtors.data | filter:$viewValue | limitTo:8"
+                    ng-model="InvoiceCtrl.debtor"
+                    typeahead="debtor as debtor.text for debtor in InvoiceCtrl.debtors.data | filter:$viewValue | limitTo:8 "
                     placeholder="{{ 'SELECT.DEBITOR' | translate }}"
                   >
-
                 </div>
               </div>
             </div>
           </div>
           <div class="panel-footer">
-            <input class="btn btn-sm btn-success" type="submit" ng-click="setDebitor()" value="{{ 'FORM.CONTINUE' | translate }}" ng-disabled="!selected.debitor || !selected.convention">
+            <input class="btn btn-sm btn-success" type="submit" ng-click="InvoiceCtrl.setDebtor()" value="{{ 'FORM.CONTINUE' | translate }}" ng-disabled="!InvoiceCtrl.debtor || !InvoiceCtrl.convention">
           </div>
         </div>
       </div>
@@ -67,7 +65,7 @@
         <div class="panel-heading">
           <i class="glyphicon glyphicon-list"></i>
           <span>
-            {{ selected.debitor.text }}
+            {{ InvoiceCtrl.debtor.text }}
           </span>
         </div>
         <table class="table table-condensed">
@@ -80,17 +78,17 @@
             </tr>
           </thead>
           <tbody>
-            <tr ng-if="loading">
+            <tr ng-if="InvoiceCtrl.loading">
               <th colspan="6" class="text-center">
                 <loading-indicator></loading-indicator>
               </th>
             </tr>
-            <tr ng-if="!loading && invoices.data.length === 0">
-              <th colspan="6" class="text-center text-danger">
+            <tr ng-if="!InvoiceCtrl.loading && InvoiceCtrl.invoices.data.length === 0 && InvoiceCtrl.queue.length === 0">
+              <th colspan="6" class="text-center">
                 <i class="glyphicon glyphicon-exclamation-sign"></i> {{ "UTIL.NO_DATA" | translate }}
               </th>
             </tr>
-            <tr ng-repeat="invoice in invoices.data | filter:filter">
+            <tr ng-repeat="invoice in InvoiceCtrl.invoices.data | filter:InvoiceCtrl.positive">
               <th>
                 <a ng-href="#/invoice/sale/{{ invoice.inv_po_id }}">
                   <i class="glyphicon glyphicon-link"></i> {{ invoice.invoiceRef }}
@@ -98,15 +96,15 @@
               </th>
               <td>{{ invoice.trans_date | date }}</td>
               <td>{{ invoice.balance | currency:invoice.currency_id }}</td>
-              <td><button class="btn btn-xs btn-default" ng-click="examineInvoice(invoice, $index)"><i class="glyphicon glyphicon-search"></i></button></td>
-              <td><button class="btn btn-xs btn-default" ng-click="enqueue($index)"><i class="glyphicon glyphicon-plus"></i></button></td>
+              <td><button class="btn btn-xs btn-default" ng-click="InvoiceCtrl.examineInvoice(invoice, $index)"><i class="glyphicon glyphicon-search"></i></button></td>
+              <td><button class="btn btn-xs btn-default" ng-click="InvoiceCtrl.enqueue($index)"><i class="glyphicon glyphicon-plus"></i></button></td>
             </tr>
           </tbody>
         </table>
       </div>
     </div>
 
-    <div class="col-xs-6" ng-switch="action">
+    <div class="col-xs-6" ng-switch="InvoiceCtrl.action">
 
       <div ng-switch-default class="alert alert-info">
         <h4>{{ "GROUP_INVOICE.TITLE" | translate }}</h4>
@@ -126,9 +124,9 @@
             <span>{{ "GROUP_INVOICE.CONVENTION_INVOICE" | translate }}</span>
           </div>
           <div class="panel-body">
-            <form name="payment" class="form-horizontal">
+            <form name="PaymentForm" class="form-horizontal">
               <fieldset>
-                <legend>{{ "GROUP_INVOICE.INVOICE_TITLE" | translate }} {{ selected.debitor.text }}</legend>
+                <legend>{{ "GROUP_INVOICE.INVOICE_TITLE" | translate }} {{ InvoiceCtrl.debtor.text }}</legend>
 
                 <div class="form-group" >
                   <label class="col-xs-3">{{ "GROUP_INVOICE.INVOICE_ID" | translate }}</label>
@@ -136,27 +134,26 @@
                   <label>{{ "GROUP_INVOICE.AGREED" | translate }}</label>
                 </div>
 
-                <div class="form-group" ng-repeat="invoice in paying">
+                <div class="form-group" ng-repeat="invoice in InvoiceCtrl.queue">
                   <p class="form-control-static col-xs-3">{{ invoice.invoiceRef }}</p>
-                  <p class="form-control-static col-xs-3">{{ invoice.balance | currency}}</p>
+                  <p class="form-control-static col-xs-3">{{ invoice.balance | currency:invoice.currency_id }}</p>
                   <div class="col-xs-6 input-group">
-                    <span class="input-group-addon">{{ currency.symbol }}</span>
-                    <input type="number" class="form-bhima" ng-model="invoice.payment" min="0" max="{{invoice.balance}}">
+                    <span class="input-group-addon">{{ InvoiceCtrl.currency.symbol }}</span>
+                    <input type="number" class="form-bhima" ng-model="invoice.payment" ng-change="InvoiceCtrl.retotal()" min="0" max="{{ invoice.balance }}">
                   </div>
                 </div>
-
               </fieldset>
 
               <div class="form-group" style="border-top: 1px solid #ddd;">
-                <label class="control-label col-xs-2">{{ "GROUP_INVOICE.BALANCE" | translate }}: </label>
-                <p class="col-xs-4 form-control-static">{{ ( balance | currency) || ("GROUP_INVOICE.ERROR_TXT_1" | translate) }}</p>
+                <label class="control-label col-xs-2">{{ "COLUMNS.BALANCE" | translate }} </label>
+                <p class="col-xs-4 form-control-static">{{ ( InvoiceCtrl.balance | currency:InvoiceCtrl.currency.id ) || ("GROUP_INVOICE.ERROR_TXT_1" | translate) }}</p>
               </div>
             </form>
           </div>
         </div>
 
-        <button class="btn btn-sm btn-success" ng-click="pay()">{{ "GROUP_INVOICE.PAY" | translate }}</button>
-        <button class="btn btn-sm btn-danger" ng-click="dequeue()">{{ "GROUP_INVOICE.CANCEL" | translate }}</button>
+        <button class="btn btn-sm btn-success" ng-click="InvoiceCtrl.pay()">{{ "GROUP_INVOICE.PAY" | translate }}</button>
+        <button class="btn btn-sm btn-danger" ng-click="InvoiceCtrl.dequeue()">{{ "GROUP_INVOICE.CANCEL" | translate }}</button>
       </div>
 
       <div ng-switch-when="confirm">
@@ -166,9 +163,9 @@
           </div>
           <div class="panel-body">
 
-            <form name="authorization" class="form-horizontal">
+            <form name="AuthorizationForm" class="form-horizontal">
               <fieldset>
-                <legend>{{ "GROUP_INVOICE.INVOICE_TITLE" | translate }} {{ selected.debitor.text }}</legend>
+                <legend>{{ "GROUP_INVOICE.INVOICE_TITLE" | translate }} {{ InvoiceCtrl.debtor.text }}</legend>
 
                 <div class="form-group" >
                   <label class="col-xs-3">{{ "GROUP_INVOICE.INVOICE_ID" | translate }}</label>
@@ -176,20 +173,19 @@
                   <label>{{ "GROUP_INVOICE.AGREED" | translate }}</label>
                 </div>
 
-                <div class="form-group" ng-repeat="invoice in paying">
+                <div class="form-group" ng-repeat="invoice in InvoiceCtrl.queue">
                   <p class="form-control-static col-xs-3">{{ invoice.invoiceRef }}</p>
-                  <p class="form-control-static col-xs-3">{{ invoice.balance | currency}}</p>
-                  <p class="form-control-static">{{ invoice.payment | currency }}</p>
+                  <p class="form-control-static col-xs-3">{{ invoice.balance | currency:invoice.currency_id  }}</p>
+                  <p class="form-control-static">{{ invoice.payment | currency:invoice.currency_id }}</p>
                 </div>
-
               </fieldset>
 
               <div class="form-group">
-                <label class="control-label col-xs-2">{{ "GROUP_INVOICE.BALANCE" | translate }}: </label>
-                <p class="col-xs-2 form-control-static">{{ ( balance | currency) || ("GROUP_INVOICE.ERROR_TXT_1" | translate) }}</p>
+                <label class="control-label col-xs-2">{{ "COLUMNS.BALANCE" | translate }}: </label>
+                <p class="col-xs-2 form-control-static">{{ ( InvoiceCtrl.balance | currency:InvoiceCtrl.currency.id) || ("GROUP_INVOICE.ERROR_TXT_1" | translate) }}</p>
                 <label class="control-label col-xs-2">{{ "GROUP_INVOICE.AUTHORIZED_BY" | translate }}:</label>
                 <div class="col-xs-6">
-                  <input class="form-bhima" ng-model="payment.authorized_by" >
+                  <input class="form-bhima" ng-model="InvoiceCtrl.payment.authorized_by" >
                 </div>
               </div>
 
@@ -197,8 +193,7 @@
           </div>
         </div>
 
-        <button ng-click="authorize()" class="btn btn-sm btn-success">{{ "GROUP_INVOICE.AUTHORIZE" | translate }}</button>
-        <button ng-click="cancel()" class="btn btn-sm btn-danger">{{ "GROUP_INVOICE.CANCEL" | translate }}</button>
+        <button ng-click="InvoiceCtrl.authorize()" class="btn btn-sm btn-success">{{ "GROUP_INVOICE.AUTHORIZE" | translate }}</button>
       </div>
 
       <div ng-switch-when="examine">
@@ -214,42 +209,42 @@
                 <div class="form-group">
                   <label class="control-label col-xs-3">{{ "COLUMNS.INVOICE_ID" | translate }}</label>
                   <div class="col-xs-9">
-                    <p class="form-control-static">{{examine.invoiceRef }}</p>
+                    <p class="form-control-static">{{ InvoiceCtrl.examine.invoiceRef }}</p>
                   </div>
                 </div>
 
                 <div class="form-group">
                   <label class="control-label col-xs-3">{{ "COLUMNS.DESCRIPTION" | translate }}</label>
                   <div class="col-xs-9">
-                    <p class="form-control-static">{{ examine.description }}</p>
+                    <p class="form-control-static">{{ InvoiceCtrl.examine.description }}</p>
                   </div>
                 </div>
 
                 <div class="form-group">
                   <label class="control-label col-xs-3">{{ "COLUMNS.INVOICE_DATE" | translate }}</label>
                   <div class="col-xs-9">
-                    <p class="form-control-static">{{examine.trans_date | date}}</p>
+                    <p class="form-control-static">{{ InvoiceCtrl.examine.trans_date | date }}</p>
                   </div>
                 </div>
 
                 <div class="form-group">
                   <label class="control-label col-xs-3">{{ "COLUMNS.ACCOUNT_ID" | translate }}</label>
                   <div class="col-xs-9">
-                    <p class="form-control-static">{{examine.account_id }}</p>
+                    <p class="form-control-static">{{ InvoiceCtrl.examine.account_id }}</p>
                   </div>
                 </div>
 
                 <div class="form-group">
                   <label class="control-label col-xs-3">{{ "COLUMNS.BALANCE" | translate }}</label>
                   <div class="col-xs-9">
-                    <p class="form-control-static">{{examine.balance | currency}}</p>
+                    <p class="form-control-static">{{ InvoiceCtrl.examine.balance | currency:InvoiceCtrl.examine.currency_id }}</p>
                   </div>
                 </div>
 
                 <div class="form-group">
                   <label class="control-label col-xs-3">{{ "COLUMNS.COMMENT" | translate }}</label>
                   <div class="col-xs-9">
-                    <p class="form-control-static">{{ examine.comment }}</p>
+                    <p class="form-control-static">{{ InvoiceCtrl.examine.comment }}</p>
                   </div>
                 </div>
 
@@ -265,7 +260,7 @@
 <script type="text/ng-template" id="ConventionList.html">
   <a>
     <span bind-html-unsafe="match.label | typeaheadHighlight:query"></span>
-    <span><i>{{match.model.name}}</i></span>
+    <span><i>{{ match.model.name }}</i></span>
   </a>
 </script>
 
@@ -273,6 +268,6 @@
 <script type="text/ng-template" id="DebtorList.html">
   <a>
     <span bind-html-unsafe="match.label | typeaheadHighlight:query"></span>
-    <span><i>{{match.model.text}}</i></span>
+    <span><i>{{ match.model.text}}</i></span>
   </a>
 </script>

--- a/client/src/partials/group_invoice/group_invoice.html
+++ b/client/src/partials/group_invoice/group_invoice.html
@@ -65,16 +65,17 @@
 
       <div class="panel panel-default" ng-switch-when="true">
         <div class="panel-heading">
-          <span class="glyphicon glyphicon-list"></span>
-          <span> {{ "GROUP_INVOICE.SELECT_INVOICES" | translate }}</span>
+          <i class="glyphicon glyphicon-list"></i>
+          <span>
+            {{ selected.debitor.text }}
+          </span>
         </div>
         <table class="table table-condensed">
           <thead>
             <tr>
               <th>{{ "COLUMNS.INVOICE_ID" | translate }}</th>
-              <th>{{ "COLUMNS.DEBITOR_ID" | translate }}</th>
               <th>{{ "COLUMNS.DATE" | translate }}</th>
-              <th>{{ "COLUMNS.TOTAL" | translate }}</th>
+              <th>{{ "COLUMNS.BALANCE" | translate }}</th>
               <th colspan="2" style="width:10%;">{{ "COLUMNS.ACTIONS" | translate }}</th>
             </tr>
           </thead>
@@ -90,10 +91,13 @@
               </th>
             </tr>
             <tr ng-repeat="invoice in invoices.data | filter:filter">
-              <td>{{invoice.inv_po_id}}</td>
-              <td>{{invoice.deb_cred_uuid}}</td>
-              <td>{{invoice.trans_date | date}}</td>
-              <td>{{invoice.balance | currency:invoice.currency_id }}</td>
+              <th>
+                <a ng-href="#/invoice/sale/{{ invoice.inv_po_id }}">
+                  <i class="glyphicon glyphicon-link"></i> {{ invoice.invoiceRef }}
+                </a>
+              </th>
+              <td>{{ invoice.trans_date | date }}</td>
+              <td>{{ invoice.balance | currency:invoice.currency_id }}</td>
               <td><button class="btn btn-xs btn-default" ng-click="examineInvoice(invoice, $index)"><i class="glyphicon glyphicon-search"></i></button></td>
               <td><button class="btn btn-xs btn-default" ng-click="enqueue($index)"><i class="glyphicon glyphicon-plus"></i></button></td>
             </tr>
@@ -129,14 +133,14 @@
                 <div class="form-group" >
                   <label class="col-xs-3">{{ "GROUP_INVOICE.INVOICE_ID" | translate }}</label>
                   <label class="col-xs-3">{{ "GROUP_INVOICE.COST" | translate }}</label>
-                  <label class="">{{ "GROUP_INVOICE.AGREED" | translate }}</label>
+                  <label>{{ "GROUP_INVOICE.AGREED" | translate }}</label>
                 </div>
 
                 <div class="form-group" ng-repeat="invoice in paying">
-                  <p class="form-control-static col-xs-3">{{ invoice.inv_po_id }}</p>
+                  <p class="form-control-static col-xs-3">{{ invoice.invoiceRef }}</p>
                   <p class="form-control-static col-xs-3">{{ invoice.balance | currency}}</p>
                   <div class="col-xs-6 input-group">
-                    <span class="input-group-addon">{{currency.data[0].symbol}}</span>
+                    <span class="input-group-addon">{{ currency.symbol }}</span>
                     <input type="number" class="form-bhima" ng-model="invoice.payment" min="0" max="{{invoice.balance}}">
                   </div>
                 </div>
@@ -169,11 +173,11 @@
                 <div class="form-group" >
                   <label class="col-xs-3">{{ "GROUP_INVOICE.INVOICE_ID" | translate }}</label>
                   <label class="col-xs-3">{{ "GROUP_INVOICE.COST" | translate }}</label>
-                  <label class="">{{ "GROUP_INVOICE.AGREED" | translate }}</label>
+                  <label>{{ "GROUP_INVOICE.AGREED" | translate }}</label>
                 </div>
 
                 <div class="form-group" ng-repeat="invoice in paying">
-                  <p class="form-control-static col-xs-3">{{ invoice.inv_po_id }}</p>
+                  <p class="form-control-static col-xs-3">{{ invoice.invoiceRef }}</p>
                   <p class="form-control-static col-xs-3">{{ invoice.balance | currency}}</p>
                   <p class="form-control-static">{{ invoice.payment | currency }}</p>
                 </div>
@@ -210,7 +214,7 @@
                 <div class="form-group">
                   <label class="control-label col-xs-3">{{ "COLUMNS.INVOICE_ID" | translate }}</label>
                   <div class="col-xs-9">
-                    <p class="form-control-static">{{examine.inv_po_id}}</p>
+                    <p class="form-control-static">{{examine.invoiceRef }}</p>
                   </div>
                 </div>
 

--- a/client/src/partials/group_invoice/group_invoice.html
+++ b/client/src/partials/group_invoice/group_invoice.html
@@ -4,13 +4,13 @@
 
 <nav>
   <div class="pull-left">
-      <ol class="breadcrumb">
-        <li><a href="#/"><span class="glyphicon glyphicon-home"></span></a></li>
-        <li class="active">{{ "GROUP_INVOICE.TITLE" | translate }}</li>
-      </ol>
+    <ol class="breadcrumb">
+      <li><a href="#/"><span class="glyphicon glyphicon-home"></span></a></li>
+      <li class="active">{{ "GROUP_INVOICE.TITLE" | translate }}</li>
+    </ol>
   </div>
-  <div class="pull-right">
-    <span class="btn btn-sm btn-default" ng-show="!!selected.convention">{{ selected.convention.name }}</span>
+  <div class="pull-right" ng-if="selected.convention">
+    <button class="btn btn-default active" disabled>{{ selected.convention.name }}</button>
   </div>
 </nav>
 
@@ -37,9 +37,6 @@
                     typeahead="group as group.name for group in conventions.data | filter:$viewValue | limitTo:8"
                     placeholder="{{ 'SELECT.DEBITOR_GROUP' | translate }}"
                   >
-                  <!--select class="form-bhima" ng-model="selected.convention" ng-options="group as group.name for group in conventions.data">
-                    <option value="">-- {{ "SELECT.DEBITOR_GROUP" | translate }} --</option>
-                  </select-->
                 </div>
               </div>
 
@@ -52,14 +49,10 @@
                     type="text"
                     typeahead-template-url="DebtorList.html"
                     ng-model="selected.debitor"
-                    typeahead="debitor as debitor.text for debitor in debitors.data | filter:$viewValue | limitTo:8"
+                    typeahead="debitor as debitor.text for debitor in debtors.data | filter:$viewValue | limitTo:8"
                     placeholder="{{ 'SELECT.DEBITOR' | translate }}"
                   >
 
-
-                  <!--select class="form-bhima" ng-model="selected.debitor" ng-options="debitor as debitor.text for debitor in debitors.data">
-                    <option value="">-- {{ "SELECT.DEBITOR" | translate }}--</option>
-                  </select-->
                 </div>
               </div>
             </div>
@@ -86,13 +79,23 @@
             </tr>
           </thead>
           <tbody>
+            <tr ng-if="loading">
+              <th colspan="6" class="text-center">
+                <loading-indicator></loading-indicator>
+              </th>
+            </tr>
+            <tr ng-if="!loading && invoices.data.length === 0">
+              <th colspan="6" class="text-center text-danger">
+                <i class="glyphicon glyphicon-exclamation-sign"></i> {{ "UTIL.NO_DATA" | translate }}
+              </th>
+            </tr>
             <tr ng-repeat="invoice in invoices.data | filter:filter">
               <td>{{invoice.inv_po_id}}</td>
               <td>{{invoice.deb_cred_uuid}}</td>
               <td>{{invoice.trans_date | date}}</td>
-              <td>{{invoice.balance | currency }}</td>
-              <td><button class="btn btn-sm btn-default" ng-click="examineInvoice(invoice, $index)"><i class="glyphicon glyphicon-search"></i></button></td>
-              <td><button class="btn btn-sm btn-default" ng-click="enqueue($index)"><i class="glyphicon glyphicon-plus"></i></button></td>
+              <td>{{invoice.balance | currency:invoice.currency_id }}</td>
+              <td><button class="btn btn-xs btn-default" ng-click="examineInvoice(invoice, $index)"><i class="glyphicon glyphicon-search"></i></button></td>
+              <td><button class="btn btn-xs btn-default" ng-click="enqueue($index)"><i class="glyphicon glyphicon-plus"></i></button></td>
             </tr>
           </tbody>
         </table>
@@ -231,13 +234,6 @@
                     <p class="form-control-static">{{examine.account_id }}</p>
                   </div>
                 </div>
-
-                <!--div class="form-group">
-                  <label class="control-label col-xs-3">{{ "COLUMNS.DEBITOR" | translate }}</label>
-                  <div class="col-xs-9">
-                    <p class="form-control-static">{{ debitors.get(examine.deb_cred_uuid).text }}</p>
-                  </div>
-                </div-->
 
                 <div class="form-group">
                   <label class="control-label col-xs-3">{{ "COLUMNS.BALANCE" | translate }}</label>

--- a/client/src/partials/group_invoice/group_invoice.js
+++ b/client/src/partials/group_invoice/group_invoice.js
@@ -18,6 +18,7 @@ function GroupInvoiceController($scope, $translate, connect, validate, messenger
 
   // get enterprise
   $scope.project = SessionService.project;
+  $scope.enterprise = SessionService.enterprise;
 
   dependencies.invoices = {
     query : 'ledgers/debitor/'
@@ -64,7 +65,8 @@ function GroupInvoiceController($scope, $translate, connect, validate, messenger
           columns : ['symbol']
         }
       },
-      join : ['enterprise.currency_id=currency.id']
+      join : ['enterprise.currency_id=currency.id'],
+      where : ['enterprise.id=' + $scope.enterprise.id]
     }
   };
 
@@ -96,11 +98,20 @@ function GroupInvoiceController($scope, $translate, connect, validate, messenger
   function setUpModels(models) {
     angular.extend($scope, models);
 
+    $scope.currency = models.currency.data[0];
 
     if ($scope.invoices) {
+
+      console.log('$scope.invoices', $scope.invoices, $scope.selected.debitor);
+
       // FIXME: this is hack
       $scope.invoices.data = $scope.invoices.data.filter(function (d) {
         return d.balance !== 0;
+      });
+
+      // proper formatting
+      $scope.invoices.data.forEach(function (i) {
+        i.invoiceRef = i.abbr + ' ' + i.reference;
       });
     }
 

--- a/client/src/partials/group_invoice/group_invoice.js
+++ b/client/src/partials/group_invoice/group_invoice.js
@@ -1,193 +1,206 @@
 angular.module('bhima.controllers')
-.controller('groupInvoice', [
-  '$scope',
-  '$translate',
-  'connect',
-  'validate',
-  'messenger',
-  'uuid',
-  'SessionService',
-  function ($scope, $translate, connect, validate, messenger, uuid, SessionService) {
+.controller('GroupInvoiceController', GroupInvoiceController);
 
-    var dependencies = {};
-    $scope.action = '';
-    $scope.convention = '';
-    $scope.selected = {};
-    $scope.paying = [];
 
-    dependencies.invoices = {
-      query : 'ledgers/debitor/'
-    };
+GroupInvoiceController.$inject = [
+  '$scope', '$translate', 'connect', 'validate', 'messenger', 'uuid', 'SessionService',
+];
 
-    dependencies.conventions = {
-      required: true,
-      query : {
-        tables : {
-          'debitor_group'  : {
-            columns : ['uuid', 'name', 'account_id']
-          }
+function GroupInvoiceController($scope, $translate, connect, validate, messenger, uuid, SessionService) {
+  var vm = this;
+
+  var dependencies = {};
+  $scope.action = '';
+  $scope.convention = '';
+  $scope.selected = {};
+  $scope.paying = [];
+  $scope.loading = false;
+
+  // get enterprise
+  $scope.project = SessionService.project;
+
+  dependencies.invoices = {
+    query : 'ledgers/debitor/'
+  };
+
+  dependencies.conventions = {
+    required: true,
+    query : {
+      tables : {
+        'debitor_group'  : {
+          columns : ['uuid', 'name', 'account_id']
+        }
+      },
+      where : [
+        'debitor_group.is_convention<>0', 'AND',
+        'debitor_group.enterprise_id=' + $scope.project.enterprise_id
+      ]
+    }
+  };
+
+  dependencies.debtors = {
+    required : true,
+    query : {
+      tables : {
+        'debitor' : {
+          columns : ['uuid', 'text']
         },
-        where : ['debitor_group.is_convention<>0', 'AND']
-      }
-    };
+        'debitor_group' : {
+          columns : ['account_id']
+        }
+      },
+      join : ['debitor.group_uuid=debitor_group.uuid']
+    }
+  };
 
-    dependencies.debitors = {
-      required : true,
-      query : {
-        tables : {
-          'debitor' : {
-            columns : ['uuid', 'text']
-          },
-          'debitor_group' : {
-            columns : ['account_id']
-          }
+  dependencies.currency = {
+    required : true,
+    query : {
+      tables : {
+        'enterprise' : {
+          columns : ['currency_id']
         },
-        join : ['debitor.group_uuid=debitor_group.uuid']
-      }
-    };
+        'currency' : {
+          columns : ['symbol']
+        }
+      },
+      join : ['enterprise.currency_id=currency.id']
+    }
+  };
 
-    dependencies.currency = {
-      required : true,
-      query : {
-        tables : {
-          'enterprise' : {
-            columns : ['currency_id']
-          },
-          'currency' : {
-            columns : ['symbol']
-          }
-        },
-        join : ['enterprise.currency_id=currency.id']
-      }
-    };
+  // startup the module
+  validate.process(dependencies, ['debtors', 'conventions', 'currency'])
+  .then(setUpModels);
 
-    // get enterprise
-    $scope.project = SessionService.project;
-    dependencies.conventions.query.where.push(
-      'debitor_group.enterprise_id=' + $scope.project.enterprise_id
-    );
-    validate.process(dependencies, ['debitors', 'conventions', 'currency']).then(setUpModels);
-
-    $scope.setDebitor = function () {
-      if (!$scope.selected.debitor) {
-        return messenger.danger('Error: No debitor selected');
-      }
-
-      dependencies.invoices.query += $scope.selected.debitor.uuid;
-      validate.process(dependencies).then(setUpModels);
-      $scope.hasDebitor = true;
-      $scope.action = 'info';
-    };
-
-    function setUpModels (models) {
-      angular.extend($scope, models);
-      if ($scope.invoices) {
-        // FIXME: this is hack
-        $scope.invoices.data = $scope.invoices.data.filter(function (d) {
-          return d.balance !== 0;
-        });
-      }
-      $scope.payment = {};
+  $scope.setDebitor = function () {
+    if (!$scope.selected.debitor) {
+      return messenger.danger('Error: No debitor selected');
     }
 
-    $scope.examineInvoice = function (invoice) {
-      $scope.examine = invoice;
-      $scope.old_action = $scope.action;
-      $scope.action = 'examine';
-    };
+    dependencies.invoices.query += $scope.selected.debitor.uuid;
 
-    $scope.back = function () {
-      $scope.action = $scope.old_action;
-    };
+    // turn on loading
+    $scope.loading = true;
 
-    $scope.selectConvention = function () {
-      $scope.action = 'selectConvention';
-      $scope.original_id = $scope.data.invoice.convention_id;
-    };
+    validate.process(dependencies)
+    .then(setUpModels)
+    .finally(function () {
+      $scope.loading = false;
+    });
 
-    $scope.saveConvention = function () {
-      $scope.action = '';
-    };
+    $scope.hasDebitor = true;
+    $scope.action = 'info';
+  };
 
-    $scope.resetConvention = function () {
-      $scope.data.invoice.convention_id = $scope.original_id;
-      $scope.action = 'default';
-    };
+  // bind data to modules
+  function setUpModels(models) {
+    angular.extend($scope, models);
 
-    $scope.enqueue = function (idx) {
-      var invoice = $scope.invoices.data.splice(idx, 1)[0];
-      invoice.payment = invoice.balance; // initialize payment to be the exact amount -- 100%
-      $scope.paying.push(invoice);
-      $scope.action = 'pay';
-    };
 
-    $scope.dequeue = function () {
-      var total_payment = $scope.total_payment = 0;
-      $scope.paying.forEach(function (i) {
-        $scope.invoices.data.push(i);
-        total_payment += i.payment;
+    if ($scope.invoices) {
+      // FIXME: this is hack
+      $scope.invoices.data = $scope.invoices.data.filter(function (d) {
+        return d.balance !== 0;
       });
-      $scope.paying.length = 0;
-      $scope.action = '';
-    };
-
-    $scope.pay = function () {
-      var payment = $scope.payment;
-      payment.project_id = $scope.project.id;
-      payment.group_uuid = $scope.selected.convention.uuid;
-      payment.debitor_uuid  = $scope.selected.debitor.uuid;
-      payment.total = $scope.paymentBalance;
-      payment.date = new Date().toISOString().slice(0,10);
-      $scope.action = 'confirm';
-    };
-
-    $scope.$watch('paying', function () {
-      var s = 0, total_debit = 0, total_credit = 0;
-      $scope.paying.forEach(function (i) {
-        s = s + i.payment;
-        total_debit += i.debit;
-        total_credit += i.credit; 
-      });
-      var balance = total_debit - total_credit;
-      $scope.balance =  balance - s;
-      $scope.paymentBalance =  s;
-    }, true);
-
-    $scope.authorize = function () {
-      var id, items, payment = connect.clean($scope.payment);
-      payment.uuid = uuid();
-      connect.basicPut('group_invoice', [payment])
-      .then(function () {
-        id = payment.uuid;
-        items = formatItems(id);
-        return connect.basicPut('group_invoice_item', items);
-      })
-      .then(function () {
-        $scope.action = '';
-        $scope.paying = [];
-        return connect.fetch('/journal/group_invoice/' + id);
-      })
-      .then(function () {
-		    messenger.success($translate.instant('GROUP_INVOICE.SUCCES'));
-      });
-    };
-
-    function formatItems (id) {
-      var items = [];
-      $scope.paying.forEach(function (i) {
-        var item = {};
-        item.uuid = uuid();
-        item.cost = i.payment;
-        item.invoice_uuid = i.inv_po_id;
-        item.payment_uuid = id;
-        items.push(item);
-      });
-
-      return items;
     }
 
-    $scope.filter = function (invoice) {
-      return invoice.balance > 0;
-    };
+    $scope.payment = {};
   }
-]);
+
+  $scope.examineInvoice = function (invoice) {
+    $scope.examine = invoice;
+    $scope.old_action = $scope.action;
+    $scope.action = 'examine';
+  };
+
+  $scope.back = function () {
+    $scope.action = $scope.old_action;
+  };
+
+  $scope.selectConvention = function () {
+    $scope.action = 'selectConvention';
+    $scope.original_id = $scope.data.invoice.convention_id;
+  };
+
+  $scope.saveConvention = function () {
+    $scope.action = '';
+  };
+
+  $scope.resetConvention = function () {
+    $scope.data.invoice.convention_id = $scope.original_id;
+    $scope.action = 'default';
+  };
+
+  $scope.enqueue = function (idx) {
+    var invoice = $scope.invoices.data.splice(idx, 1)[0];
+    invoice.payment = invoice.balance; // initialize payment to be the exact amount -- 100%
+    $scope.paying.push(invoice);
+    $scope.action = 'pay';
+  };
+
+  $scope.dequeue = function () {
+    var total_payment = $scope.total_payment = 0;
+    $scope.paying.forEach(function (i) {
+      $scope.invoices.data.push(i);
+      total_payment += i.payment;
+    });
+    $scope.paying.length = 0;
+    $scope.action = '';
+  };
+
+  $scope.pay = function () {
+    var payment = $scope.payment;
+    payment.project_id = $scope.project.id;
+    payment.group_uuid = $scope.selected.convention.uuid;
+    payment.debitor_uuid  = $scope.selected.debitor.uuid;
+    payment.total = $scope.paymentBalance;
+    payment.date = new Date().toISOString().slice(0,10);
+    $scope.action = 'confirm';
+  };
+
+  $scope.$watch('paying', function () {
+    var s = 0, total_debit = 0, total_credit = 0;
+    $scope.paying.forEach(function (i) {
+      s = s + i.payment;
+      total_debit += i.debit;
+      total_credit += i.credit;
+    });
+    var balance = total_debit - total_credit;
+    $scope.balance =  balance - s;
+    $scope.paymentBalance =  s;
+  }, true);
+
+  $scope.authorize = function () {
+    var id, items, payment = connect.clean($scope.payment);
+    payment.uuid = uuid();
+    connect.post('group_invoice', [payment])
+    .then(function () {
+      id = payment.uuid;
+      items = formatItems(id);
+      return connect.post('group_invoice_item', items);
+    })
+    .then(function () {
+      $scope.action = '';
+      $scope.paying = [];
+      return connect.fetch('/journal/group_invoice/' + id);
+    })
+    .then(function () {
+      messenger.success($translate.instant('GROUP_INVOICE.SUCCES'));
+    });
+  };
+
+  function formatItems(id) {
+    return $scope.paying.map(function (i) {
+      var item = {};
+      item.uuid = uuid();
+      item.cost = i.payment;
+      item.invoice_uuid = i.inv_po_id;
+      item.payment_uuid = id;
+      return item;
+    });
+  }
+
+  $scope.filter = function (invoice) {
+    return invoice.balance > 0;
+  };
+}

--- a/client/src/partials/journal/journal.utilities.js
+++ b/client/src/partials/journal/journal.utilities.js
@@ -223,7 +223,8 @@ angular.module('bhima.controllers')
     $scope.refreshFilter = function refreshFilter () {
       $scope.filter.param = '';
       dataview.setFilterArgs({
-        param : $scope.filter.param
+        param : $scope.filter.param,
+        re : new RegExp($scope.filter.param, 'i')
       });
       dataview.refresh();
     };


### PR DESCRIPTION
This PR rewrites the client-side code base of Group Invoice (`/group_invoice`), but does not change the logic.  The following changes have been made:
 - No more UUIDs in the view
 - All currency filters reference the sale currency ID
 - Complete removal of `$scope` in favor of `controller as` syntax
 - Loading indicators while data is fetched from the server
 - Fixes to broken HTML.

Fixes #674.