### PR TITLE
FIX(cash return): do not submit w/o currency

### DIFF
--- a/client/src/index.html
+++ b/client/src/index.html
@@ -99,7 +99,7 @@
 <script src="vendor/slickgrid/bhima.slickgrid.js"></script>
 
 <!--angular-->
-<script src="vendor/angular/angular.js"></script>
+<script src="vendor/angular/angular.min.js"></script>
 <script src="vendor/angular-route/angular-route.js"></script>
 
 <!-- angular-chart-->

--- a/client/src/js/app.js
+++ b/client/src/js/app.js
@@ -416,7 +416,7 @@ function bhimaconfig($routeProvider) {
     templateUrl : 'partials/primary_cash/expense/payroll.html'
   })
   .when('/primary_cash/expense/cash_return/:cashbox', {
-    controller : 'cashReturn',
+    controller : 'PrimaryCashReturnController as ReturnCtrl',
     templateUrl : 'partials/primary_cash/expense/cash_return.html'
   })
   .when('/primary_cash/expense/multi_payroll/', {

--- a/client/src/partials/primary_cash/expense/cash_return.html
+++ b/client/src/partials/primary_cash/expense/cash_return.html
@@ -6,8 +6,8 @@
   <div class="pull-left">
     <ol class="breadcrumb">
       <li><a href="#/"><span class="glyphicon glyphicon-home"></span></a></li>
-      <li><a href="#/primary_cash/">{{ 'PRIMARY_CASH.TITLE' | translate}}</a></li>
-      <li class="active">{{ 'CASH_RETURN.TITLE' | translate}}</li>
+      <li><a href="#/primary_cash/">{{ 'PRIMARY_CASH.TITLE' | translate }}</a></li>
+      <li class="active">{{ 'CASH_RETURN.TITLE' | translate }}</li>
     </ol>
   </div>
 
@@ -29,65 +29,59 @@
     <div class="col-xs-6">
       <div class="panel panel-primary">
         <div class="panel-heading">
-          <i class="glyphicon glyphicon-list-alt"></i>
-          {{ "CASH_RETURN.TITLE" | translate }}
+          <i class="glyphicon glyphicon-list-alt"></i> {{ "CASH_RETURN.TITLE" | translate }}
         </div>
-        <div class="panel-body">
-          <form class="form">
-            <div class="form-group">
-              <div class="input-group">
-                <span class="input-group-btn dropdown">
-                  <a class="btn btn-default btn-sm dropdown-toggle">
-                    {{ session.data.type || "..."  | uppercase}} <span class="caret" data-caret="&#9660;"></span>
-                  </a>
-                  <ul class="dropdown-menu">
-                    <li><a ng-click="setType('D')">{{ "COLUMNS.DEBTOR" | translate }}</a></li>
-                    <li><a ng-click="setType('C')">{{ "COLUMNS.CREDITOR" | translate }}</a></li>
-                  </ul>
-                </span>
-                <input
-                  class="form-bhima"
-                  ng-model="session.data.deb_cred"
-                  typeahead="e as e.text for e in entities | filter:{type : session.data.type} | filter:$viewValue | limitTo:8"
-                  typeahead-template-url="entityListItem.tmpl.html" placeholder="{{ 'SELECT.DEB_CRED' | translate }}" 
-                  typeahead-on-select="getCredDeb()"
-                >
-              </div>
-            </div>
-
-            <div class="form-group">
-              <div class="input-group">
-              <span class="input-group-addon">
-                <span>{{ "CASH_RETURN.TAPE_VALUE" | translate }}</span>
+        <form class="panel-body" name="CashForm">
+          <div class="form-group">
+            <label>{{ "COLUMNS.DEBITOR" | translate }}/{{ "COLUMNS.CREDITOR" | translate }}</label>
+            <div class="input-group">
+              <span class="input-group-btn dropdown">
+                <a class="btn btn-default btn-sm dropdown-toggle">
+                  {{ session.data.type || "..."  | uppercase }} <span class="caret" data-caret="&#9660;"></span>
+                </a>
+                <ul class="dropdown-menu">
+                  <li><a ng-click="setType('D')">{{ "COLUMNS.DEBTOR" | translate }}</a></li>
+                  <li><a ng-click="setType('C')">{{ "COLUMNS.CREDITOR" | translate }}</a></li>
+                </ul>
               </span>
+              <input
+                class="form-bhima"
+                ng-model="session.data.deb_cred"
+                typeahead="e as e.text for e in entities | filter:{type : session.data.type} | filter:$viewValue | limitTo:8"
+                typeahead-template-url="entityListItem.tmpl.html"
+                placeholder="{{ 'SELECT.DEB_CRED' | translate }}"
+                typeahead-on-select="getCredDeb()"
+              >
+            </div>
+          </div>
+
+          <div class="form-group">
+            <label>{{ "COLUMNS.AMOUNT" | translate }}</label>
+            <div class="input-group">
               <input type="number" ng-model="session.data.value" class="form-bhima" required>
               <span class="input-group-addon">
-                <span>{{session.base.selectedItem.symbol}}</span>
+                {{ session.base.selectedItem.symbol }}
               </span>
-              </div>
             </div>
-
-            <div class="form-group">
-              <div class="input-group">
-                <span class="input-group-addon">
-                  <span>{{ "CASH_RETURN.DESC" | translate }}</span>
-                </span>
-                <input ng-model="session.data.description" ng-disabled="session.data.description" class="form-bhima" required>
-              </div>
-            </div>
-          </form>
-        </div>
-        <div class="panel-footer">
-          <div class="col-sm-offset-10">
-            <button class="btn btn-sm btn-success" ng-click="submit()" ng-disabled="!valid()">{{ 'FORM.SUBMIT' | translate }}</button>
           </div>
+
+          <div class="form-group">
+            <label>{{ "COLUMNS.DESCRIPTION" | translate }}</label>
+            <input ng-model="session.data.description" ng-disabled="session.data.description" class="form-bhima" required>
+          </div>
+        </form>
+        <div class="panel-footer clearfix">
+          <button class="btn btn-sm btn-success pull-right" ng-click="submit()" ng-disabled="!valid()">
+            {{ 'FORM.SUBMIT' | translate }}
+          </button>
         </div>
       </div>
     </div>
+
     <div class="col-xs-6">
       <div class="alert alert-info">
-        <h4>{{ 'CASH_RETURN.TITLE' | translate}}</h4>
-        <p>{{ 'CASH_RETURN.DESCRIPTION' | translate}}</p>
+        <h4>{{ 'CASH_RETURN.TITLE' | translate }}</h4>
+        <p>{{ 'CASH_RETURN.DESCRIPTION' | translate }}</p>
       </div>
     </div>
   </div>

--- a/client/src/partials/primary_cash/expense/cash_return.js
+++ b/client/src/partials/primary_cash/expense/cash_return.js
@@ -1,194 +1,185 @@
 angular.module('bhima.controllers')
-.controller('cashReturn', [
-  '$scope',
-  '$routeParams',
-  '$translate',
-  '$location',
-  'messenger',
-  'validate',
-  'appstate',
-  'appcache',
-  'connect',
-  'util',
-  'exchange',
-  '$q',
-  'uuid',
-  'SessionService',
-  function ($scope, $routeParams, $translate, $location, messenger, validate, appstate, Appcache, connect, util, exchange, $q, uuid, Session) {
-    /**
-      * TODO use controller alias as possible and redirect url when no daily exchange rate
-      */
-    var dependencies = {},
-        cache = new Appcache('cash_return'),
-        session = $scope.session = {data : {}, base : {}};
+.controller('PrimaryCashReturnController', PrimaryCashReturnController);
 
-    session.base.cashbox = $routeParams.cashbox;
+PrimaryCashReturnController.$inject = [
+  '$scope', '$routeParams', '$translate', '$location', 'messenger', 'validate',
+  'appstate', 'appcache', 'connect', 'util', 'exchange', '$q', 'uuid', 'SessionService',
+];
 
-    dependencies.modules = {
-      query : {
-        tables : {
-          'primary_cash_module' : {
-            columns : ['id']
-          }
+function PrimaryCashReturnController($scope, $routeParams, $translate, $location, messenger, validate, appstate, Appcache, connect, util, exchange, $q, uuid, Session) {
+  var dependencies = {},
+      cache = new Appcache('cash_return'),
+      session = $scope.session = {data : {}, base : {}};
+
+  session.base.cashbox = $routeParams.cashbox;
+
+  dependencies.modules = {
+    query : {
+      tables : {
+        'primary_cash_module' : {
+          columns : ['id']
+        }
+      },
+      where : ['primary_cash_module.text=cash_return']
+    }
+  };
+
+  dependencies.cash_box = {
+    required : true,
+    query : {
+      tables : {
+        'cash_box_account_currency' : {
+          columns : ['id', 'currency_id', 'account_id']
         },
-        where : ['primary_cash_module.text=cash_return']
-      }
-    };
-
-    dependencies.cash_box = {
-      required : true,
-      query : {
-        tables : {
-          'cash_box_account_currency' : {
-            columns : ['id', 'currency_id', 'account_id']
-          },
-          'currency' : {
-            columns : ['symbol', 'min_monentary_unit']
-          },
-          'cash_box' : {
-            columns : ['id', 'text', 'project_id']
-          }
+        'currency' : {
+          columns : ['symbol', 'min_monentary_unit']
         },
-        join : [
-          'cash_box_account_currency.currency_id=currency.id',
-          'cash_box_account_currency.cash_box_id=cash_box.id'
-        ],
-        where : [
-          'cash_box_account_currency.cash_box_id=' + session.base.cashbox
-        ]
-      }
-    };
+        'cash_box' : {
+          columns : ['id', 'text', 'project_id']
+        }
+      },
+      join : [
+        'cash_box_account_currency.currency_id=currency.id',
+        'cash_box_account_currency.cash_box_id=cash_box.id'
+      ],
+      where : [
+        'cash_box_account_currency.cash_box_id=' + session.base.cashbox
+      ]
+    }
+  };
 
-    dependencies.debtors = {
-      query: {
-        identifier : 'uuid',
-        'tables' : {
-          'debitor' : { 'columns' : ['uuid', 'text'] },
-          'patient' : { 'columns' : ['first_name', 'last_name'] },
-          'debitor_group' : { 'columns' : ['name'] },
-          'account' : { 'columns' : ['account_number', 'id'] }
-        },
-        join: ['debitor.uuid=patient.debitor_uuid', 'debitor_group.uuid=debitor.group_uuid', 'debitor_group.account_id=account.id']
-      }
-    };
+  dependencies.debtors = {
+    query: {
+      identifier : 'uuid',
+      'tables' : {
+        'debitor' : { 'columns' : ['uuid', 'text'] },
+        'patient' : { 'columns' : ['first_name', 'last_name'] },
+        'debitor_group' : { 'columns' : ['name'] },
+        'account' : { 'columns' : ['account_number', 'id'] }
+      },
+      join: ['debitor.uuid=patient.debitor_uuid', 'debitor_group.uuid=debitor.group_uuid', 'debitor_group.account_id=account.id']
+    }
+  };
 
-    dependencies.creditors = {
-      query: {
-        'tables' : {
-          'creditor' : { 'columns' : ['uuid', 'text'] },
-          'creditor_group' : { 'columns' : ['name'] },
-          'account' : { 'columns' : ['account_number', 'id'] }
-        },
-        join: ['creditor.group_uuid=creditor_group.uuid','creditor_group.account_id=account.id']
-      }
-    };
+  dependencies.creditors = {
+    query: {
+      'tables' : {
+        'creditor' : { 'columns' : ['uuid', 'text'] },
+        'creditor_group' : { 'columns' : ['name'] },
+        'account' : { 'columns' : ['account_number', 'id'] }
+      },
+      join: ['creditor.group_uuid=creditor_group.uuid','creditor_group.account_id=account.id']
+    }
+  };
 
-    cache.fetch('type').then(defineType);
-    cache.fetch('selectedItem').then(load);
+  cache.fetch('type').then(defineType);
+  cache.fetch('selectedItem').then(load);
 
-    appstate.register('project', function (project) {
-      session.base.project = project;
-      validate.process(dependencies)
-      .then(init);
+  // start the module up
+  startup();
+
+  function startup() {
+    session.base.project = Session.project;
+    validate.process(dependencies)
+    .then(init);
+  }
+
+  function init(models) {
+    var entities = models.entities = [];
+    models.debtors.data.forEach(function (debtor) {
+      debtor.type = 'd';
+      entities.push(debtor);
     });
 
-    function init (models) {
-      var entities = models.entities = [];
-      models.debtors.data.forEach(function (debtor) {
-        debtor.type = 'd';
-        entities.push(debtor);
-      });
+    models.creditors.data.forEach(function (creditor) {
+      creditor.type = 'c';
+      entities.push(creditor);
+    });
 
-      models.creditors.data.forEach(function (creditor) {
-        creditor.type = 'c';
-        entities.push(creditor);
-      });
-
-      angular.extend($scope, models);
-    }
-
-    function setCashAccount(cashAccount) {
-      if (cashAccount) {
-        session.base.selectedItem = cashAccount;
-        cache.put('selectedItem', cashAccount);
-      }
-    }
-
-    function defineType (type){
-      if (!type) { return ; }
-      session.data.type = type;
-    }
-
-    function load (selectedItem) {
-      if (!selectedItem) { return ; }
-      session.base.selectedItem = selectedItem;
-    }
-
-    function valid (){
-      return session.data.deb_cred && session.data.value;
-    }
-
-    function submit (){
-      var document_uuid = uuid();
-
-      var primary_cash = {
-        uuid          : uuid(),
-        project_id    : session.base.project.id,
-        type          : 'S',
-        date          : util.sqlDate(new Date()),
-        deb_cred_uuid : session.data.deb_cred.uuid,
-        deb_cred_type : session.data.type,
-        currency_id   : session.base.selectedItem.currency_id,
-        account_id    : session.data.deb_cred.id,
-        cost          : session.data.value,
-        user_id       : Session.user.id,
-        description   : session.data.description,
-        cash_box_id   : session.base.cashbox,
-        origin_id     : $scope.modules.data[0].id
-      };
-
-      var primary_cash_item = {
-        uuid              : uuid(),
-        primary_cash_uuid : primary_cash.uuid,
-        debit             : 0,
-        credit            : primary_cash.cost,
-        document_uuid     : document_uuid
-      };
-
-      connect.post('primary_cash', primary_cash)
-      .then(function (){
-        return connect.post('primary_cash_item', primary_cash_item);
-      })
-      .then(function (){
-        return connect.fetch('/journal/cash_return/' + primary_cash.uuid);
-      })
-      .then(function () {
-        session.data = {};
-        messenger.success($translate.instant('CASH_RETURN.SUBMIT_SUCCESS'));
-      })
-      .then(function () {
-        $location.path('/invoice/cash_return/' + primary_cash.uuid);
-      })
-      .catch(function (err) {
-        messenger.danger($translate.instant('CASH_RETURN.SUBMIT_FAILED'));
-      });
-    }
-
-    function setType (type){
-      if (type) {
-        session.data.type = type;
-        cache.put('type', type);
-      }
-    }
-
-    function getCredDeb () {
-      session.data.description = [session.base.project.abbr, 'REMBOUR_C.P', session.data.deb_cred.text, session.data.type].join('/');
-    }
-
-    $scope.setCashAccount = setCashAccount;
-    $scope.valid = valid;
-    $scope.setType = setType;
-    $scope.submit = submit;
-    $scope.getCredDeb = getCredDeb;
+    angular.extend($scope, models);
   }
-]);
+
+  function setCashAccount(cashAccount) {
+    if (cashAccount) {
+      session.base.selectedItem = cashAccount;
+      cache.put('selectedItem', cashAccount);
+    }
+  }
+
+  function defineType(type) {
+    if (!type) { return ; }
+    session.data.type = type;
+  }
+
+  function load(selectedItem) {
+    if (!selectedItem) { return ; }
+    session.base.selectedItem = selectedItem;
+  }
+
+  function valid() {
+    return session.data.deb_cred && session.data.value && session.base.selectedItem;
+  }
+
+  function submit() {
+    var document_uuid = uuid();
+
+    var primary_cash = {
+      uuid          : uuid(),
+      project_id    : session.base.project.id,
+      type          : 'S',
+      date          : util.sqlDate(new Date()),
+      deb_cred_uuid : session.data.deb_cred.uuid,
+      deb_cred_type : session.data.type,
+      currency_id   : session.base.selectedItem.currency_id,
+      account_id    : session.data.deb_cred.id,
+      cost          : session.data.value,
+      user_id       : Session.user.id,
+      description   : session.data.description,
+      cash_box_id   : session.base.cashbox,
+      origin_id     : $scope.modules.data[0].id
+    };
+
+    var primary_cash_item = {
+      uuid              : uuid(),
+      primary_cash_uuid : primary_cash.uuid,
+      debit             : 0,
+      credit            : primary_cash.cost,
+      document_uuid     : document_uuid
+    };
+
+    connect.post('primary_cash', primary_cash)
+    .then(function () {
+      return connect.post('primary_cash_item', primary_cash_item);
+    })
+    .then(function () {
+      return connect.fetch('/journal/cash_return/' + primary_cash.uuid);
+    })
+    .then(function () {
+      session.data = {};
+      messenger.success($translate.instant('CASH_RETURN.SUBMIT_SUCCESS'));
+    })
+    .then(function () {
+      $location.path('/invoice/cash_return/' + primary_cash.uuid);
+    })
+    .catch(function (err) {
+      messenger.danger($translate.instant('CASH_RETURN.SUBMIT_FAILED'));
+    });
+  }
+
+  function setType(type) {
+    if (type) {
+      session.data.type = type;
+      cache.put('type', type);
+    }
+  }
+
+  function getCredDeb() {
+    session.data.description = [session.base.project.abbr, 'REMBOUR_C.P', session.data.deb_cred.text, session.data.type].join('/');
+  }
+
+  $scope.setCashAccount = setCashAccount;
+  $scope.valid = valid;
+  $scope.setType = setType;
+  $scope.submit = submit;
+  $scope.getCredDeb = getCredDeb;
+}


### PR DESCRIPTION
Fixes #711.

This commit ensures that the user cannot submit the cash reimbursement
form without first selecting a currency id.  Additionally, it uses form
`<label>` elements instead of input groups render to form, to be more in
line with bhima's style so far.  Finally, the HTML has been cleaned up a fair amount.