### PR TITLE
FIX(journal): grid edit mode renders properly

### DIFF
--- a/client/src/partials/journal/journal.grid.js
+++ b/client/src/partials/journal/journal.grid.js
@@ -23,7 +23,6 @@ angular.module('bhima.controllers')
 
     function initialise (models) {
       angular.extend($scope, models);
-      console.log(models);
 
       // set up grid properties
       columns = [

--- a/client/src/partials/journal/journal.utilities.js
+++ b/client/src/partials/journal/journal.utilities.js
@@ -292,7 +292,8 @@ angular.module('bhima.controllers')
       if (!manager || !manager.session || !manager.session.mode) { return; }
       var e = $('#journal_grid');
       e[manager.session.mode === 'static' ? 'removeClass' : 'addClass']('danger');
-      manager.fn.regroup();
+      //manager.fn.regroup();
+      grid.invalidate();
     });
 
     function beginEditMode () {


### PR DESCRIPTION
Fixes #842.

This commit re-renders the grid through a call to `grid.invalidate()`
whenever the session.mode changes, rather than regrouping.  This has
the affect of ensuring that the edit mode buttons are present when the
user needs them.