### PR TITLE
CHORE(reports): clean up reports

### DIFF
--- a/client/src/css/report.css
+++ b/client/src/css/report.css
@@ -49,4 +49,5 @@
   background : white;
   overflow-y : auto;
   overflow-x : hidden;
+  margin-bottom: 50px;
 }

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -1735,7 +1735,7 @@
    "SEPTEMBER"          : "September",
    "TITLE"              : "Operating Account",
    "TOTAL_CHARGE"       : "Total Charge",
-   "TOTAL_PROFIT"       : "Totall profit",
+   "TOTAL_PROFIT"       : "Total profit",
    "VIEW"               : "View"
    },
 "PATIENT_EDIT": {

--- a/client/src/partials/reports/global_transaction/global_transaction.html
+++ b/client/src/partials/reports/global_transaction/global_transaction.html
@@ -1,147 +1,139 @@
 <div ng-switch="ReportCtrl.state">
-    <div ng-switch-default>
-      <main>
-        <div class="col-xs-12">
-          <div class="panel panel-default">
-            <div class="panel-heading">
-              {{ "UTIL.CONFIGURE_REPORT" | translate }} :
-              <strong>{{ "ALLTRANSACTIONS.TITLE" | translate }}</strong>
-            </div>
-
-            <div class="panel-body">
-              <form name="configForm" novalidate>
-
-                <div class="row">
-                  <div class="col-xs-4">
-                    <div class="form-group">
-                      <label class="control-label col-xs-4 required">{{ "UTIL.ACCOUNT" | translate }}</label>
-
-                      <!-- Select using ng-options vs. ng-repeat to reduce impact on DOM loading times -->
-                      <select
-                        ng-options="account.id as account.display disable when (account.account_type_id===3) for account in ReportCtrl.accounts.data | orderBy:'account_number'"
-                        ng-model="ReportCtrl.model.account_id"
-                        class="form-bhima">
-                        <option value="">-- {{"SELECT.ALL" | translate }} --</option>
-                      </select>
-
-                    </div>
-                  </div>
-
-                  <div class="col-xs-4">
-                    <label class="control-label col-xs-4 required">{{ "UTIL.SOURCE" | translate }}</label>
-                    <select class="form-bhima" id="sources" ng-model="ReportCtrl.model.source_id">
-                      <option required ng-repeat="source in ReportCtrl.model.sources" value='{{$index}}'>{{source}}</option>
-                    </select>
-                  </div>
-
-                  <div class="col-xs-4">
-                    <label class="control-label col-xs-4 required">{{ "UTIL.CURRENCY" | translate }}</label>
-                    <select class="form-bhima" ng-model="ReportCtrl.model.c" ng-options="currency.id as currency.symbol for currency in ReportCtrl.currencies.data"></select>
-                  </div>
-                </div>
-
-                <div class="row">
-                  <div class="col-xs-4">
-                    <div class="input-group">
-                      <span class="input-group-addon">{{ "UTIL.DATE_FROM" | translate }}</span>
-                      <div>
-                        <input class="form-bhima" type="date" ng-model="ReportCtrl.session.dateFrom" rows="20" required>
-                      </div>
-                    </div>
-                  </div>
-
-                  <div class="col-xs-4">
-                    <div class="input-group">
-                      <span class="input-group-addon">{{ "UTIL.DATE_TO" | translate }}</span>
-                      <div>
-                        <input class="form-bhima" type="date" ng-model="ReportCtrl.session.dateTo" rows="20" required>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </form>
-            </div>
-
-            <div class="panel-footer">
-              <div class="pull-right">
-                <button class="btn btn-sm btn-success" type="button" ng-click="ReportCtrl.generate()" ng-disabled="configForm.$invalid">
-                  <span ng-if="!ReportCtrl.session.buttonLoader">{{ "UTIL.GENERATE" | translate }}</span>
-                  <span ng-if="ReportCtrl.session.loaderState === 'loading' && ReportCtrl.session.buttonLoader">
-                    <loading-indicator></loading-indicator>
-                  </span>
-                </button>
-              </div>
-              <div class="clearfix"></div>
-            </div>
+  <div ng-switch-default>
+    <main class="extend">
+      <div class="col-xs-12">
+        <div class="panel panel-default">
+          <div class="panel-heading">
+            {{ "UTIL.CONFIGURE_REPORT" | translate }} :
+            <strong>{{ "ALLTRANSACTIONS.TITLE" | translate }}</strong>
           </div>
-        </div>
-      </main>
-    </div>
 
-    <div ng-switch-when="generate">
-      <header>
-        {{ "ALLTRANSACTIONS.TITLE" | translate }}
-      </header>
+          <form class="panel-body" name="configForm" novalidate>
 
-      <nav>
-        <button
-          style="margin-left: 5px;"
-          ng-click="ReportCtrl.reconfigure()"
-          class="btn btn-sm btn-default pull-right">
-          <span class="glyphicon glyphicon-repeat"></span>
-        </button>
+            <div class="row">
+              <div class="col-xs-4">
+                <div class="form-group">
+                  <label class="required">{{ "UTIL.ACCOUNT" | translate }}</label>
+                  <select
+                    class="form-bhima"
+                    ng-options="account.id as account.display disable when (account.account_type_id===3) for account in ReportCtrl.accounts.data | orderBy:'account_number'"
+                    ng-model="ReportCtrl.model.account_id"
+                    required>
+                    <option value="">-- {{ "SELECT.ALL" | translate }} --</option>
+                  </select>
+                </div>
+              </div>
 
-        <div class="pull-right">
-          <button ng-click="ReportCtrl.download()" class="btn btn-default btn-sm square">
-            <span class="glyphicon glyphicon-save"></span>
-            {{ 'UTIL.EXPORT_TO_CSV' | translate }}
-          </button>
+              <div class="col-xs-4">
+                <label class="required">{{ "UTIL.SOURCE" | translate }}</label>
+                <select class="form-bhima" id="sources" ng-model="ReportCtrl.model.source_id" ng-options="$index as source for source in ReportCtrl.model.sources" required>
+                  <option value="" disabled>-- {{ "SELECT.SOURCE" | translate }} --</option>
+                </select>
+              </div>
 
-          <button ng-click="ReportCtrl.printReport()" class="btn btn-default btn-sm square">
-            <span class="glyphicon glyphicon-print"></span>
-            {{ 'UTIL.PRINT' | translate }}
-          </button>
-        </div>
+              <div class="col-xs-4">
+                <label class="required">{{ "UTIL.CURRENCY" | translate }}</label>
+                <select class="form-bhima" ng-model="ReportCtrl.model.c" ng-options="currency.id as currency.symbol for currency in ReportCtrl.currencies.data" required>
+                    <option value="" disabled>-- {{ "SELECT.CURRENCY" | translate }} --</option>
+                </select>
+              </div>
+            </div>
 
-      </nav>
+            <div class="row">
+              <div class="col-xs-4">
+                <div class="input-group">
+                  <span class="input-group-addon">{{ "UTIL.DATE_FROM" | translate }}</span>
+                  <input class="form-bhima" type="date" ng-model="ReportCtrl.session.dateFrom" rows="20" required>
+                </div>
+              </div>
 
-      <div class="report report-compressed">
-        <div class="reportBody">
-          <div class="reportFrame">
-              <ng-include src="'partials/reports/templates/enterprise_header.html'" onload=""></ng-include>
-              <h4>{{ "ALLTRANSACTIONS.DEFAULT" | translate }} <small>{{ReportCtrl.session.account_number}}</small></h4>
-              <h4 class="visible-print"> {{ ReportCtrl.session.dateFrom | date }} - {{ ReportCtrl.session.dateTo | date }}</small></h4>
-              <table id="transactionsTable" class="reportTable">
-                <thead>
-                  <tr>
-                    <th width="10%">{{ "COLUMNS.TRANS_ID" | translate }}</th>
-                    <th width="15%">{{ "COLUMNS.TRANSACTION_DATE" | translate }}</th>
-                    <th width="10%">{{ "COLUMNS.ACCOUNT_NUMBER" | translate }}</th>
-                    <th width="45%">{{ "COLUMNS.DESCRIPTION" | translate }}</th>
-                    <th width="10%">{{ "COLUMNS.DEBIT" | translate }}</th>
-                    <th width="10%">{{ "COLUMNS.CREDIT" | translate }}</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr ng-repeat="record in ::ReportCtrl.records | orderBy:'trans_id'">
-                    <td width="10%"> {{ record.trans_id }} </td>
-                    <td width="15%"> {{ record.trans_date | date }} </td>
-                    <td width="10%"> {{ record.account_number }} </td>
-                    <td width="30%"> {{ record.description}} </td>
-                    <td> {{ record.debit | currency }} </td>
-                    <td> {{ record.credit | currency }} </td>
-                  </tr>
-                </tbody>
-                <tfoot>
-                  <tr>
-                    <th colspan="4" width="65%">{{ "COLUMNS.TOTAL" | translate }} : {{ ReportCtrl.records.length }}</th>
-                    <th>{{ ReportCtrl.session.somDebit | currency:ReportCtrl.model.c }}</th>
-                    <th>{{ ReportCtrl.session.somCredit | currency:ReportCtrl.model.c }}</th>
-                  </tr>
-                </tfoot>
-              </table>
+              <div class="col-xs-4">
+                <div class="input-group">
+                  <span class="input-group-addon">{{ "UTIL.DATE_TO" | translate }}</span>
+                  <input class="form-bhima" type="date" ng-model="ReportCtrl.session.dateTo" rows="20" required>
+                </div>
+              </div>
+            </div>
+          </form>
+          <div class="panel-footer clearfix">
+            <div class="pull-right">
+              <button class="btn btn-sm btn-success" type="button" ng-click="ReportCtrl.generate()" ng-disabled="configForm.$invalid">
+                <span ng-if="!ReportCtrl.session.buttonLoader">{{ "UTIL.GENERATE" | translate }}</span>
+                <span ng-if="ReportCtrl.session.loaderState === 'loading' && ReportCtrl.session.buttonLoader">
+                  <loading-indicator></loading-indicator>
+                </span>
+              </button>
+            </div>
           </div>
         </div>
       </div>
+    </main>
+  </div>
+
+  <div ng-switch-when="generate">
+    <header>
+      {{ "ALLTRANSACTIONS.TITLE" | translate }}
+    </header>
+
+    <nav>
+      <button
+        style="margin-left: 5px;"
+        ng-click="ReportCtrl.reconfigure()"
+        class="btn btn-sm btn-default pull-right">
+        <i class="glyphicon glyphicon-repeat"></i>
+      </button>
+
+      <div class="pull-right">
+        <button ng-click="ReportCtrl.download()" class="btn btn-default btn-sm">
+          <i class="glyphicon glyphicon-save"></i>
+          {{ 'UTIL.EXPORT_TO_CSV' | translate }}
+        </button>
+
+        <button ng-click="ReportCtrl.printReport()" class="btn btn-default btn-sm">
+          <i class="glyphicon glyphicon-print"></i>
+          {{ 'UTIL.PRINT' | translate }}
+        </button>
+      </div>
+
+    </nav>
+
+    <div class="report report-compressed">
+      <div class="reportBody">
+        <div class="reportFrame">
+            <ng-include src="'partials/reports/templates/enterprise_header.html'"></ng-include>
+            <h4>{{ "ALLTRANSACTIONS.DEFAULT" | translate }} <small>{{ReportCtrl.session.account_number}}</small></h4>
+            <h4 class="visible-print"> {{ ReportCtrl.session.dateFrom | date }} - {{ ReportCtrl.session.dateTo | date }}</small></h4>
+            <table id="transactionsTable" class="reportTable">
+              <thead>
+                <tr>
+                  <th width="10%">{{ "COLUMNS.TRANS_ID" | translate }}</th>
+                  <th width="15%">{{ "COLUMNS.TRANSACTION_DATE" | translate }}</th>
+                  <th width="10%">{{ "COLUMNS.ACCOUNT_NUMBER" | translate }}</th>
+                  <th width="45%">{{ "COLUMNS.DESCRIPTION" | translate }}</th>
+                  <th width="10%">{{ "COLUMNS.DEBIT" | translate }}</th>
+                  <th width="10%">{{ "COLUMNS.CREDIT" | translate }}</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr ng-repeat="record in ::ReportCtrl.records | orderBy:'trans_id'">
+                  <td width="10%"> {{ record.trans_id }} </td>
+                  <td width="15%"> {{ record.trans_date | date }} </td>
+                  <td width="10%"> {{ record.account_number }} </td>
+                  <td width="30%"> {{ record.description}} </td>
+                  <td class="text-right"> {{ record.debit | currency:record.currency_id }} </td>
+                  <td class="text-right"> {{ record.credit | currency:record.currency_id }} </td>
+                </tr>
+              </tbody>
+              <tfoot>
+                <tr>
+                  <th colspan="4">{{ "COLUMNS.TOTAL" | translate }} : {{ ReportCtrl.records.length }}</th>
+                  <th class="text-right">{{ ReportCtrl.session.somDebit | currency:ReportCtrl.model.c }}</th>
+                  <th class="text-right">{{ ReportCtrl.session.somCredit | currency:ReportCtrl.model.c }}</th>
+                </tr>
+              </tfoot>
+            </table>
+        </div>
+      </div>
     </div>
+  </div>
 </div>

--- a/client/src/partials/reports/global_transaction/global_transaction.js
+++ b/client/src/partials/reports/global_transaction/global_transaction.js
@@ -6,9 +6,13 @@ ReportGlobalTransactionController.$inject = [
 ];
 
 /**
-  * Reprot Global Transaction Controller
-  * This controller is responsible for managing report of all transactions
-  */
+* Reprot Global Transaction Controller
+* This controller is responsible for managing report of all transactions
+*
+* TODO/FIXME
+*  -- Why does this use exchange? The data should be from the journal/general ledger
+*  and those are already converted!
+*/
 function ReportGlobalTransactionController (connect, $translate, validate, util, exchange, SessionService, exportFile) {
   var vm = this,
       session = vm.session = {},
@@ -155,6 +159,7 @@ function ReportGlobalTransactionController (connect, $translate, validate, util,
         }
       });
       vm.records = res;
+      console.log('vm.records:', vm.records);
       return res;
     })
     .then(getTotal)

--- a/client/src/partials/reports/operating_account/operating_account.html
+++ b/client/src/partials/reports/operating_account/operating_account.html
@@ -1,58 +1,49 @@
 <div ng-switch="OperatingCtrl.state">
   <div ng-switch-default>
-    <main>
-      <div class="col-xs-12">
+    <main class="extend">
       <div class="panel panel-default">
         <div class="panel-heading">
-          <b> {{ "OPERATING_ACCOUNT.CONFIGURE_REPORT" | translate }} </b>
+          <strong>{{ "OPERATING_ACCOUNT.CONFIGURE_REPORT" | translate }}</strong>
         </div>
+        <form class="panel-body" name="configForm" novalidate>
+          <div class="form-group">
+            <label class="required">
+              {{ "OPERATING_ACCOUNT.FISCAL_YEAR" | translate }}
+            </label>
+            <select class="form-bhima"
+              ng-model="OperatingCtrl.session.fiscal_year_id"
+              ng-options="fy.id as fy.fiscal_year_txt for fy in OperatingCtrl.fiscalYears.data"
+              ng-change="OperatingCtrl.getPeriods()" required>
+              <option value="" disabled>-- {{ "SELECT.FISCAL_YEAR" | translate }} --</option>
+            </select>
+          </div>
 
-        <div class="panel-body">
-          <form name="configForm" novalidate>
-            <div class="form-group">
-              <label class="control-label col-xs-4 required">
-                {{ "OPERATING_ACCOUNT.FISCAL_YEAR" | translate }}
-              </label>
-              <div>
-                <select class="form-bhima"
-                  ng-model="OperatingCtrl.session.fiscal_year_id"
-                  ng-options="fy.id as fy.fiscal_year_txt for fy in OperatingCtrl.fiscalYears.data"
-                  ng-change="OperatingCtrl.getPeriods()" required>
-                  <option value="" disabled>-- {{ "SELECT.FISCAL_YEAR" | translate }} --</option>
-                </select>
-              </div>
-            </div>
+          <div class="form-group">
+            <label class="required">
+              {{ "OPERATING_ACCOUNT.PERIOD" | translate }}
+            </label>
+            <select class="form-bhima"
+              ng-model="OperatingCtrl.session.period_id"
+              ng-disabled="!OperatingCtrl.session.fiscal_year_id"
+              required>
+              <option value="" disabled>
+                {{ "SELECT.PERIOD" | translate }}
+              </option>
+              <option value="all">
+                {{ "UTIL.ALL" | translate }}
+              </option>
+              <option ng-repeat="per in OperatingCtrl.selectablePeriods track by per.id" value="{{per.id}}">
+                {{ OperatingCtrl.formatPeriod(per) }}
+              </option>
+            </select>
+          </div>
 
-            <div class="form-group">
-              <label class="control-label col-xs-4 required">
-                {{ "OPERATING_ACCOUNT.PERIOD" | translate }}
-              </label>
-              <div>
-                <select class="form-bhima"
-                  ng-model="OperatingCtrl.session.period_id"
-                  ng-disabled="!OperatingCtrl.session.fiscal_year_id"
-                  required>
-                  <option value="" disabled>
-                    {{ "SELECT.PERIOD" | translate }}
-                  </option>
-                  <option value="all">
-                    {{ "UTIL.ALL" | translate }}
-                  </option>
-                  <option ng-repeat="per in OperatingCtrl.selectablePeriods" value="{{per.id}}">
-                    {{ OperatingCtrl.formatPeriod(per) }}
-                  </option>
-                </select>
-              </div>
-            </div>
-
-            <div class="pull-right">
-              <button class="btn btn-sm btn-success" type="button" ng-click="OperatingCtrl.generate()" ng-disabled="configForm.$invalid">
-                {{ "OPERATING_ACCOUNT.GENERATE" | translate }}
-              </button>
-            </div>
-          </form>
-        </div>
-      </div>
+          <div class="pull-right">
+            <button class="btn btn-sm btn-success" type="button" ng-click="OperatingCtrl.generate()" ng-disabled="configForm.$invalid">
+              {{ "OPERATING_ACCOUNT.GENERATE" | translate }}
+            </button>
+          </div>
+        </form>
       </div>
     </main>
   </div>
@@ -60,8 +51,8 @@
   <div ng-switch-when="generate">
     <header>
       {{ "OPERATING_ACCOUNT.TITLE" | translate }} /
-      {{ OperatingCtrl.fiscalYears.get(OperatingCtrl.session.fiscal_year_id).fiscal_year_txt}} /
-      {{ OperatingCtrl.session.period_id == 'all' ? OperatingCtrl.all_period : (OperatingCtrl.periods.get(session.period_id).period_start | date) + ' -- ' + (OperatingCtrl.periods.get(OperatingCtrl.session.period_id).period_stop | date)}}
+      {{ OperatingCtrl.fiscalYears.get(OperatingCtrl.session.fiscal_year_id).fiscal_year_txt }} /
+      {{ OperatingCtrl.session.period_id == 'all' ? OperatingCtrl.all_period : (OperatingCtrl.periods.get(OperatingCtrl.session.period_id).period_start | date) + ' -- ' + (OperatingCtrl.periods.get(OperatingCtrl.session.period_id).period_stop | date)}}
     </header>
 
     <nav>
@@ -69,16 +60,16 @@
         style="margin-left: 5px;"
         ng-click="OperatingCtrl.reconfigure()"
         class="btn btn-sm btn-default pull-right">
-        <span class="glyphicon glyphicon-repeat"></span>
+        <i class="glyphicon glyphicon-repeat"></i>
       </button>
 
       <div class="pull-right">
         <button ng-click="OperatingCtrl.download()" class="btn btn-default btn-sm square">
-          <span class="glyphicon glyphicon-save"></span>
+          <i class="glyphicon glyphicon-save"></i>
           {{ 'UTIL.EXPORT_TO_CSV' | translate }}
         </button>
         <button ng-click="OperatingCtrl.printReport()" class="btn btn-default btn-sm square">
-          <span class="glyphicon glyphicon-print"></span>
+          <i class="glyphicon glyphicon-print"></i>
           {{ 'UTIL.PRINT' | translate }}
         </button>
       </div>
@@ -87,37 +78,39 @@
     <div class="report">
       <div class="reportBody">
         <div class="reportFrame">
-          <ng-include src="'partials/reports/templates/enterprise_header.html'" onload=""></ng-include>
+          <ng-include src="'partials/reports/templates/enterprise_header.html'"></ng-include>
 
           <h4 class="visible-print">
             {{ "OPERATING_ACCOUNT.TITLE" | translate }} :
             <small>
-              {{ OperatingCtrl.fiscalYears.get(session.fiscal_year_id).fiscal_year_txt}} /
+              {{ OperatingCtrl.fiscalYears.get(OperatingCtrl.session.fiscal_year_id).fiscal_year_txt }} /
               {{ OperatingCtrl.session.period_id == 'all' ? 'Tous' : (OperatingCtrl.periods.get(OperatingCtrl.session.period_id).period_start | date) + ' -- ' + (OperatingCtrl.periods.get(OperatingCtrl.session.period_id).period_stop | date)}}
             </small>
           </h4>
-          <table id="patientTable" class="reportTable">
+          <table class="reportTable">
             <thead>
               <tr>
-                <th>{{ "COLUMNS.NR" | translate }}</th>
-                <th>{{ "COLUMNS.ACCOUNT" | translate }}</th>
-                <th>{{ "COLUMNS.LABEL" | translate }}</th>
-                <th>{{ "COLUMNS.CHARGE" | translate }}</th>
-                <th>{{ "COLUMNS.PROFIT" | translate }}</th>
+                <th class="text-center">{{ "COLUMNS.NR" | translate }}</th>
+                <th class="text-center">{{ "COLUMNS.ACCOUNT" | translate }}</th>
+                <th class="text-center">{{ "COLUMNS.LABEL" | translate }}</th>
+                <th class="text-center">{{ "COLUMNS.CHARGE" | translate }}</th>
+                <th class="text-center">{{ "COLUMNS.PROFIT" | translate }}</th>
               </tr>
             </thead>
             <tbody>
-              <tr ng-repeat='record in OperatingCtrl.records'>
+              <tr ng-repeat='record in OperatingCtrl.records track by record.account_number'>
                 <td> {{ $index + 1 }} </td>
                 <td> {{ record.account_number}} </td>
                 <td> {{ record.account_txt }} </td>
-                <td> {{ record.debit }} </td>
-                <td> {{ record.credit }} </td>
+                <td class="text-right"> {{ record.debit | currency:OperatingCtrl.enterprise.currency_id }} </td>
+                <td class="text-right"> {{ record.credit | currency:OperatingCtrl.enterprise.currency_id }} </td>
               </tr>
             </tbody>
           </table>
           <h6 class="visible-print">
-            {{ 'OPERATING_ACCOUNT.TOTAL_CHARGE' | translate }}: <b>{{ debitTotal | currency:OperatingCtrl.session.currency }}</b> | {{ 'OPERATING_ACCOUNT.TOTAL_PROFIT' | translate }}: <b>{{ creditTotal | currency:session.currency }}</b> | {{ 'COLUMNS.RESULT' | translate }} : <b>{{ Result | currency:session.currency }}</b>
+            {{ 'OPERATING_ACCOUNT.TOTAL_CHARGE' | translate }}: <b>{{ OperatingCtrl.totals.debit | currency:OperatingCtrl.enterprise.currency_id }}</b>
+            | {{ 'OPERATING_ACCOUNT.TOTAL_PROFIT' | translate }}: <b>{{ OperatingCtrl.totals.credit | currency:OperatingCtrl.enterprise.currency_id }}</b>
+            | {{ 'COLUMNS.RESULT' | translate }} : <b>{{ OperatingCtrl.totals.balance | currency:OperatingCtrl.enterprise.currency_id }}</b>
           </h6>
         </div>
       </div>
@@ -126,32 +119,23 @@
     <footer>
       <table style="width: 99%, margin-top: 3px">
         <tbody>
-          <td style="width:20%;">
-            <b>{{ 'OPERATING_ACCOUNT.TOTAL_CHARGE' | translate }}: </b>
-            <span>
-              <b>{{ OperatingCtrl.debitTotal | currency:OperatingCtrl.session.currency }}</b>
-            </span>
+          <th style="width:20%;">
+            {{ 'OPERATING_ACCOUNT.TOTAL_CHARGE' | translate }}:
+            {{ OperatingCtrl.totals.debit | currency:OperatingCtrl.enterprise.currency_id }}
             <span ng-if="OperatingCtrl.session.searching">...</span>
-          </td>
+          </th>
 
-          <td style="width:20%;">
-          </td>
-
-          <td style="width:20%;">
-            <b>{{ 'OPERATING_ACCOUNT.TOTAL_PROFIT' | translate }}: </b>
-            <span>
-              <b>{{ OperatingCtrl.creditTotal | currency:OperatingCtrl.session.currency }}</b>
-            </span>
+          <th style="width:20%;">
+            {{ 'OPERATING_ACCOUNT.TOTAL_PROFIT' | translate }}:
+            {{ OperatingCtrl.totals.credit | currency:OperatingCtrl.enterprise.currency_id }}
             <span ng-if="OperatingCtrl.session.searching">...</span>
-          </td>
+          </th>
 
-          <td style="width:20%;">
-            <b>{{ 'COLUMNS.RESULT' | translate }}: </b>
-            <span>
-              <b>{{ OperatingCtrl.Result | currency:OperatingCtrl.session.currency }}</b>
-            </span>
+          <th style="width:20%;">
+            {{ 'COLUMNS.RESULT' | translate }}:
+            {{ OperatingCtrl.totals.balance | currency:OperatingCtrl.enterprise.currency_id }}
             <span ng-if="OperatingCtrl.session.searching">...</span>
-          </td>
+          </th>
         </tbody>
       </table>
     </footer>

--- a/client/src/partials/reports/transactions/account.html
+++ b/client/src/partials/reports/transactions/account.html
@@ -1,69 +1,59 @@
 <div ng-switch="state">
   <div ng-switch-default>
-    <main>
-      <div class="col-xs-12">
-        <div class="panel panel-default">
-          <div class="panel-heading">
-            <b> {{ "REPORT.CONFIGURE_REPORT" | translate }} : </b> {{ "REPORT.TRANSACTIONS_BY_ACCOUNT" | translate }}
-          </div>
-
-          <div class="panel-body">
-            
-            <form name="configForm" novalidate>
-              <div class="form-group">
-                <label class="control-label col-xs-4 required">
-                  {{ "COLUMNS.LIMIT" | translate }}
-                </label>
-                <div>
-                  <div class="pull-left form-group input-group">
-                  <span class="input-group-addon">
-                    <span class="glyphicon glyphicon-ban-circle"></span>
-                  </span>  
-                  <select class="form-bhima" ng-model="session.limit" ng-options="limit as limit for limit in session.limits" required>
-                    <option disabled="disabled" value="">-- {{ "SELECT.VALUE" | translate }} -- </option>
-                  </select>
-                  </div>
-                </div>
-              </div> 
-
-              <div class="form-group">
-                <label class="control-label col-xs-4 required">
-                  {{ "COLUMNS.ACCOUNT_NUMBER" | translate }}
-                </label>
-                <div>
-                  <div class="pull-left form-group input-group">
-                  <span class="input-group-addon">
-                    <span class="glyphicon glyphicon-folder-open"></span>
-                  </span>  
-                    <select class="form-bhima" ng-model="session.account" ng-options="account as account.account_number + ' - ' + account.account_txt for account in accounts.data | orderBy:'account_number'" required>
-                      <option disabled="disabled" value="">-- {{ "SELECT.ACCOUNT" | translate }} -- </option>
-                    </select>
-                  </div>
-                </div>
-              </div>                        
-
-              <div class="pull-right">
-                <button class="btn btn-sm btn-success" type="button" ng-click="search()" ng-disabled="configForm.$invalid">
-                  {{ "REPORT.GENERATE" | translate }}
-                </button>
-              </div>
-
-            </form>
-          </div>
+    <main class="extend">
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <strong>{{ "REPORT.CONFIGURE_REPORT" | translate }}:</strong> {{ "REPORT.TRANSACTIONS_BY_ACCOUNT" | translate }}
         </div>
+
+        <form class="panel-body" name="ConfigForm" novalidate>
+          <div class="form-group">
+            <label class="required">
+              {{ "COLUMNS.LIMIT" | translate }}
+            </label>
+            <div>
+              <div class="pull-left form-group input-group">
+              <span class="input-group-addon">
+                <span class="glyphicon glyphicon-ban-circle"></span>
+              </span>
+              <select class="form-bhima" ng-model="session.limit" ng-options="limit as limit for limit in session.limits" required>
+                <option disabled="disabled" value="">-- {{ "SELECT.VALUE" | translate }} -- </option>
+              </select>
+              </div>
+            </div>
+          </div>
+
+          <div class="form-group">
+            <label class="required">
+              {{ "COLUMNS.ACCOUNT_NUMBER" | translate }}
+            </label>
+            <div class="input-group">
+              <span class="input-group-addon">
+                <i class="glyphicon glyphicon-folder-open"></i>
+              </span>
+              <select class="form-bhima" ng-model="session.account" ng-options="account as account.account_number + ' - ' + account.account_txt for account in accounts.data | orderBy:'account_number'" required>
+                <option value="" disabled>-- {{ "SELECT.ACCOUNT" | translate }} --</option>
+              </select>
+            </div>
+          </div>
+
+          <button class="btn btn-sm btn-success pull-right" type="button" ng-click="search()" ng-disabled="ConfigForm.$invalid">
+            {{ "REPORT.GENERATE" | translate }}
+          </button>
+        </form>
       </div>
-    </main>  
+    </main>
   </div>
-  <div ng-switch-when="generate">  
+
+  <div ng-switch-when="generate">
     <header>
       {{ "REPORT.TRANSACTIONS_BY_ACCOUNT" | translate }} / {{ session.account.account_number }} : <b> {{ session.account.account_txt }} </b> / {{ session.timestamp | date }}
     </header>
 
     <nav>
-
-      <div class="pull-right">        
+      <div class="pull-right">
         <button class="btn btn-sm btn-default" ng-click="print()">
-          <span class="glyphicon glyphicon-print"></span>
+          <i class="glyphicon glyphicon-print"></i>
           {{ "UTIL.PRINT" | translate }}
         </button>
 
@@ -71,17 +61,16 @@
           style="margin-left: 5px;"
           ng-click="reconfigure()"
           class="btn btn-sm btn-default pull-right">
-          <span class="glyphicon glyphicon-repeat"></span>
+          <i class="glyphicon glyphicon-repeat"></i>
         </button>
       </div>
-    
     </nav>
 
     <div class="report">
       <div class="reportBody">
         <div class="reportFrame">
           <ng-include src="'partials/reports/templates/enterprise_header.html'" onload=""></ng-include>
-          
+
           <h4 class="visible-print">
             {{ "OPERATING_ACCOUNT.TITLE" | translate }} :
             <small>
@@ -98,26 +87,23 @@
               </tr>
             </thead>
             <tbody>
-              <tr ng-repeat='transaction in transactions'>
-                <td>{{ transaction.trans_date | date }}</td>
-                <td>{{ transaction.description }}</td>
-                <td>{{ transaction.debit | currency:transaction.currency_id }}</td>
-                <td>{{ transaction.credit | currency:transaction.currency_id }}</td>
+              <tr ng-if="session.loading">
+                <td colspan="4" class="text-center"><loading-indicator></loading-indicator></td>
               </tr>
-            </tbody>
-            <tbody ng-if="!transactions.length && session.account">
-              <tr>
+              <tr ng-if="!transactions.length && !session.loading">
                 <td colspan="4">{{ "REPORT.NO_TRANSACTIONS" | translate }}</td>
               </tr>
-            </tbody>
-            <tfoot>
-              <tr>
+              <tr ng-repeat='transaction in transactions track by uuid'>
+                <td>{{ transaction.trans_date | date }}</td>
+                <td>{{ transaction.description }}</td>
+                <td class="text-right">{{ transaction.debit | currency:transaction.currency_id }}</td>
+                <td class="text-right">{{ transaction.credit | currency:transaction.currency_id }}</td>
               </tr>
-            </tfoot>
+            </tbody>
           </table>
           <h6 class="visible-print">
-            {{ 'COLUMNS.TOTAL_DEBIT' | translate }}: <b >{{ session.sum_debit | currency:session.currency }}</b> | {{ 'COLUMNS.TOTAL_CREDIT' | translate }}: <b>{{ session.sum_credit | currency:session.currency }}</b> |  
-          </h6>          
+            {{ 'COLUMNS.TOTAL_DEBIT' | translate }}: <b >{{ session.sum_debit | currency:session.currency }}</b> | {{ 'COLUMNS.TOTAL_CREDIT' | translate }}: <b>{{ session.sum_credit | currency:session.currency }}</b> |
+          </h6>
         </div>
       </div>
     </div>
@@ -125,25 +111,21 @@
     <footer>
       <table style="width: 99%, margin-top: 3px">
         <tbody>
-          <td style="width:20%;">
-            <span class="glyphicon glyphicon-list-alt" style="color: #428bca"></span> <b>{{ transactions.length }}</b>
-          </td>
+          <th style="width:20%;">
+            <i class="glyphicon glyphicon-list-alt" style="color: #428bca"></i> {{ transactions.length }}
+          </th>
 
-          <td style="width:25%;">
-            <b>{{ 'COLUMNS.TOTAL_DEBIT' | translate }}: </b>
-            <span>
-              <b>{{ session.sum_debit | currency:session.currency }}</b>
-            </span>
+          <th style="width:25%;">
+            {{ 'COLUMNS.TOTAL_DEBIT' | translate }}:
+            {{ session.sum_debit | currency:session.currency }}
             <span ng-if="session.searching">...</span>
-          </td>
+          </th>
 
-          <td style="width:25%;">
-            <b>{{ 'COLUMNS.TOTAL_CREDIT' | translate }}: </b>
-            <span>
-              <b>{{ session.sum_credit | currency:session.currency }}</b>
-            </span>
+          <th style="width:25%;">
+            {{ 'COLUMNS.TOTAL_CREDIT' | translate }}:
+            {{ session.sum_credit | currency:session.currency }}
             <span ng-if="session.searching">...</span>
-          </td>
+          </th>
 
           <td class="hidden-print" style="width:30%;">
             <select class="form-bhima" ng-model="session.currency" ng-options="currency.id as currency.symbol for currency in currencies.data" ng-change="convert()"></select>
@@ -151,5 +133,5 @@
         </tbody>
       </table>
     </footer>
-  </div>  
+  </div>
 </div>

--- a/client/src/partials/reports/transactions/account.js
+++ b/client/src/partials/reports/transactions/account.js
@@ -1,102 +1,100 @@
 angular.module('bhima.controllers')
-.controller('report.transactions.account', [
-  '$scope',
-  'validate',
-  'connect',
-  'appstate',
-  'exchange',
-  'SessionService',
-  function ($scope, validate, connect, appstate, exchange, SessionService) {
-    var session = $scope.session = {},
+.controller('report.transactions.account', ReportAccountTransactionsController);
+
+ReportAccountTransactionsController.$inject = [
+  '$scope', '$window', 'validate', 'connect', 'appstate', 'exchange', 'SessionService'
+];
+
+/**
+* This report presents all transactions hitting a given account.
+*/
+function ReportAccountTransactionsController($scope, $window, validate, connect, appstate, exchange, Session) {
+  var session = $scope.session = {},
       dependencies = {},
       state = $scope.state;
 
-    dependencies.accounts = {
-      query : {
-        tables : {
-          'account' : {
-            columns : ['id', 'account_number', 'account_txt']
-          }
+  dependencies.accounts = {
+    query : {
+      tables : {
+        'account' : {
+          columns : ['id', 'account_number', 'account_txt']
         }
       }
-    };
+    }
+  };
 
-    dependencies.currencies = {
-      required : true,
-      query : {
-        tables : {
-          'currency' : {
-            columns : ['id', 'symbol']
-          }
+  dependencies.currencies = {
+    required : true,
+    query : {
+      tables : {
+        'currency' : {
+          columns : ['id', 'symbol']
         }
       }
-    };
-
-    session.timestamp = new Date();
-
-    session.limits = [10, 25, 50, 75, 100, 500, 1000, 5000, 10000];
-
-    function startup(models) {
-      $scope.currencies = models.currencies;
-      session.currency = SessionService.enterprise.currency_id;
-      models.accounts.data.forEach(function (acc) {
-        acc.account_number = String(acc.account_number);
-      });
-      session.limit = 10;
-      angular.extend($scope, models);
     }
+  };
 
-    appstate.register('enterprise', function (enterprise) {
-      $scope.enterprise = enterprise;
-      session.currency = $scope.enterprise.currency_id;
-      validate.process(dependencies)
-      .then(startup);
+  session.timestamp = new Date();
+  $scope.enterprise = Session.enterprise;
+  session.currency = $scope.enterprise.currency_id;
+  session.limits = [10, 25, 50, 75, 100, 500, 1000, 5000, 10000];
+  session.loading = false;
+
+  function startup(models) {
+    $scope.currencies = models.currencies;
+    session.currency = Session.enterprise.currency_id;
+    models.accounts.data.forEach(function (acc) {
+      acc.account_number = String(acc.account_number);
     });
-
-    $scope.search = function search() {
-      $scope.state = 'generate';
-      if (!session.account || !session.limit) { return; }
-      var query = '?account=' + session.account.id;
-      query += '&limit=' + session.limit;
-      connect.fetch('/reports/transactions/' + query)
-      .then(function (data) {
-        $scope.transactions = data;
-        convert();
-      });
-    };
-
-    function initialize (models) {
-      angular.extend($scope, models);
-    }
-
-    appstate.register('enterprise', function (enterprise) {
-      $scope.enterprise = enterprise;
-      validate.process(dependencies)
-      .then(initialize);
-    });
-
-    $scope.print = function print() {
-      window.print();
-    };
-
-   function reconfigure () {
-      $scope.state = null;
-      $scope.session.account = null;
-      $scope.session.limit = null;
-    }
-
-    function convert () {
-      if($scope.transactions) {
-        session.sum_debit = 0;
-        session.sum_credit = 0;      
-        $scope.transactions.forEach(function (transaction) {
-          session.sum_debit += exchange.convertir(transaction.debit, transaction.currency_id, session.currency,new Date());
-          session.sum_credit += exchange.convertir(transaction.credit, transaction.currency_id, session.currency,new Date());
-        });        
-      }
-    }
-
-    $scope.convert = convert;
-    $scope.reconfigure = reconfigure;
+    session.limit = 10;
+    angular.extend($scope, models);
   }
-]);
+
+  validate.process(dependencies)
+  .then(startup);
+
+  $scope.search = function search() {
+    $scope.state = 'generate';
+
+    if (!session.account || !session.limit) { return; }
+
+    // make sure to purge old data
+    if ($scope.transactions) { $scope.transactions.length = 0; }
+
+    var query = '?account=' + session.account.id +
+                '&limit=' + session.limit;
+
+    session.loading = true;
+
+    connect.fetch('/reports/transactions/' + query)
+    .then(function (data) {
+      $scope.transactions = data;
+      convert();
+    })
+    .finally(function () { session.loading = false; });
+  };
+
+  $scope.print = function print() {
+    $window.print();
+  };
+
+ function reconfigure() {
+    $scope.state = null;
+    $scope.session.account = null;
+    $scope.session.limit = null;
+  }
+
+  function convert() {
+    if ($scope.transactions) {
+      session.sum_debit = 0;
+      session.sum_credit = 0;
+      $scope.transactions.forEach(function (transaction) {
+        session.sum_debit += exchange.convertir(transaction.debit, transaction.currency_id, session.currency,new Date());
+        session.sum_credit += exchange.convertir(transaction.credit, transaction.currency_id, session.currency,new Date());
+      });
+    }
+  }
+
+  $scope.convert = convert;
+  $scope.reconfigure = reconfigure;
+}

--- a/client/src/partials/reports_proposed/balance/balance.html
+++ b/client/src/partials/reports_proposed/balance/balance.html
@@ -1,49 +1,40 @@
-<!-- TODO Add translation keys -->
-
 <header data-header>
   {{'BALANCE.BUILD_BALANCE' | translate}}
 </header>
 
-<main>
+<main class="extend">
   <div class="panel panel-default">
-    <div class="panel-heading">{{'BALANCE.DOCUMENT_CONFIG' | translate}}</div>
-    <div class="panel-body">
-      <form>
-        <div class="form-group">
-          <label>{{'BALANCE.LANGUAGE' | translate}}</label>
+    <div class="panel-heading">{{ 'BALANCE.DOCUMENT_CONFIG' | translate }}</div>
+    <form class="panel-body">
 
-          <div>
-            <span ng-repeat="language in configuration.language.options">
-              <button
-                class="btn btn-default btn-lg"
-                ng-class="{'active' : configuration.language.selected===language}"
-                ng-click="selectConfiguration('language', language)">{{language.label}}</button>
-            </span>
-          </div>
+      <div class="form-group">
+        <label class="required">
+          {{ "BALANCE.FISCAL_YEAR" | translate }}
+        </label>
+        <select class="form-bhima" ng-model="session.fy_id" ng-options="fyid as fy.fiscal_year_txt for fy in model.fiscalYears.data">
+          <option value="" disabled>-- {{ 'SELECT.FISCAL' | translate }} --</option>
+        </select>
+      </div>
+
+      <div class="form-group">
+        <label>{{ 'BALANCE.LANGUAGE' | translate }}</label>
+        <div>
+          <span ng-repeat="language in configuration.language.options">
+            <button
+              class="btn btn-default btn-lg"
+              ng-class="{'active' : configuration.language.selected===language}"
+              ng-click="selectConfiguration('language', language)">{{ language.label }}</button>
+          </span>
         </div>
+      </div>
 
-        <div class="form-group">
-          <label class="control-label col-xs-4 required">
-            {{ "BALANCE.FISCAL_YEAR" | translate }}
-          </label>
-          <div>
-            <select class="form-bhima" ng-model="session.fy_id">
-              <option ng-repeat="fy in model.fiscalYears.data" ng-value="fy.id">
-                {{fy.fiscal_year_txt}}
-              </option>
-            </select>
-          </div>
-        </div>
+      <button
+        class="btn btn-default"
+        ng-disabled="session.building"
+        ng-click="generateDocument()" ng-if="!generatedDocumentPath">{{ session.building ? 'UTIL.LOADING' : 'UTIL.GENERATE' | translate }}
+      </button>
 
-        <!-- Links swapped out to allow target _blank (open PDF in new tab) -->
-        <button
-          class="btn btn-default"
-          ng-disabled="session.building"
-          ng-click="generateDocument()" ng-if="!generatedDocumentPath">{{session.building ? 'Loading' : 'Generate Document'}}
-        </button>
-
-        <a class="btn btn-success" href="{{generatedDocumentPath}}" target="_blank" ng-if="generatedDocumentPath" ng-click="clearPath()">Document Build Success - Open Document</a>
-      </form>
-    </div>
+      <a class="btn btn-success" ng-href="{{ generatedDocumentPath }}" target="_blank" ng-if="generatedDocumentPath" ng-click="clearPath()">Document Build Success - Open Document</a>
+    </form>
   </div>
 </main>

--- a/client/src/partials/reports_proposed/balance/balance.js
+++ b/client/src/partials/reports_proposed/balance/balance.js
@@ -1,107 +1,75 @@
 angular.module('bhima.controllers')
-.controller('configureBalance', [
-  '$scope',
-  '$http',
-  '$sce',
-  'validate',
-  function ($scope, $http, $sce, validate) {
+.controller('configureBalance', ConfigureBalanceSheetController);
 
-    var dependencies = {};
+ConfigureBalanceSheetController.$inject = [
+  '$scope', '$http', '$sce', 'validate', 'reportConfigService'
+];
 
-    // Configuration objects optionally passed to /report/build - drives configuration UI
-    var configuration = {
-      language : {
-        options : [
-          {value : 'en', label : 'English'},
-          {value : 'fr', label : 'French'}
-        ]
-      }
-    };
+function ConfigureBalanceSheetController($scope, $http, $sce, validate, ReportConfig) {
+  var dependencies = {};
 
-    var serverUtilityPath = '/report/build/balance';
-    var generatedDocumentPath = null;
-    var session = $scope.session = {};
+  // Configuration objects optionally passed to /report/build - drives configuration UI
 
-    $scope.model = {};
+  var serverUtilityPath = '/report/build/balance';
+  var generatedDocumentPath = null;
+  var session = $scope.session = {};
 
-    dependencies.fiscalYears = {
-      query : {
-        identifier : 'id',
-        tables : {
-          'fiscal_year' : {
-            columns : ['id', 'fiscal_year_txt']
-          }
+  dependencies.fiscalYears = {
+    query : {
+      identifier : 'id',
+      tables : {
+        'fiscal_year' : {
+          columns : ['id', 'fiscal_year_txt']
         }
       }
-    };
-
-    // Expose configuration to scope - set module state
-    session.building = false;
-    $scope.configuration = configuration;
-
-    // TODO Load default configuration from appcache if it exists before selecting default
-
-    validate.process(dependencies)
-    .then(complete);
-
-    function complete (res){
-      $scope.model = res;
-      setDefaultConfiguration();
     }
+  };
 
-    function selectConfiguration(key, value) {
-      configuration[key].selected = value;
-    }
+  // Expose configuration to scope - set module state
+  session.building = false;
+  $scope.configuration = ReportConfig.configuration;
 
-    function setDefaultConfiguration() {
-      selectConfiguration('language', configuration.language.options[0]);
-    }
+  // TODO Load default configuration from appcache if it exists before selecting default
+  validate.process(dependencies)
+  .then(complete);
 
-    // POST configuration object to /report/build/:target
-    function generateDocument() {
-      var path = serverUtilityPath;
-      var configurationObject = {};
-
-      // Temporarily set configuration options - This shouldn't be manually compiled
-      configurationObject.language = configuration.language.selected.value;
-      configurationObject.fy = session.fy_id || $scope.model.fiscalYears.data[0].id;
-
-      // Update state
-      session.building = true;
-
-      $http.post(path, configurationObject)
-      .success(function (result) {
-
-        // Expose generated document path to template
-        session.building = false;
-        $scope.generatedDocumentPath = result;
-      })
-      .error(function (code) {
-        session.building = false;
-
-        // TODO Handle error
-      });
-    }
-
-    // Utility method - GET PDF blob displaying embedded object
-    function downloadDocument(url) {
-
-      $http.get(url, {responseType : 'arraybuffer'})
-      .success(function (pdfResult) {
-        var file = new Blob([pdfResult], {type: 'application/pdf'});
-        var fileURL = URL.createObjectURL(file);
-
-        // Expose document to scope
-        $scope.pdfContent = $sce.trustAsResourceUrl(fileURL);
-      });
-    }
-
-    function clearPath() {
-      $scope.generatedDocumentPath = null;
-    }
-
-    $scope.selectConfiguration = selectConfiguration;
-    $scope.generateDocument = generateDocument;
-    $scope.clearPath = clearPath;
+  function complete(res) {
+    $scope.model = res;
+    setDefaultConfiguration();
   }
-]);
+
+  function selectConfiguration(key, value) {
+    $scope.configuration[key].selected = value;
+  }
+
+  function setDefaultConfiguration() {
+    selectConfiguration('language', $scope.configuration.language.options[0]);
+  }
+
+  // POST configuration object to /report/build/:target
+  function generateDocument() {
+    var path = serverUtilityPath;
+    var configurationObject = {};
+
+    // Temporarily set configuration options - This shouldn't be manually compiled
+    configurationObject.language = $scope.configuration.language.selected.value;
+    configurationObject.fy = session.fy_id || $scope.model.fiscalYears.data[0].id;
+
+    // Update state
+    session.building = true;
+
+    $http.post(path, configurationObject)
+    .then(function (response) {
+      $scope.generatedDocumentPath = response.data;
+    })
+    .finally(function () { session.building = false; });
+  }
+
+  function clearPath() {
+    $scope.generatedDocumentPath = null;
+  }
+
+  $scope.selectConfiguration = selectConfiguration;
+  $scope.generateDocument = generateDocument;
+  $scope.clearPath = clearPath;
+}

--- a/server/controllers/report.js
+++ b/server/controllers/report.js
@@ -587,12 +587,12 @@ function transactionsByAccount(params) {
   _limit = p.limit;
 
   sql =
-    'SELECT trans_date, description, account_number, debit, credit, currency_id ' +
+    'SELECT uuid, trans_date, description, account_number, debit, credit, currency_id ' +
     'FROM (' +
-      'SELECT trans_date, description, account_id, debit, credit, currency_id ' +
+      'SELECT uuid, trans_date, description, account_id, debit, credit, currency_id ' +
       'FROM posting_journal ' +
     'UNION ' +
-      'SELECT trans_date, description, account_id, debit, credit, currency_id ' +
+      'SELECT uuid, trans_date, description, account_id, debit, credit, currency_id ' +
       'FROM general_ledger' +
     ') AS journal JOIN account ON ' +
       'journal.account_id = account.id ' +
@@ -1030,7 +1030,6 @@ function stockComplete(params) {
 
 function operatingAccount(params) {
   params = querystring.parse(params);
-  console.log(params);
   var fiscal_id = sanitize.escape(params.fiscal_id),
     sql;
 
@@ -1043,10 +1042,10 @@ function operatingAccount(params) {
     'AND account_type.type = \'income/expense\' ' +
     'ORDER BY account.account_number ASC';
 
-  if(params.period_id === 'all'){
+  if (params.period_id === 'all') {
     sql = 
       'SELECT period_total.period_id, account.account_number, account.account_txt, SUM(period_total.credit) AS \'credit\', ' +
-      'SUM(period_total.debit) AS \'debit\' ' +
+        'SUM(period_total.debit) AS \'debit\' ' +
       'FROM period_total ' +
       'JOIN account ON account.id = period_total.account_id ' +
       'JOIN account_type ON account_type.id = account.account_type_id ' +


### PR DESCRIPTION
This commit implements a number of fixes on accounting reports.  They
are enumerated here:
 1. Massive HTML cleanups.  Make sure labels line up with inputs, using
 ng-options where possible, etc.
 2. Broken conversion to `controller as` in operating_account has been
 corrected.
 3. Better translations in places
 4. Make sure reports that overflow are visible about footers
 5. Make sure currencies are right-aligned and formatted with their
 proper currency ids.

**NOTE** This commit does not change _anything_ about the behavior of the accounting reports, except where the report was broken and has been fixed.  Behavioral changes will follow in a separate pull request.