### PR TITLE
FEAT(di): require strict dependency injection

### DIFF
--- a/client/src/index.html
+++ b/client/src/index.html
@@ -7,7 +7,7 @@
   <link rel="icon" href="assets/favicon.ico" type="image/x-icon">
   <link rel="stylesheet" href="css/style.min.css">
 </head>
-<body ng-app="bhima">
+<body ng-app="bhima" ng-strict-di>
 
 <!--not required in placeholder rewrite-->
 <div ng-controller="ApplicationController as AppCtrl">


### PR DESCRIPTION
Since we have agreed to use Controller.$inject syntax (#719), and are compiling
all our scripts through gulp, we can get some speed gains by adding the
strict DI mode directive to the main application.  For more details,
[see this link](https://docs.angularjs.org/guide/production).

I've tested most of the modules, and this change leaves them unaffected.
However, if we do find issues, we might want to add ng-annotate to our
gulp build.