### PR TITLE
FIX(primary cash): ui date form limits

### DIFF
--- a/client/src/index.html
+++ b/client/src/index.html
@@ -99,7 +99,7 @@
 <script src="vendor/slickgrid/bhima.slickgrid.js"></script>
 
 <!--angular-->
-<script src="vendor/angular/angular.js"></script>
+<script src="vendor/angular/angular.min.js"></script>
 <script src="vendor/angular-route/angular-route.js"></script>
 
 <!-- angular-chart-->

--- a/client/src/partials/primary_cash/expense/generic.html
+++ b/client/src/partials/primary_cash/expense/generic.html
@@ -29,7 +29,7 @@
       style="margin-left: 5px;"
       ng-click="reconfigure()"
       class="btn btn-sm btn-default">
-      {{'PRIMARY_CASH.EXPENSE.SELECT_ACCOUNT' | translate}}
+      {{ 'PRIMARY_CASH.EXPENSE.SELECT_ACCOUNT' | translate }}
       <span class="glyphicon glyphicon-repeat"></span>
     </button>
 
@@ -59,7 +59,8 @@
               type="text"
               ng-model="session.ac"
               placeholder="Selectionner compte"
-              typeahead="ac as formatAccount(ac) for ac in session.accounts | filter:$viewValue | limitTo:15" typeahead-template-url="AccountList.html"
+              typeahead="ac as formatAccount(ac) for ac in session.accounts | filter:$viewValue | limitTo:15"
+              typeahead-template-url="AccountList.html"
               typeahead-on-select="setConfiguration(session.ac)"
               >
             <span class="input-group-btn">
@@ -71,7 +72,7 @@
     </div>
   </div>
 
-  <div ng-if="session.configured"  class="row margin-top-10">
+  <div ng-if="session.configured" class="row margin-top-10">
     <div class="col-xs-6">
       <div class="panel panel-primary">
         <div class="panel-heading">
@@ -83,13 +84,13 @@
 
             <div class="form-group" style="padding-right: 0;">
               <label>{{ "PRIMARY_CASH.EXPENSE.EXPENSE_DATE" | translate }}</label>
-              <input class="form-bhima" type="date" ng-model="session.receipt.date" max="{{ session.tomorrow }}" required>
+              <input class="form-bhima" type="date" ng-model="session.receipt.date" ng-max="{{ session.tomorrow }}" max="{{ session.today | date:'yyyy-MM-dd' }}"  required>
               <p ng-if="!session.hasDailyRate">
                 <b class="text-danger"><span class="glyphicon glyphicon-warning-sign"></span>
-                  {{ 'EXCHANGE.NO_EXCHANGE_RATE' | translate}} {{session.receipt.date | date}}
+                  {{ 'EXCHANGE.NO_EXCHANGE_RATE' | translate }} {{session.receipt.date | date }}
                 </b>
                 <b class="text-info">
-                  <a title="{{ 'EXCHANGE.SET_HERE' | translate}}" href="#/exchange_rate">
+                  <a title="{{ 'EXCHANGE.SET_HERE' | translate }}" href="#/exchange_rate">
                     <span class="glyphicon glyphicon-cog"></span>
                   </a>
                 </b>

--- a/client/src/partials/primary_cash/expense/generic.js
+++ b/client/src/partials/primary_cash/expense/generic.js
@@ -12,6 +12,11 @@ function PrimaryCashExpenseGenericController ($scope, $routeParams, $translate, 
       session      = $scope.session = { receipt : { date : new Date() }, configure : false, complete : false },
       cache        = new Appcache('expense');
 
+  session.today = new Date();
+  tomorrow = new Date();
+  tomorrow.setDate(session.today.getDate() + 1);
+  session.tomorrow = tomorrow;
+
   dependencies.currencies = {
     query : {
       tables : {
@@ -43,8 +48,9 @@ function PrimaryCashExpenseGenericController ($scope, $routeParams, $translate, 
   $scope.setConfiguration = setConfiguration;
 
   // Watchers
-  $scope.$watch('session.receipt', valid, true);
-  $scope.$watch('session.currency', valid, true);
+  // TODO -- replace validation $watchers with angular validation
+  $scope.$watchCollection('session.receipt', valid);
+  $scope.$watchCollection('session.currency', valid);
 
   // Startup
   startup();
@@ -52,7 +58,7 @@ function PrimaryCashExpenseGenericController ($scope, $routeParams, $translate, 
   cache.fetch('account').then(getAccount);
 
   // Functions
-  function load (currency) {
+  function load(currency) {
     if (!currency) { return; }
     session.currency = currency;
   }
@@ -85,14 +91,14 @@ function PrimaryCashExpenseGenericController ($scope, $routeParams, $translate, 
     .catch(error);
   }
 
-  function getAccount (ac) {
+  function getAccount(ac) {
     if (!ac) { return; }
      session.configured = true;
      session.ac = ac;
      session.complete = true;
   }
 
-  function clear () {
+  function clear() {
     session.receipt = {};
     session.receipt.date = new Date();
     session.receipt.value = 0.00;
@@ -103,7 +109,7 @@ function PrimaryCashExpenseGenericController ($scope, $routeParams, $translate, 
     session.hasDailyRate = exchange.hasDailyRate(date);
   }
 
-  function valid () {
+  function valid() {
     if (!session || !session.receipt) {
       session.invalid = true;
       return;
@@ -133,7 +139,7 @@ function PrimaryCashExpenseGenericController ($scope, $routeParams, $translate, 
       currency_id   : session.currency.id,
       cost          : receipt.cost,
       user_id       : SessionService.user.id,
-      description   : 'HBB' + '_C.P DEP GEN/' + receipt.description, //fix me
+      description   : 'HBB' + '_C.P DEP GEN/' + receipt.description, // FIXME -- hard coded name
       cash_box_id   : receipt.cash_box_id,
       origin_id     : 4,
     };
@@ -161,31 +167,31 @@ function PrimaryCashExpenseGenericController ($scope, $routeParams, $translate, 
     .catch(error);
   }
 
-  function setCurrency (obj) {
-    session.currency=obj;
+  function setCurrency(obj) {
+    session.currency = obj;
     cache.put('currency', obj);
   }
 
-  function update (value) {
+  function update(value) {
     session.receipt.recipient = value;
   }
 
-  function error (err) {
+  function error(err) {
     messenger.error(err);
   }
 
-  function formatAccount (ac) {
-    if(ac){return ac.account_number + ' - ' + ac.account_txt;}
+  function formatAccount(ac) {
+    if (ac) {return ac.account_number + ' - ' + ac.account_txt;}
   }
 
-  function reconfigure () {
+  function reconfigure() {
     session.configured = false;
     session.ac = null;
     session.complete = false;
   }
 
-  function setConfiguration (ac) {
-    if(ac){
+  function setConfiguration(ac) {
+    if (ac) {
       cache.put('account', ac);
       session.configured = true;
       session.ac = ac;

--- a/client/src/partials/primary_cash/income/generic/generic.html
+++ b/client/src/partials/primary_cash/income/generic/generic.html
@@ -85,7 +85,7 @@
 
             <div class="form-group" style="padding-right: 0;">
               <label>{{ "PRIMARY_CASH.INCOME.DATE" | translate }}</label>
-              <input type="date" class="form-bhima" ng-model="session.receipt.date" max="{{ session.tomorrow }}" required>
+              <input type="date" class="form-bhima" ng-model="session.receipt.date" ng-max="{{ session.tomorrow }}" max="{{ session.today | date:'yyyy-MM-dd' }}" required>
               <p ng-if="!session.hasDailyRate">
                 <b class="text-danger"><span class="glyphicon glyphicon-warning-sign"></span>
                   {{ 'EXCHANGE.NO_EXCHANGE_RATE' | translate}} {{session.receipt.date | date}}

--- a/client/src/partials/primary_cash/income/generic/generic.js
+++ b/client/src/partials/primary_cash/income/generic/generic.js
@@ -7,11 +7,17 @@ PrimaryCashIncomeGenericController.$inject = [
 ];
 
 function PrimaryCashIncomeGenericController ($scope, $routeParams, $translate, validate, messenger, SessionService, connect, uuid, util, $location, Appcache, exchange) {
-  var isDefined, tomorrow,
+  var isDefined    = angular.isDefined,
       dependencies = {},
       session      = $scope.session = { receipt : {}, configured : false, complete : false },
       cache        = new Appcache('income');
 
+  // set proper dates
+  session.today = new Date();
+  var tomorrow = new Date();
+  tomorrow.setDate(session.today.getDate() + 1);
+  session.tomorrow = tomorrow;
+  isDefined = angular.isDefined;
   dependencies.currencies = {
     query : {
       tables : {
@@ -43,8 +49,8 @@ function PrimaryCashIncomeGenericController ($scope, $routeParams, $translate, v
   $scope.setConfiguration = setConfiguration;
 
   // Watchers
-  $scope.$watch('session.receipt', valid, true);
-  $scope.$watch('session.currency', valid, true);
+  $scope.$watchCollection('session.receipt', valid);
+  $scope.$watchCollection('session.currency', valid);
 
   // Startup
   startup();
@@ -71,13 +77,7 @@ function PrimaryCashIncomeGenericController ($scope, $routeParams, $translate, v
       throw new Error('No cashbox selected');
     }
 
-    isDefined = angular.isDefined;
     $scope.timestamp = new Date();
-
-    // session.today = $scope.timestamp.toISOString().slice(0, 10);
-    tomorrow = new Date();
-    tomorrow.setDate(tomorrow.getDate() + 1);
-    session.tomorrow = util.htmlDate(tomorrow);
 
     // init models
     $scope.project =  SessionService.project;


### PR DESCRIPTION
Fixes #849.

This commit fixes the date limits in both the generic expense and
generic income forms.  Previously, the min/max attributes limited the
date selection to all dates including the next day, this commit changes
that selection to all dates including the present day.

Other minor changes:
  - $scope.$watch() --> $scope.$watchCollection() for collections
  - Nicer JS formatting