### PR TITLE
CHORE(cost center): structure/style improvments

### DIFF
--- a/client/src/js/app.js
+++ b/client/src/js/app.js
@@ -292,7 +292,7 @@ function bhimaconfig($routeProvider) {
     templateUrl: 'partials/cost_center/center/analysis_center.html'
   })
   .when('/cost_center/assigning/', {
-    controller: 'costCenter.assigning',
+    controller: 'CostCenterAssignmentController',
     templateUrl: 'partials/cost_center/assigning/assigning.html'
   })
   .when('/cost_center/allocation/', {

--- a/client/src/partials/cost_center/allocation/allocation.css
+++ b/client/src/partials/cost_center/allocation/allocation.css
@@ -1,4 +1,0 @@
-.versement-header {
-  height: 50%;
-  overflow: auto;
-}

--- a/client/src/partials/cost_center/allocation/allocation.html
+++ b/client/src/partials/cost_center/allocation/allocation.html
@@ -1,107 +1,98 @@
 <header data-header>
-  {{'VERSEMENT.TITLE' | translate}}
+  {{ 'VERSEMENT.TITLE' | translate }}
 </header>
 
 <nav>
   <div class="pull-left">
     <ol class="breadcrumb">
-      <li><a href="#/"><span class="glyphicon glyphicon-home"></span></a></li>
+      <li><a href="#/"><i class="glyphicon glyphicon-home"></i></a></li>
       <li><a href="#/cost_center">{{ "VERSEMENT.PARENT" | translate }}</a></li>
       <li class="active">{{ "VERSEMENT.TITLE" | translate }}</li>
     </ol>
   </div>
 </nav>
 
-<main>
+<main class="extend margin-top-10">
   <div class="panel panel-default">
-    <div class="panel-heading">
-      {{'VERSEMENT.CHOOSE' | translate}}
-    </div>
-    <div class="panel-body">
-      <form class="form">
-        <div class="form-group">
-          <select
-            class="col-xs-2 form-bhima"
-            ng-model="CenterCtrl.configuration.costCenter"
-            ng-options="cc as cc.text for cc in CenterCtrl.cost_centers.data"
-            ng-change="CenterCtrl.performChange()">
-          </select>
-        </div>
-      </form>
-    </div>
+    <div class="panel-heading">{{ 'VERSEMENT.CHOOSE' | translate }}</div>
+    <form class="form panel-body">
+      <select
+        class="form-bhima"
+        ng-model="CenterCtrl.configuration.costCenter"
+        ng-options="cc as cc.text for cc in CenterCtrl.cost_centers.data"
+        ng-change="CenterCtrl.performChange()">
+        <option value="" disabled>-- {{ 'SELECT.COST_CENTER' | translate }} --</option>
+      </select>
+    </form>
   </div>
 
   <div class="row">
-
     <div class="col-xs-6">
-      <div class="panel panel-default">
-        <div class="panel-heading" style="height: 50px;">
-          <span> {{ 'VERSEMENT.AVAILABLE_ACCOUNT' | translate}} {{ CenterCtrl.selected.text }}</span>
+      <div class="panel panel-default" style="height: 500px; overflow:auto;">
+        <div class="panel-heading clearfix">
+          {{ 'VERSEMENT.AVAILABLE_ACCOUNT' | translate }} {{ CenterCtrl.selected.text }}
           <span class="pull-right">
-            <span ng-if="CenterCtrl.state === 'loading'">
-              <loading-indicator></loading-indicator>
-            </span>
             <button
               ng-disabled="!CenterCtrl.isAssignable()"
-              ng-click="CenterCtrl.assign()" 
+              ng-click="CenterCtrl.assign()"
               ng-if="CenterCtrl.state !== 'loading'"
-              class="btn btn-sm btn-default"
-              type="submit">
-              {{'VERSEMENT.VERSER' | translate}}
+              class="btn btn-sm btn-default">
+              {{ 'VERSEMENT.VERSER' | translate }}
             </button>
           </span>
         </div>
-        <div class="panel-body versement-header">
-          <table class="table table-condensed table-striped">
-            <thead>
-              <tr>
-                <th><input type="checkbox" ng-model="CenterCtrl.checkAvailable.all" ng-change="CenterCtrl.checkAllAvailable()"/></th>
-                <th>Account Number</th>
-                <th>Account Name</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr ng-repeat="account in CenterCtrl.availableAccounts.data">
-                <td><input type="checkbox" ng-model="account.checked"/></td>
-                <td>{{ account.account_number }}</td>
-                <td>{{ account.account_txt }}</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+        <table class="table table-condensed table-striped">
+          <thead>
+            <tr>
+              <th><input type="checkbox" ng-model="CenterCtrl.checkAvailable.all" ng-change="CenterCtrl.checkAllAvailable()"/></th>
+              <th>{{ 'COLUMNS.ACCOUNT_NUMBER' | translate }}</th>
+              <th>{{ 'COLUMNS.ACCOUNT' | translate }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr class="text-center" ng-if="CenterCtrl.state === 'loading'">
+              <td colspan="3"><loading-indicator></loading-indicator></td>
+            </tr>
+            <tr ng-repeat="account in CenterCtrl.availableAccounts.data">
+              <td><input type="checkbox" ng-model="account.checked"/></td>
+              <td>{{ account.account_number }}</td>
+              <td>{{ account.account_txt }}</td>
+            </tr>
+          </tbody>
+        </table>
       </div>
     </div>
 
     <div class="col-xs-6">
-      <div class="panel panel-primary">
-        <div class="panel-heading" style="height: 50px;">
-          {{ 'VERSEMENT.ASSOCIATED_TO' | translate }} <b>{{ CenterCtrl.selectedCostCenter.text }}
-            <span ng-if="!CenterCtrl.selectedCostCenter">{{'VERSEMENT.PLEASE_SELECT' | translate}}</span></b>
+      <div class="panel panel-primary" style="height: 500px; overflow-y:auto;">
+        <div class="panel-heading clearfix">
+          {{ 'VERSEMENT.ASSOCIATED_TO' | translate }}
+          <strong>
+            {{ CenterCtrl.selectedCostCenter.text }}
+            <span ng-if="!CenterCtrl.selectedCostCenter">{{ 'VERSEMENT.PLEASE_SELECT' | translate }}</span>
+          </strong>
           <span class="pull-right">
-            <button ng-disabled="!CenterCtrl.isRemovable()" class="btn btn-sm btn-default" type="submit" ng-click="CenterCtrl.remove()">
+            <button ng-disabled="!CenterCtrl.isRemovable()" class="btn btn-sm btn-default" ng-click="CenterCtrl.remove()">
               {{ 'VERSEMENT.REMOVE' | translate }}
             </button>
           </span>
         </div>
-
-        <div class="panel-body versement-header">
-          <table class="table table-condensed table-striped">
-            <thead>
-              <tr>
-                <th><input type="checkbox" ng-model="CenterCtrl.checkAssociated.all" ng-change="CenterCtrl.checkAllAssociated()"/></th>
-                <th>Account Number</th>
-                <th>Account Name</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr ng-repeat="associatedAccount in CenterCtrl.associatedAccounts.data">
+        <table class="table table-condensed table-striped">
+          <thead>
+            <tr>
+              <th><input type="checkbox" ng-model="CenterCtrl.checkAssociated.all" ng-change="CenterCtrl.checkAllAssociated()"/></th>
+              <th>{{ 'COLUMNS.ACCOUNT_NUMBER' | translate }}</th>
+              <th>{{ 'COLUMNS.ACCOUNT' | translate }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr ng-repeat="associatedAccount in CenterCtrl.associatedAccounts.data">
               <td><input type="checkbox" ng-model="associatedAccount.checked"/></td>
               <td>{{ associatedAccount.account_number }}</td>
               <td>{{ associatedAccount.account_txt }}</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+            </tr>
+          </tbody>
+        </table>
       </div>
     </div>
   </div>

--- a/client/src/partials/cost_center/allocation/allocation.js
+++ b/client/src/partials/cost_center/allocation/allocation.js
@@ -6,10 +6,10 @@ CostCenterAllocationController.$inject = [
 ];
 
 /**
-  * Cost Center Allocation Controller
-  * This controller is reponsible to manage Accoount deposit (versement)
-  */
-function CostCenterAllocationController ($q, connect, appstate,validate, SessionService) {
+* Cost Center Allocation Controller
+* This controller is reponsible to manage Accoount deposit (versement)
+*/
+function CostCenterAllocationController($q, connect, appstate,validate, SessionService) {
   var vm            = this,
       dependencies  = {},
       configuration = vm.configuration = {};
@@ -113,6 +113,9 @@ function CostCenterAllocationController ($q, connect, appstate,validate, Session
     return connect.req('/removeFromCostCenter/'+JSON.stringify(data));
   }
 
+  // TODO -- this function can potentially send lots of HTTP requests.  We
+  // should refactor this into a single API endpoint to send a list of accounts
+  // to.
   function updateAccounts(accounts) {
     return $q.all(
       accounts.map(function (account) {
@@ -154,5 +157,4 @@ function CostCenterAllocationController ($q, connect, appstate,validate, Session
   function error(err) {
     console.error(err);
   }
-
 }

--- a/client/src/partials/cost_center/assigning/assigning.css
+++ b/client/src/partials/cost_center/assigning/assigning.css
@@ -1,4 +1,0 @@
-.assigning-header {
-  height: 200px;
-  overflow: auto;
-}

--- a/client/src/partials/cost_center/assigning/assigning.html
+++ b/client/src/partials/cost_center/assigning/assigning.html
@@ -5,131 +5,122 @@
 <nav>
   <div class="pull-left">
     <ol class="breadcrumb">
-      <li><a href="#/"><span class="glyphicon glyphicon-home"></span></a></li>
+      <li><a href="#/"><i class="glyphicon glyphicon-home"></i></a></li>
       <li><a href="#/cost_center">{{ "ASSIGNING.PARENT" | translate }}</a></li>
       <li class="active">{{ "ASSIGNING.TITLE" | translate }}</li>
     </ol>
   </div>
 </nav>
 
-<main>
+<main class="extend margin-top-10">
+
   <div class="panel panel-default" ng-if="action!='suivant'">
-    <div class="panel-heading">
-      {{ 'ASSIGNING.CHOOSE' | translate}}
-    </div>
-    <div class="panel-body">
-      <form>
-        <div class="form-group">
-          <select class="col-xs-2 form-bhima" ng-model="configuration.aux_cost_center" ng-change="performChange()">
-            <option value="{{cc}}" ng-repeat="cc in model.aux_cost_centers.data  | orderBy:'text'">{{cc.text}}</option>
-          </select>
+    <div class="panel-heading">{{ 'ASSIGNING.CHOOSE' | translate }}</div>
+    <form class="panel-body">
+      <select class="form-bhima" ng-model="configuration.aux_cost_center" ng-change="performChange()" ng-options="cc as cc.text for cc in model.aux_cost_centers.data  | orderBy:'text'">
+        <option value="" disabled>-- {{ 'SELECT.COST_CENTER' | translate }} --</option>
+      </select>
+    </form>
+  </div>
+
+  <div ng-switch="action">
+    <div ng-switch-default class="row">
+      <div class="col-xs-6">
+        <div class="panel panel-default">
+          <div class="panel-heading clearfix">
+            <span>{{ 'ASSIGNING.INFO_COST_CENTER' | translate }} {{ selected.text }}</span>
+          </div>
+          <div class="panel-body">
+            <div ng-if="selected_aux_cost_center">
+              <div class="form-group">
+                <label>{{ "ASSIGNING.LABEL_CC" | translate }}</label>
+                <p class="form-control-static">{{ selected_aux_cost_center.text }}</p>
+              </div>
+
+              <div class="form-group">
+                <label>{{ "ASSIGNING.TYPE_CC" | translate }}</label>
+                <p class="form-control-static">{{ 'ASSIGNING.AUX_CC' | translate }}</p>
+              </div>
+
+              <div class="form-group">
+                <label>{{ "ASSIGNING.NOTE" | translate }}</label>
+                <p class="form-control-static">{{ selected_aux_cost_center.note }}</p>
+              </div>
+            </div>
+            <div ng-if="!selected_aux_cost_center" class="alert alert-warning">
+              {{ 'ASSIGNING.NO_CHOOSEN' | translate }}
+            </div>
+          </div>
         </div>
-      </form>
+      </div>
+
+    <div class="col-xs-6">
+      <div class="panel panel-primary" style="max-height:500px; overflow:auto;">
+        <div class="panel-heading clearfix">
+          <span>
+            {{ 'ASSIGNING.ASSOCIATED_TO' | translate }} <b>{{ selected_aux_cost_center.text }}<span ng-if="!selected_aux_cost_center">{{ 'ASSIGNING.PLEASE_SELECT' | translate }}</span></b>
+          </span>
+          <span class="pull-right">
+            <button ng-disabled="!isForwardable()" class="btn btn-default" type="submit" ng-click="suivant()"> {{ 'ASSIGNING.NEXT' | translate }}</button>
+          </span>
+        </div>
+        <table class="table table-condensed table-striped">
+          <thead>
+            <tr>
+              <th><input type="checkbox" ng-model="cc.all" ng-change="checkAll()"/></th>
+              <th>{{ 'ASSIGNING.PRI_CENTERS' | translate }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr ng-repeat="pri_cost_center in model.pri_cost_centers.data | orderBy:'text'">
+              <td><input type="checkbox" ng-model="pri_cost_center.checked"/></td>
+              <td>{{ pri_cost_center.text }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </div>
   </div>
 
-  <div class="row">
-    <div class="col-xs-12" ng-switch="action">
-      <div ng-switch-default>
-        <div class="col-xs-6">
-          <div class="panel panel-default">
-            <div class="panel-heading" style="height: 50px;">
-              <span> {{ 'ASSIGNING.INFO_COST_CENTER' | translate}} {{selected.text}} </span>
-            </div>
-            <div class="panel-body assigning-header">
-              <div ng-if="selected_aux_cost_center">
-                <div class="form-group">
-              <label class="control-label">{{ "ASSIGNING.LABEL_CC" | translate }}</label>
-              <br>
-              {{selected_aux_cost_center.text}}
-            </div>
+  <div ng-switch-when="suivant">
+    <div class="panel panel-primary" style="max-height:600px; overflow:auto;">
+      <div class="panel-heading clearfix">
+        <span>
+          {{ 'ASSIGNING.AUX_CENTER' | translate }} : <b>{{ selected_aux_cost_center.text }}</b>
+          {{ 'ASSIGNING.COST' | translate }} : <b>{{ selected_aux_cost_center.cost | currency}}</b>
+        </span>
 
-            <div class="form-group">
-              <label class="control-label">{{ "ASSIGNING.TYPE_CC" | translate }}</label>
-              <br>
-              {{ 'ASSIGNING.AUX_CC' | translate}}
-            </div>
-
-            <div class="form-group">
-              <label class="control-label">{{ "ASSIGNING.NOTE" | translate }}</label>
-              <br>
-              {{selected_aux_cost_center.note}}
-            </div>
-          </div>
-          <div ng-if="!selected_aux_cost_center" class="alert alert-warning square"> {{ 'ASSIGNING.NO_CHOOSEN' | translate}}</div>
-            </div>
-          </div>
-        </div>
-
-        <div class="col-xs-6">
-          <div class="panel panel-primary">
-            <div class="panel-heading" style="height: 50px;">
-              <span>
-                {{ 'ASSIGNING.ASSOCIATED_TO' | translate}} <b>{{selected_aux_cost_center.text}}<span ng-if="!selected_aux_cost_center">{{ 'ASSIGNING.PLEASE_SELECT' | translate}}</span></b>
-              </span>
-              <span class="pull-right">
-                <button ng-disabled="!isForwardable()" class="btn btn-default" type="submit" ng-click="suivant()"> {{ 'ASSIGNING.NEXT' | translate}}</button>
-              </span>
-            </div>
-
-            <div class="panel-body assigning-header">
-              <table class="table table-condensed table-striped">
-                <thead>
-                  <tr><th><input type="checkbox" ng-model="cc.all" ng-change="checkAll()"/></th><th>{{ 'ASSIGNING.PRI_CENTERS' | translate}}</th></tr>
-                </thead>
-                <tbody>
-                  <tr ng-repeat="pri_cost_center in model.pri_cost_centers.data | orderBy:'text'">
-                    <td><input type="checkbox" ng-model="pri_cost_center.checked"/></td>
-                    <td>{{pri_cost_center.text}}</td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </div>
-        </div>
-    </div>
-
-    <div ng-switch-when="suivant">
-      <div class="panel panel-primary">
-        <div class="panel-heading" style="height: 50px;">
-          <span>
-            {{ 'ASSIGNING.AUX_CENTER' | translate}} : <b>{{selected_aux_cost_center.text}}</b>
-            {{ 'ASSIGNING.COST' | translate}} : <b>{{selected_aux_cost_center.cost | currency}}</b>
-          </span>
-          <span class="pull-right">
-            <button type="submit" ng-click="apply()" class="btn btn-default">Apply</button>
-          </span>
-        </div>
-        <div class="panel-body" style="height : 100%;">
-          <table class="table table-condensed table-bordered">
-            <thead>
-              <tr>
-                <th>{{ 'ASSIGNING.PRI_CENTERS' | translate}}</th>
-                <th>{{ 'ASSIGNING.INITIAL_COST' | translate}}</th>
-                <th>{{ 'ASSIGNING.COEFF' | translate}}</th>
-                <th>{{ 'ASSIGNING.AL_COST' | translate}}</th>
-                <th>{{ 'ASSIGNING.TOTAL' | translate}}</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr ng-repeat="pcs in model.selected_pri_cost_centers">
-                <td>{{pcs.text}}</td>
-                <td>{{pcs.initial_cost}}</td>
-                <td><input type="number" ng-model="pcs.criteriaValue" ng-change="calculate()" class="form-invoice"></td>
-                <td>{{pcs.allocatedCost}}</td>
-                <td>{{pcs.totalCost}}</td>
-              </tr>
-            </tbody>
-            <tfoot>
-              <tr>
-                <td><b>{{ 'ASSIGNING.TOTALS' | translate}}</b></td>
-                <td colspan="3" align="right"><b>{{getTotalAllocatedCost() | currency}}</b></td>
-                <td colspan="4"><b>{{getTotal() | currency}}<b/></td>
-              </tr>
-            </tfoot>
-          </table>
-        </div>
+        <span class="pull-right">
+          <button type="submit" ng-click="apply()" class="btn btn-default">Apply</button>
+        </span>
       </div>
+      <table class="table table-condensed table-bordered">
+        <thead>
+          <tr>
+            <th>{{ 'ASSIGNING.PRI_CENTERS' | translate }}</th>
+            <th>{{ 'ASSIGNING.INITIAL_COST' | translate }}</th>
+            <th>{{ 'ASSIGNING.COEFF' | translate }}</th>
+            <th>{{ 'ASSIGNING.AL_COST' | translate }}</th>
+            <th>{{ 'ASSIGNING.TOTAL' | translate }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr ng-repeat="pcs in model.selected_pri_cost_centers track by pcs.id">
+            <td>{{ pcs.text }}</td>
+            <td class="text-right">{{ pcs.initial_cost | currency:enterprise.currency_id }}</td>
+            <td><input type="number" ng-model="pcs.criteriaValue" ng-change="calculate()" class="form-invoice"></td>
+            <td class="text-right">{{ pcs.allocatedCost | currency:enterprise.currency_id }}</td>
+            <td class="text-right">{{ pcs.totalCost | currency:enterprise.currency_id }}</td>
+          </tr>
+        </tbody>
+        <tfoot>
+          <tr>
+            <th>{{ 'ASSIGNING.TOTALS' | translate }}</th>
+            <th colspan="3" class="text-right">{{ getTotalAllocatedCost() | currency:enterprise.currency_id }}</th>
+            <th colspan="4" class="text-right">{{ getTotal() | currency }}</th>
+          </tr>
+        </tfoot>
+      </table>
     </div>
   </div>
 </main>

--- a/client/src/partials/cost_center/assigning/assigning.js
+++ b/client/src/partials/cost_center/assigning/assigning.js
@@ -1,207 +1,207 @@
 angular.module('bhima.controllers')
-.controller('costCenter.assigning', [
-  '$scope',
-  '$q',
-  'connect',
-  'appstate',
-  'messenger',
-  'validate',
-  'util',
-  '$translate',
-  'SessionService',
-  function ($scope, $q, connect, appstate, messenger, validate, util, $translate, SessionService) {
-    var dependencies = {},
-        config = $scope.configuration = {};
+.controller('CostCenterAssignmentController', CostCenterAssignmentController);
 
-    dependencies.aux_cost_centers = {
-      query : {
-        tables : {
-          'cost_center' : {
-            columns : ['id', 'text', 'note']
-          }
+CostCenterAssignmentController.$inject = [
+  '$scope', '$q', 'connect', 'appstate', 'messenger', 'validate',
+  'util', '$translate', 'SessionService'
+];
+
+/**
+* Cost Center Assignment Controller
+*/
+function CostCenterAssignmentController($scope, $q, connect, appstate, messenger, validate, util, $translate, Session) {
+  var dependencies = {},
+      config = $scope.configuration = {};
+
+  dependencies.aux_cost_centers = {
+    query : {
+      tables : {
+        'cost_center' : {
+          columns : ['id', 'text', 'note']
+        }
+      },
+      where : ['cost_center.is_principal=0']
+    }
+  };
+
+  dependencies.pri_cost_centers = {
+    query : {
+      tables : {
+        'cost_center' : {
+          columns : ['id', 'text', 'note']
         },
-        where : ['cost_center.is_principal=0']
-      }
-    };
-
-    dependencies.pri_cost_centers = {
-      query : {
-        tables : {
-          'cost_center' : {
-            columns : ['id', 'text', 'note']
-          },
-        },
-        where : ['cost_center.is_principal=1']
-      }
-    };
-
-    startup();
-
-    function startup() {
-      $scope.project = SessionService.project;
-      validate.process(dependencies)
-      .then(init)
-      .catch(error);
+      },
+      where : ['cost_center.is_principal=1']
     }
+  };
 
-    function init(model) {
-      $scope.model = model;
-      $scope.cc = {};
-      $scope.cc.all = false;
-    }
+  startup();
 
-    function performChange() {
-      $scope.selected_aux_cost_center = JSON.parse(config.aux_cost_center);
-    }
-
-    function isForwardable() {
-      if (!$scope.selected_aux_cost_center) { return false; }
-      if (!$scope.model.pri_cost_centers.data.length) { return false; }
-      return $scope.model.pri_cost_centers.data.some(function (account) {
-        return account.checked;
-      });
-    }
-
-    function checkAll() {
-      $scope.model.pri_cost_centers.data.forEach(function (item) {
-        item.checked = $scope.cc.all;
-      });
-    }
-
-    function setAction(action) {
-      $scope.action = action;
-    }
-
-    function processSelectedCost(cc) {
-      return connect.req('/cost/'+ $scope.project.id + '/' + cc.id);
-    }
-
-    function suivant() {
-      $scope.model.selected_pri_cost_centers = $scope.model.pri_cost_centers.data.filter(function (cc) {
-        return cc.checked;
-      });
-
-      processSelectedCost($scope.selected_aux_cost_center)
-      .then(handleResult)
-      .then(processPrincipalsCenters)
-      .then(handleResults)
-      .then(function() {
-        setAction('suivant');
-        calculate();
-      })
-      .catch(error);
-    }
-
-    function processPrincipalsCenters() {
-      $scope.model.selected_pri_cost_centers.forEach(function (pc) {
-        pc.criteriaValue = 1;
-      });
-      return $q.all(
-        $scope.model.selected_pri_cost_centers.map(function (pc) {
-          return processSelectedCost(pc);
-        })
-      );
-    }
-
-    function handleResult(cout) {      
-      $scope.selected_aux_cost_center.cost = cout.data.cost;
-      return $q.when();
-    }
-
-    function handleResults(couts) {
-      couts.forEach(function (cout, index) {
-        $scope.model.selected_pri_cost_centers[index].initial_cost = cout.data.cost;
-      });
-      return $q.when();
-    }
-
-    function calculate() {
-      var somCritereValue = 0;
-      $scope.model.selected_pri_cost_centers.forEach(function (item) {
-        somCritereValue+=item.criteriaValue;
-      });
-      $scope.model.selected_pri_cost_centers.forEach(function (item) {
-        item.allocatedCost = $scope.selected_aux_cost_center.cost * (item.criteriaValue / somCritereValue);
-        item.allocatedCost = item.allocatedCost || 0;
-        item.totalCost = item.initial_cost + item.allocatedCost;
-      });
-    }
-
-    function getTotalAllocatedCost() {
-      var som = 0;
-      $scope.model.selected_pri_cost_centers.forEach(function (item) {
-        som += item.allocatedCost || 0;
-      });
-      return som;
-    }
-
-    function getTotal() {
-      var som = 0;
-      $scope.model.selected_pri_cost_centers.forEach(function (item) {
-        som += item.totalCost || 0;
-      });
-      return som;
-    }
-
-    function apply() {
-      sanitize()
-      .then(writeAssignation)
-      .then(writeAssignationItem)
-      .then(handleSucess)
-      .catch(handleApplyError);
-    }
-
-    function sanitize() {
-      $scope.assignation = {
-        project_id : $scope.project.id,
-        auxi_cc_id : $scope.selected_aux_cost_center.id,
-        cost       : $scope.selected_aux_cost_center.cost,
-        date       : util.sqlDate(new Date()),
-        note       : 'Assignation/'+$scope.selected_aux_cost_center.text+'/'+new Date().toString()
-      };
-
-      $scope.assignation_items = [];
-      $scope.model.selected_pri_cost_centers.forEach(function (pc) {
-        var ass_item = {
-          pri_cc_id : pc.id,
-          init_cost : pc.initial_cost,
-          value_criteria : pc.criteriaValue
-        };
-        $scope.assignation_items.push(ass_item);
-      });
-      return $q.when();
-    }
-
-    function writeAssignation () {
-      return connect.basicPut('cost_center_assignation', [$scope.assignation]);
-    }
-
-    function writeAssignationItem (model) {
-      $scope.assignation_items.forEach(function (item) {
-        item.cost_center_assignation_id = model.data.insertId;
-      });
-      return connect.basicPut('cost_center_assignation_item', $scope.assignation_items);
-    }
-
-    function handleSucess () {
-      messenger.success($translate.instant('ASSIGNING.INSERT_SUCCES_MESSAGE'));
-    }
-
-    function handleApplyError () {
-      messenger.danger($translate.instant('SERVICE.INSERT_FAIL_MESSAGE'));
-    }
-
-    function error(err) {
-      console.log('Error: ', err);
-    }
-
-    $scope.performChange = performChange;
-    $scope.checkAll = checkAll;
-    $scope.isForwardable = isForwardable;
-    $scope.suivant = suivant;
-    $scope.calculate = calculate;
-    $scope.getTotalAllocatedCost = getTotalAllocatedCost;
-    $scope.getTotal = getTotal;
-    $scope.apply = apply;
+  function startup() {
+    $scope.project = Session.project;
+    $scope.enterprise = Session.enterprise;
+    validate.process(dependencies)
+    .then(init)
+    .catch(error);
   }
-]);
+
+  function init(model) {
+    $scope.model = model;
+    $scope.cc = {};
+    $scope.cc.all = false;
+  }
+
+  function performChange() {
+    $scope.selected_aux_cost_center = config.aux_cost_center;
+  }
+
+  function isForwardable() {
+    if (!$scope.selected_aux_cost_center) { return false; }
+    if (!$scope.model.pri_cost_centers.data.length) { return false; }
+    return $scope.model.pri_cost_centers.data.some(function (account) {
+      return account.checked;
+    });
+  }
+
+  function checkAll() {
+    $scope.model.pri_cost_centers.data.forEach(function (item) {
+      item.checked = $scope.cc.all;
+    });
+  }
+
+  function setAction(action) {
+    $scope.action = action;
+  }
+
+  function processSelectedCost(cc) {
+    return connect.req('/cost/'+ $scope.project.id + '/' + cc.id);
+  }
+
+  function suivant() {
+    $scope.model.selected_pri_cost_centers = $scope.model.pri_cost_centers.data.filter(function (cc) {
+      return cc.checked;
+    });
+
+    processSelectedCost($scope.selected_aux_cost_center)
+    .then(handleResult)
+    .then(processPrincipalsCenters)
+    .then(handleResults)
+    .then(function() {
+      setAction('suivant');
+      calculate();
+    })
+    .catch(error);
+  }
+
+  function processPrincipalsCenters() {
+    $scope.model.selected_pri_cost_centers.forEach(function (pc) {
+      pc.criteriaValue = 1;
+    });
+    return $q.all(
+      $scope.model.selected_pri_cost_centers.map(function (pc) {
+        return processSelectedCost(pc);
+      })
+    );
+  }
+
+  function handleResult(cout) {
+    $scope.selected_aux_cost_center.cost = cout.data.cost;
+    return $q.when();
+  }
+
+  function handleResults(couts) {
+    couts.forEach(function (cout, index) {
+      $scope.model.selected_pri_cost_centers[index].initial_cost = cout.data.cost;
+    });
+    return $q.when();
+  }
+
+  function calculate() {
+    var somCritereValue = 0;
+    $scope.model.selected_pri_cost_centers.forEach(function (item) {
+      somCritereValue+=item.criteriaValue;
+    });
+    $scope.model.selected_pri_cost_centers.forEach(function (item) {
+      item.allocatedCost = $scope.selected_aux_cost_center.cost * (item.criteriaValue / somCritereValue);
+      item.allocatedCost = item.allocatedCost || 0;
+      item.totalCost = item.initial_cost + item.allocatedCost;
+    });
+  }
+
+  function getTotalAllocatedCost() {
+    var som = 0;
+    $scope.model.selected_pri_cost_centers.forEach(function (item) {
+      som += item.allocatedCost || 0;
+    });
+    return som;
+  }
+
+  function getTotal() {
+    var som = 0;
+    $scope.model.selected_pri_cost_centers.forEach(function (item) {
+      som += item.totalCost || 0;
+    });
+    return som;
+  }
+
+  function apply() {
+    sanitize()
+    .then(writeAssignation)
+    .then(writeAssignationItem)
+    .then(handleSucess)
+    .catch(handleApplyError);
+  }
+
+  function sanitize() {
+    $scope.assignation = {
+      project_id : $scope.project.id,
+      auxi_cc_id : $scope.selected_aux_cost_center.id,
+      cost       : $scope.selected_aux_cost_center.cost,
+      date       : util.sqlDate(new Date()),
+      note       : 'Assignation/'+$scope.selected_aux_cost_center.text+'/'+new Date().toString()
+    };
+
+    $scope.assignation_items = [];
+    $scope.model.selected_pri_cost_centers.forEach(function (pc) {
+      var ass_item = {
+        pri_cc_id : pc.id,
+        init_cost : pc.initial_cost,
+        value_criteria : pc.criteriaValue
+      };
+      $scope.assignation_items.push(ass_item);
+    });
+    return $q.when();
+  }
+
+  function writeAssignation () {
+    return connect.post('cost_center_assignation', [ $scope.assignation ]);
+  }
+
+  function writeAssignationItem (model) {
+    $scope.assignation_items.forEach(function (item) {
+      item.cost_center_assignation_id = model.data.insertId;
+    });
+    return connect.post('cost_center_assignation_item', $scope.assignation_items);
+  }
+
+  function handleSucess () {
+    messenger.success($translate.instant('ASSIGNING.INSERT_SUCCES_MESSAGE'));
+  }
+
+  function handleApplyError () {
+    messenger.danger($translate.instant('SERVICE.INSERT_FAIL_MESSAGE'));
+  }
+
+  function error(err) {
+    console.log('Error: ', err);
+  }
+
+  $scope.performChange = performChange;
+  $scope.checkAll = checkAll;
+  $scope.isForwardable = isForwardable;
+  $scope.suivant = suivant;
+  $scope.calculate = calculate;
+  $scope.getTotalAllocatedCost = getTotalAllocatedCost;
+  $scope.getTotal = getTotal;
+  $scope.apply = apply;
+}

--- a/client/src/partials/cost_center/center/analysis_center.css
+++ b/client/src/partials/cost_center/center/analysis_center.css
@@ -1,4 +1,0 @@
-.principal-header {
-  height: 500px;
-  overflow: auto;
-}

--- a/client/src/partials/cost_center/center/analysis_center.html
+++ b/client/src/partials/cost_center/center/analysis_center.html
@@ -1,11 +1,11 @@
 <header data-header>
-  {{'ANALYSIS_CENTER.TITLE' | translate }}
+  {{ 'ANALYSIS_CENTER.TITLE' | translate }}
 </header>
 
 <nav>
   <div class="pull-left">
     <ol class="breadcrumb">
-      <li><a href="#/"><span class="glyphicon glyphicon-home"></span></a></li>
+      <li><a href="#/"><i class="glyphicon glyphicon-home"></i></a></li>
       <li><a href="#/cost_center">{{ "ANALYSIS_CENTER.PARENT" | translate }}</a></li>
       <li class="active">{{ "ANALYSIS_CENTER.TITLE" | translate }}</li>
     </ol>
@@ -16,18 +16,11 @@
   </button>
 </nav>
 
-<main>
+<main class="extend margin-top-10">
   <div class="col-xs-6">
-    <div class="panel panel-primary" style="height : 100%; overflow : auto;">
+    <div class="panel panel-primary" style="max-height: 650px; overflow: auto;">
       <div class="panel-heading">
         {{ 'ANALYSIS_CENTER.REGISTERED' | translate }}
-
-        <!-- show loader for GET methods -->
-        <div class="pull-right">
-          <span ng-if="CenterCtrl.session.state === 'loading'">
-            <loading-indicator></loading-indicator>
-          </span>
-        </div>
       </div>
       <table class="table table-condensed table-striped">
         <thead>
@@ -37,8 +30,11 @@
           </tr>
         </thead>
         <tbody>
+          <tr ng-if="CenterCtrl.session.state === 'loading'" class="text-center">
+            <td colspan="3"><loading-indicator></loading-indicator></td>
+          </tr>
           <tr ng-repeat="cc in CenterCtrl.model.cost_centers.data  | orderBy:'text'">
-            <td>{{cc.text}}</td>
+            <td>{{cc.text }}</td>
             <td>
               <a class="action" ng-click="CenterCtrl.setAction('edit', cc)"><i class="glyphicon glyphicon-pencil"></i></a>
             </td>
@@ -47,9 +43,9 @@
             </td>
           </tr>
 
-          <tr ng-if="!CenterCtrl.model.cost_centers.data.length">
+          <tr ng-if="!CenterCtrl.model.cost_centers.data.length && CenterCtrl.session.state !== 'loading'">
             <td colspan="3">
-              <div class="alert alert-warning square">
+              <div class="alert alert-warning">
                 {{ 'ANALYSIS_CENTER.NONE_FOUND' | translate }}
               </div>
             </td>
@@ -70,15 +66,15 @@
     <div ng-switch-when="register">
       <form class="form-horizontal" name="newForm" novalidate>
         <fieldset>
-          <legend>{{'ANALYSIS_CENTER.REGISTER' | translate}}</legend>
-          <div class="form-group required">
-            <label class="col-xs-2 control-label"> {{'ANALYSIS_CENTER.TEXT' | translate}} </label>
+          <legend>{{ 'ANALYSIS_CENTER.REGISTER' | translate }}</legend>
+          <div class="form-group">
+            <label class="col-xs-2 control-label required"> {{ 'ANALYSIS_CENTER.TEXT' | translate }} </label>
             <div class="col-xs-10">
               <input class="form-bhima" ng-model="CenterCtrl.register.text" required>
             </div>
           </div>
 
-          <div class="form-group required">
+          <div class="form-group">
             <div class="col-sm-offset-2 col-sm-10">
               <div class="checkbox">
                 <label>
@@ -86,14 +82,14 @@
                     ng-true-value="1"
                     ng-false-value="0"
                     ng-model="CenterCtrl.register.is_principal">
-                  {{'ANALYSIS_CENTER.IS_PRINCIPAL' | translate}}
+                  {{ 'ANALYSIS_CENTER.IS_PRINCIPAL' | translate }}
                 </label>
               </div>
             </div>
           </div>
 
           <div class="form-group">
-            <label class="col-xs-2 control-label">{{'ANALYSIS_CENTER.NOTE' | translate}}</label>
+            <label class="col-xs-2 control-label">{{ 'ANALYSIS_CENTER.NOTE' | translate }}</label>
             <div class="col-xs-10">
               <textarea class="form-control" ng-model="CenterCtrl.register.note" rows="3">
               </textarea>
@@ -101,8 +97,8 @@
           </div>
 
           <div class="form-group pull-right">
-            <input ng-click="CenterCtrl.save()" ng-disabled="newForm.$invalid" class="btn btn-sm btn-success" type="submit" value="{{'FORM.SAVE' | translate}}">
-            <input class="btn btn-sm btn-default" type="reset" value="{{'FORM.RESET' | translate}}">
+            <input ng-click="CenterCtrl.save()" ng-disabled="newForm.$invalid" class="btn btn-sm btn-success" type="submit" value="{{ 'FORM.SAVE' | translate }}">
+            <input class="btn btn-sm btn-default" type="reset" value="{{ 'FORM.RESET' | translate }}">
           </div>
         </fieldset>
       </form>
@@ -112,16 +108,16 @@
     <div ng-switch-when="edit">
       <form class="form-horizontal">
         <fieldset>
-          <legend>{{'ANALYSIS_CENTER.MODIFYING' | translate}}</legend>
+          <legend>{{ 'ANALYSIS_CENTER.MODIFYING' | translate }}</legend>
 
-          <div class="form-group required">
-            <label class="col-xs-2 control-label">{{'ANALYSIS_CENTER.TEXT' | translate}}</label>
+          <div class="form-group">
+            <label class="col-xs-2 control-label required">{{ 'ANALYSIS_CENTER.TEXT' | translate }}</label>
             <div class="col-xs-10">
               <input class="form-bhima" ng-model="CenterCtrl.selected.text" required>
             </div>
           </div>
 
-          <div class="form-group required">
+          <div class="form-group">
             <div class="col-sm-offset-2 col-sm-10">
               <div class="checkbox">
                 <label>
@@ -130,23 +126,22 @@
                     ng-true-value="1"
                     ng-false-value="0"
                     ng-model="CenterCtrl.selected.is_principal">
-                  {{'ANALYSIS_CENTER.IS_PRINCIPAL' | translate}}
+                  {{ 'ANALYSIS_CENTER.IS_PRINCIPAL' | translate }}
                 </label>
               </div>
             </div>
           </div>
 
           <div class="form-group">
-            <label class="col-xs-2 control-label">{{'ANALYSIS_CENTER.NOTE' | translate}}</label>
+            <label class="col-xs-2 control-label">{{ 'ANALYSIS_CENTER.NOTE' | translate }}</label>
             <div class="col-xs-10">
-              <textarea class="form-control" ng-model="CenterCtrl.selected.note" rows="3">
+              <textarea class="form-bhima" ng-model="CenterCtrl.selected.note" rows="3">
               </textarea>
             </div>
           </div>
 
           <div class="pull-right">
-            <input ng-click="CenterCtrl.edit()" class="btn btn-sm btn-success" type="submit" value="{{'FORM.SAVE' | translate}}">
-            <!--input class="btn btn-sm btn-default" type="reset" value="{{'FORM.RESET' | translate}}"-->
+            <input ng-click="CenterCtrl.edit()" class="btn btn-sm btn-success" type="submit" value="{{ 'FORM.SAVE' | translate }}">
           </div>
         </fieldset>
       </form>

--- a/client/src/partials/cost_center/cost_center.html
+++ b/client/src/partials/cost_center/cost_center.html
@@ -5,26 +5,26 @@
 <nav>
   <div class="pull-left">
     <ol class="breadcrumb">
-      <li><a href="#/"><span class="glyphicon glyphicon-home"></span></a></li>
+      <li><a href="#/"><i class="glyphicon glyphicon-home"></i></a></li>
       <li class="active">{{ "COST_CENTER.TITLE" | translate }}</li>
     </ol>
   </div>
 </nav>
 
-<main>
-  <div class="row margin-top-10">
+<main class="extend margin-top-10">
+  <div class="row">
     <div class="col-xs-6">
 
-      <div class="panel panel-default square">
-        <div class="panel-heading square">
-          <span class="glyphicon glyphicon-cog"></span> {{ 'COST_CENTER.OPERATION' | translate }}
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <i class="glyphicon glyphicon-cog"></i> {{ 'COST_CENTER.OPERATION' | translate }}
         </div>
 
         <div class="panel-body">
           <ul class="primary_cash_list">
             <li ng-repeat="item in CenterCtrl.configuration.operations">
-              <span style="color: rgb(7, 150, 35);" class="glyphicon glyphicon-asterisk"></span>
-              <a class="menu-item" ng-click="CenterCtrl.loadPath(item.link)">{{item.key | translate}}</a>
+              <i style="color: rgb(7, 150, 35);" class="glyphicon glyphicon-asterisk"></i>
+              <a class="menu-item" ng-click="CenterCtrl.loadPath(item.link)">{{ item.key | translate }}</a>
             </li>
           </ul>
         </div>

--- a/client/src/partials/cost_center/cost_center.js
+++ b/client/src/partials/cost_center/cost_center.js
@@ -6,29 +6,23 @@ CostCenterController.$inject = [
 ];
 
 /**
-  * Cost Center Controller
-  * This controller is responsible for managing menu in cost center
-  */
+* Cost Center Controller
+* This controller is responsible for managing menu in cost center
+*/
 function CostCenterController ($location, $translate) {
   var vm = this,
       configuration = vm.configuration = {};
 
-  configuration.operations = [
-    {
-      key : $translate.instant('COST_CENTER.OPERATIONS.CC'),
-      link : '/cost_center/center/'
-    },
-
-    {
-      key : $translate.instant('COST_CENTER.OPERATIONS.VERSEMENT'),
-      link : '/cost_center/allocation/'
-    },
-
-    {
-      key : $translate.instant('COST_CENTER.OPERATIONS.ASSIGN'),
-      link : '/cost_center/assigning/'
-    }
-  ];
+  configuration.operations = [{
+    key : $translate.instant('COST_CENTER.OPERATIONS.CC'),
+    link : '/cost_center/center/'
+  }, {
+    key : $translate.instant('COST_CENTER.OPERATIONS.VERSEMENT'),
+    link : '/cost_center/allocation/'
+  }, {
+    key : $translate.instant('COST_CENTER.OPERATIONS.ASSIGN'),
+    link : '/cost_center/assigning/'
+  }];
 
   vm.loadPath = function loadPath(path) {
     $location.path(path);


### PR DESCRIPTION
This commit fixes lots of HTML + CSS in all cost center modules.  Some
notable changes:
 1. Use "clearfix" to handle content overflows instead of fixed heights
 in pixels.
 2. Force tables to adopt a fixed height and scroll-y on overflow
 3. Use proper bootstrap styles for form groups, labels, and static
 content
 4. Use class="extend" to remove white footer
 5. Translations implemented for cost_allocations
 6. Use ng-options instead of ng-repeat for speed improvements and allow
 a default SELECT option
 7. Loading indicators moved into table and "no data" messages do
 not show until data finished loading (#726).
 8. Currencies are rendered with enterprise currency id
 9. Currencies are right-aligned
 10. Removed unused CSS files

**Screenshots**
![screenshot from 2015-10-28 16 30 41](https://cloud.githubusercontent.com/assets/896472/10793533/9681f7e0-7d91-11e5-97fb-eb27c0f4f878.png)

![screenshot from 2015-10-28 16 30 53](https://cloud.githubusercontent.com/assets/896472/10793535/970502f2-7d91-11e5-9c18-f2bf2b68b45a.png)
![screenshot from 2015-10-28 16 30 59](https://cloud.githubusercontent.com/assets/896472/10793536/974a663a-7d91-11e5-8913-73d56abedbc7.png)
![screenshot from 2015-10-28 16 31 03](https://cloud.githubusercontent.com/assets/896472/10793537/9754488a-7d91-11e5-9156-a1a83df9cd76.png)
![screenshot from 2015-10-28 16 31 10](https://cloud.githubusercontent.com/assets/896472/10793538/97fafcac-7d91-11e5-9542-5bd2d8660a5d.png)
