### PR TITLE
FIX(mysql pool): set higher handshake timeout

### DIFF
--- a/server/config/environment/server.js
+++ b/server/config/environment/server.js
@@ -7,7 +7,8 @@ var config = {
     'host'     : 'localhost',
     'user'     : 'bhima',
     'password' : 'HISCongo2013',
-    'database' : 'bhima'
+    'database' : 'bhima',
+    'acquireTimeout' : 30000
   },
   'session' : {
     'secret' : 'xopen blowfish',

--- a/server/lib/db.js
+++ b/server/lib/db.js
@@ -18,7 +18,6 @@
 var q = require('q');
 
 var cfg = require('./../config/environment/server').db;
-var uuid = require('./guid');
 
 var db, con, supportedDatabases, dbms;
 
@@ -192,8 +191,9 @@ function executeAsTransaction(querries) {
   return deferred.promise;
 }
 
-function mysqlInit (config) {
+function mysqlInit(config) {
   'use strict';
+
   var db = require('mysql');
   return db.createPool(config);
 }


### PR DESCRIPTION
Node v4.2.0 seems to result in database build errors due to handshake
timeouts.  This commit raises the timeout limit for the connection pool
to allow Travis CI to build the database correctly.