### PR TITLE
FIX(sessions): Allow persistent sessions

### DIFF
--- a/server/config/environment/server.js
+++ b/server/config/environment/server.js
@@ -4,15 +4,16 @@ var config = {
   'rootFile' : '/index.html',
   'port' : 8080,
   'db' : {
-    'host'     : 'localhost',
-    'user'     : 'bhima',
-    'password' : 'HISCongo2013',
-    'database' : 'bhima'
+    'host':     'localhost',
+    'user':     'bhima',
+    'password': 'HISCongo2013',
+    'database': 'bhima'
   },
   'session' : {
     'secret' : 'xopen blowfish',
     'resave' : false,
     'saveUninitialized' : false,
+    'reapInterval' : -1 // disables session reaping
   },
   'uploadFolder' : 'client/upload/',
 

--- a/server/config/express.js
+++ b/server/config/express.js
@@ -27,6 +27,7 @@ module.exports = function (app, authentication) {
     secret            : cfg.session.secret,
     saveUninitialized : cfg.session.saveUninitialized,
     resave            : cfg.session.resave,
+    reapInterval      : cfg.session.reapInterval,
     unset             : 'destroy',
     cookie            : { secure : true }
   }));


### PR DESCRIPTION
This commit stops the server from deleting sessions from the file store.
That means a user must explicitly log out to remove their session
information (or the server must be restarted).

If we have better login error handling and messaging, this can be reset.
At the moment, it's very helpful so that users do not get kicked out of
their sessions while working.