### PR TITLE
Removed client lint from client build process 

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,6 +16,7 @@ var gulp       = require('gulp'),
     path       = require('path'),
     iife       = require('gulp-iife'),
     rimraf     = require('rimraf'),
+    gutil      = require('gulp-util'),
 
     // mocha for server-side testing
     mocha      = require('gulp-mocha'),
@@ -168,9 +169,20 @@ gulp.task('watch-client', function () {
   gulp.watch(paths.client.vendor, ['client-mv-vendor']);
 });
 
+// TODO This message can be removed once the lint/build process has been transitioned
+gulp.task('notify-lint-process', function () { 
+  gutil.log(gutil.colors.yellow('REMINDER: Please ensure you have run the command `gulp lint` before submitting a pull request to github'));
+})
+
 // builds the client with all the options available
 gulp.task('build-client', ['client-clean'], function () {
-  gulp.start('client-lint-js', 'client-minify-js', 'client-minify-css', 'client-mv-vendor', 'client-vendor-build-slickgrid', 'client-mv-static');
+  gulp.start('client-minify-js', 'client-minify-css', 'client-mv-vendor', 'client-vendor-build-slickgrid', 'client-mv-static', 'notify-lint-process');
+});
+
+// Lint client code seperately from build process 
+// TODO Processes for linting server code - requires uncategorised commit update
+gulp.task('lint', ['client-clean'], function () { 
+  gulp.start('client-lint-js', 'client-lint-i18n');
 });
 
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
This pull request speed up the client build process significantly. 

On my development machine the build process now takes **~900ms** down from **~7s**. 

The client lint process has been moved to a new task **gulp lint**. A warning has been added to the build process to remind developers to lint their code before submitting a pull request. This utilises gulp-util (developed by the gulp team).