### PR TITLE
CHORE(stock status): display stock projections

### DIFF
--- a/client/src/partials/reports/stock_status/stock_status.html
+++ b/client/src/partials/reports/stock_status/stock_status.html
@@ -30,7 +30,7 @@
               <th>{{ "COLUMNS.MINIMUM_STOCK" | translate }} </th>
               <th>{{ "COLUMNS.MAXIMUM_STOCK" | translate }} </th>
               <th>{{ "COLUMNS.MONTHS_REMAINING" | translate }} </th>
-              <th>{{ "COLUMNS.ALERTS" | translate }} </th>
+              <th class="hidden-print">{{ "COLUMNS.ALERTS" | translate }} </th>
             </tr>
           </thead>
           <tbody>
@@ -43,10 +43,10 @@
               <td>{{ row.quantity }}</td>
               <td>{{ row.consumptionByMonth }}</td>
               <td>{{ row.securityStock }}</td>
-              <td>{{ row.stock_min }}</td>
-              <td>{{ row.stock_max }}</td>
+              <td>{{ row.minimumStock }}</td>
+              <td>{{ row.maximumStock }}</td>
               <td>{{ row.monthsRemaining || '--' }}</td>
-              <td class="text-center">
+              <td class="text-center hidden-print">
                 <span class="label" ng-class="{ 'label-primary' : row.overstock, 'label-warning' : row.shortage, 'label-danger' : row.stockout }" ng-if="row.alert">
                   {{ row.alert | translate }}
                 </span>

--- a/client/src/partials/reports/stock_status/stock_status.js
+++ b/client/src/partials/reports/stock_status/stock_status.js
@@ -12,7 +12,7 @@ StockStatusReportController.$inject = ['$http', '$timeout'];
 * NOTES
 *  1) I have removed "quantity to order", as I think this should really be a
 *     parameter provided by an alert.  Currently, our calculations are inaccurate
-*     due to poor data
+*     due to poor data.
 */
 function StockStatusReportController($http, $timeout) {
   var vm = this;
@@ -40,6 +40,10 @@ function StockStatusReportController($http, $timeout) {
   // template the data into the view
   function template(response) {
     var report;
+
+    // FIXME - we are hard-coding procurement period to 1 until there is a
+    // good system for estimating procurement period.
+    var pp = 1;
 
     // filter out items that are missing both a quantity and a lead time.  This
     // should ensure that we have only relevant data.
@@ -75,6 +79,13 @@ function StockStatusReportController($http, $timeout) {
       row.monthsRemaining = row.consumptionByMonth ?
         (row.quantity  / row.consumptionByMonth).toFixed(2) :
         0;
+
+      // FIXME
+      // These are temporary patches until we have more data to work with.
+      // This type of analysis should be done on the server as well
+      row.shortage = row.consumptionByMonth !== 0 && row.monthsRemaining < 3;
+      row.minimumStock = (row.securityStock || 0) * 2;
+      row.maximumStock = (row.consumptionByMonth || 0)*pp + row.minimumStock;
 
       // if there is an alert, we template it in
       row.alert = row.stockout ? 'STOCK.ALERTS.STOCKOUT' :


### PR DESCRIPTION
This commit removes the dependence on the fixed inventory numbers and
shows only the projected numbers from stock calculations over time.

NOTE that is change is hard-coded, and needs to provide more flexibility
to the users viewing the stock status report than it is able to provide
here.

Finally, the alert column is hidden in the printed form.