### PR TITLE
FIX(trial balance): separate balance states

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -3057,6 +3057,7 @@
    "SHOW"             : "Show",
    "SHOW_ERRORS"      : "Show Errors",
    "SHOW_WARNINGS"    : "Show Warnings",
+   "SHOW_RESULTS"   : "Show Results",
    "SIGNATURES"       : "Signatures",
    "SUMMARY"          : "Summary",
    "TITLE"            : "Trial Balance",

--- a/client/src/i18n/fr.json
+++ b/client/src/i18n/fr.json
@@ -3057,6 +3057,7 @@
    "SHOW"             : "Voir",
    "SHOW_ERRORS"      : "Afficher des Erreurs",
    "SHOW_WARNINGS"    : "Afficher des Avertissements",
+   "SHOW_RESULTS"   : "Afficher des Résultats",
    "SIGNATURES"       : "Signées",
    "SUMMARY"          : "Summaire",
    "TITLE"            : "Rapprochement",

--- a/client/src/partials/journal/trialbalance/trialbalance.html
+++ b/client/src/partials/journal/trialbalance/trialbalance.html
@@ -2,8 +2,11 @@
   <div class="modal-header">
     <h3 class="pull-left">{{ 'TRIAL_BALANCE.TITLE' | translate }}</h3>
     <div class="modal-icons">
-      <a class="btn btn-default" ng-click="BalanceCtrl.toggleExceptionState()" ng-class="{ 'active' : BalanceCtrl.state === 'exception' }" ng-if="BalanceCtrl.hasExceptions">
-        {{ BalanceCtrl.hasErrors ? "TRIAL_BALANCE.SHOW_ERRORS" : "TRIAL_BALANCE.SHOW_WARNINGS" | translate }}
+      <a class="btn btn-default" ng-click="BalanceCtrl.toggleExceptionState()" ng-if="BalanceCtrl.hasExceptions && BalanceCtrl.state !== 'exception'">
+        <i class="glyphicon glyphicon-exclamation-sign"></i> {{ BalanceCtrl.hasErrors ? "TRIAL_BALANCE.SHOW_ERRORS" : "TRIAL_BALANCE.SHOW_WARNINGS" | translate }}
+      </a>
+      <a class="btn btn-default" ng-click="BalanceCtrl.toggleExceptionState()" ng-if="BalanceCtrl.hasExceptions && BalanceCtrl.state === 'exception'">
+        <i class="glyphicon glyphicon-tasks"></i> {{ "TRIAL_BALANCE.SHOW_RESULTS" | translate }}
       </a>
     </div>
     <div class="modal-print" ng-hide="BalanceCtrl.state === 'loading'" >


### PR DESCRIPTION
This commit changes the way error and results states work in the trial
balance.  Rather than having a single button with the message "view errors",
and is toggled _active_ when clicked, we now change the button text
depending on the current state.  While looking at results, it will still
read "view errors", but will switch to "view results" on click to
clearly indicate to the user to return.

**Results Mode**
![resultsmode](https://cloud.githubusercontent.com/assets/896472/10758515/1779045a-7cb2-11e5-94ad-a976978a7460.png)

**Error Mode**
![errormode](https://cloud.githubusercontent.com/assets/896472/10758510/111160ee-7cb2-11e5-98c2-ad28b9b2f29b.png)
