### PR TITLE
FIX(exchange): set rates to today, not yesterday

### DIFF
--- a/client/src/partials/exchange_rate/exchange_rate.html
+++ b/client/src/partials/exchange_rate/exchange_rate.html
@@ -81,6 +81,7 @@
       <div class="panel panel-default" ng-switch-when="new">
         <div class="panel-body">
 
+
           <form name="RateForm" class="form-horizontal" novalidate>
             <fieldset>
               <legend>{{ 'EXCHANGE.SET' | translate }}</legend>
@@ -96,7 +97,7 @@
 
               <div class="form-group" >
                 <div class="col-xs-11">
-                  <input type="date" class="form-bhima" ng-model="ExchangeCtrl.form.date" max="{{ ExchangeCtrl.today | date:'yyyy-MM-dd' }}" ng-disabled="!ExchangeCtrl.form.isOld">
+                  <input name="date" type="date" class="form-bhima" ng-model="ExchangeCtrl.form.date" ng-disabled="!ExchangeCtrl.form.isOld" ng-max="{{ ExchangeCtrl.tomorrow }}" max="{{ ExchangeCtrl.today | date:'yyyy-MM-dd' }}">
                 </div>
               </div>
 
@@ -108,7 +109,7 @@
                 </div>
 
                 <div class="col-sm-offset-1 col-xs-5">
-                  <select class="form-bhima" ng-model="ExchangeCtrl.form.foreign_currency_id" ng-options="c.id as c.name for c in ExchangeCtrl.currency.data | filter:ExchangeCtrl.fcurrency track by c.id" required>
+                  <select name="currency" class="form-bhima" ng-model="ExchangeCtrl.form.foreign_currency_id" ng-options="c.id as c.name for c in ExchangeCtrl.currency.data | filter:ExchangeCtrl.fcurrency track by c.id" required>
                     <option value="" disabled>-- {{ 'SELECT.CURRENCY' | translate }} --</option>
                   </select>
                 </div>
@@ -139,7 +140,7 @@
               </div>
             </fieldset>
 
-            <input type="submit" class="btn btn-sm btn-success" ng-click="ExchangeCtrl.submit()" ng-disabled="RateForm.$invalid" value="{{ 'FORM.SUBMIT' | translate }}">
+            <input type="submit" class="btn btn-sm btn-success" ng-click="ExchangeCtrl.submit(RateForm.$invalid)" ng-disabled="RateForm.$invalid" value="{{ 'FORM.SUBMIT' | translate }}">
           </form>
         </div>
       </div>

--- a/client/src/partials/exchange_rate/exchange_rate.js
+++ b/client/src/partials/exchange_rate/exchange_rate.js
@@ -20,7 +20,8 @@ function ExchangeRateController(connect, appstate, validate, exchange, Session, 
   var dependencies = {};
 
   // bind data
-  vm.today = Dates.current.day();
+  vm.today = new Date();
+  vm.tomorrow = Dates.next.day();
   vm.enterprise = Session.enterprise;
   vm.form = { date : vm.today };
   vm.state = 'default';
@@ -75,14 +76,14 @@ function ExchangeRateController(connect, appstate, validate, exchange, Session, 
   function buildModels(models) {
     angular.extend(vm, models);
 
-    console.log('models:', models);
-
     vm.currentRates = vm.rates.data.filter(function (rate) {
       return new Date(rate.date).setHours(0,0,0,0) === new Date().setHours(0,0,0,0);
     });
   }
 
-  function submit() {
+  function submit(invalid) {
+
+    if (invalid) { return; }
 
     var data = {
       enterprise_currency_id : vm.enterprise.currency_id,


### PR DESCRIPTION
This commit fixes a critical bug in which the rates were always set to
the day before.  This is do to errors in the angular validation,
stemming from differences between ngMax and the HTML max attribute.

Fixes #824.