### PR TITLE
FIX(journal): show errors for missing accounts

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -1966,6 +1966,7 @@
    "TRANSACTION_NUMBER"    : "Transaction #",
    "TRANSACTION_SUCCESS"   : "Transaction edits and logs saved successfully",
    "TRIAL_BALANCE"         : "Trial Balance",
+   "UNKNOWN_ACCOUNT"     : "Unknown Account",
    "VERIFY_TRANSACTION"    : "Verify Transaction"
    },
 "PRICE_LIST": {

--- a/client/src/i18n/fr.json
+++ b/client/src/i18n/fr.json
@@ -1967,6 +1967,7 @@
    "TRANSACTION_NUMBER"    : "Numéro de Transaction",
    "TRANSACTION_SUCCESS"   : " Edition des transaction et logs enregistrés avec succès",
    "TRIAL_BALANCE"         : "Rapprochement",
+   "UNKNOWN_ACCOUNT"     : "Compte Inconnu",
    "VERIFY_TRANSACTION"    : "Verifier Transaction"
    },
 "PRICE_LIST": {

--- a/client/src/partials/journal/journal.controls.js
+++ b/client/src/partials/journal/journal.controls.js
@@ -16,7 +16,6 @@ angular.module('bhima.controllers')
   'messenger',
   'SessionService',
   function ($scope, $rootScope, $q, $window, $translate, uuid, Store, util, connect, precision, validate, appstate, liberror, messenger, Session) {
-    /* jshint unused : true */
     var dependencies = {};
     var columns, options, dataview, grid, manager;
     var sortColumn;

--- a/client/src/partials/journal/journal.utilities.js
+++ b/client/src/partials/journal/journal.utilities.js
@@ -192,8 +192,11 @@ angular.module('bhima.controllers')
         dataview.setGrouping({
           getter: 'account_id',
           formatter: function(g) {
-            var account_txt = $scope.account.get(g.rows[0].account_number).account_txt || '';
-            return '<span style="font-weight: bold">' + ( $scope.account ? account_txt : g.value) + '</span>';
+            var account = $scope.account.get(g.rows[0].account_number),
+                label = account && account.account_txt ?
+                  account.account_number + ' ' + account.account_txt :
+                  $translate.instant('POSTING_JOURNAL.UNKNOWN_ACCOUNT');
+            return '<span style="font-weight: bold">' + label + '</span>';
           },
           aggregators: [
             new Slick.Data.Aggregators.Sum('debit'),


### PR DESCRIPTION
Fixes #702.

This commit prevents the journal from throwing and error when an account
is missing (in error) and the user selected 'group by account'.
Instead, the missing account(s) will be labeled 'Unknown Account', and
be grouped at the top of the posting journal.