### PR TITLE
FIX(sales): improved sale recoverability

### DIFF
--- a/client/src/partials/sales/sales.html
+++ b/client/src/partials/sales/sales.html
@@ -47,7 +47,7 @@
             ng-model="serviceComponent.selected"
             ng-options="service as service.name  for service in model.services.data"
           >
-            <option value="" disabled selected>...</option>
+            <option value="" disabled>...</option>
           </select>
           <span class="input-group-btn">
             <button
@@ -63,14 +63,14 @@
   <!-- Distributable or not -->
   <div class="panel" ng-class="{'panel-success' : session.is_distributable, 'panel-warning' : !session.is_distributable}">
     <div class="panel-heading">
-      <i class="glyphicon glyphicon-export"></i> 
+      <i class="glyphicon glyphicon-export"></i>
       <strong>{{ 'SALE.DETAILS' | translate }} : </strong>
     </div>
     <div class="panel-body">
       <div class="col-xs-4">
         <div class="input-group">
           <label class="input-group-addon">{{ 'SALE.DATE' | translate }} :</label>
-          <input class="form-control" type="date" ng-model="session.invoice_date">
+          <input class="form-bhima" type="date" ng-model="session.invoice_date">
         </div>
       </div>
       <div class="col-xs-8">


### PR DESCRIPTION
This commit fixes several issues with recovering sales:
 1. The invoice_date and is_distributable fields are now able to be
 recovered with the rest of the sale.
 2. The sale now saves to appcache when removing items as well as on
 addition, ensuring that a working copy remains up to date with edits
 3. Changed a form-control to a form-bhima.

Fixes #318.