### PR TITLE
CHORE(build): ensure js minification works

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -103,8 +103,9 @@ gulp.task('client-lint-js', function () {
 // writes output to bhima.min.js
 gulp.task('client-minify-js', function () {
   return gulp.src(paths.client.javascript)
-    .pipe(iife())
+    .pipe(gulpif(UGLIFY, uglify({ mangle: true })))
     .pipe(concat('js/bhima.min.js'))
+    .pipe(iife())
     .pipe(gulp.dest(CLIENT_FOLDER));
 });
 
@@ -124,15 +125,15 @@ gulp.task('client-mv-vendor', function () {
     .pipe(gulp.dest(CLIENT_FOLDER + 'vendor/'));
 });
 
-// SlickGrid repository is very modular and does not include distribution folder 
-// This build process combines all required components for BHIMA and optionally 
+// SlickGrid repository is very modular and does not include distribution folder
+// This build process combines all required components for BHIMA and optionally
 // minifies the output
-gulp.task('client-vendor-build-slickgrid', function () { 
-  
+gulp.task('client-vendor-build-slickgrid', function () {
+
   // Specifiy components required by BHIMA
   var slickgridComponents = [
     'client/vendor/slickgrid/lib/jquery.event.*.js',
-    'client/vendor/slickgrid/*.js', 
+    'client/vendor/slickgrid/*.js',
     'client/vendor/slickgrid/plugins/*.js'
   ];
 
@@ -248,7 +249,7 @@ gulp.task('client-test-e2e', function () {
 
 // ensure that the server actually runs
 gulp.task('server-test-run', function () {
-  spawn('node', [path.join(SERVER_FOLDER, 'app.js')], {stdio: 'inherit'}); 
+  spawn('node', [path.join(SERVER_FOLDER, 'app.js')], {stdio: 'inherit'});
 });
 
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
This commit creates the options available for JavaScript minification in
production.  The options here have been tested, and reduce the bhima script
size by more than 50%.

Additionally, the order of IIFE has been change so that a single IIFE
wraps the entire bhima script, rather than multiple created for each
bhima javascript file.  This should produce smaller file sizes and
slight performance improvements.

**NOTE**: The minification option is still turned off in this commit.  It should be turned on in production.