### PR TITLE
FIX(inventory): calculate stock levels correctly

### DIFF
--- a/server/controllers/inventory.js
+++ b/server/controllers/inventory.js
@@ -460,11 +460,14 @@ function getInventoryLots(req, res, next) {
 * GET /inventory/:uuid/lots
 * Retrieve all active lots (quantity > 0) for a given inventory item.  NOTE -
 * this query does not filter by expiration date or any other stock metadata.
+* Returns an array of lots to the client.
+* 
+* @function getInventoryLotsById
 */
 function getInventoryLotsById(req, res, next) {
   'use strict';
 
-  var uuid = req.param.uuid;
+  var uuid = req.params.uuid;
 
   lots.getInventoryLotsById(uuid)
   .then(function (rows) {
@@ -472,7 +475,7 @@ function getInventoryLotsById(req, res, next) {
       throw core.errors.NO_STOCK;
     }
 
-    res.status(200).json(rows[0]);
+    res.status(200).json(rows);
   })
   .catch(function (error) {
     core.errorHandler(error, req, res, next);

--- a/server/controllers/inventory/lots.js
+++ b/server/controllers/inventory/lots.js
@@ -16,10 +16,10 @@ function getInventoryLotsById(uuid) {
   var sql;
 
   sql =
-    'SELECT s.lot_number, (s.quanity - c.quantity) AS quantity ' +
-    'FROM stock AS s JOIN consumption AS c ON ' +
+    'SELECT s.lot_number, s.quantity - IF(c.canceled, 0, IFNULL(c.quantity, 0)) AS quantity ' +
+    'FROM stock AS s LEFT JOIN consumption AS c ON ' +
       's.tracking_number = c.tracking_number ' +
-    'WHERE s.uuid = ? AND quantity > 0;';
+    'WHERE s.inventory_uuid = ?';
 
   return db.exec(sql, [uuid]);
 }

--- a/server/controllers/inventory/stock.js
+++ b/server/controllers/inventory/stock.js
@@ -54,18 +54,11 @@ function getStockLevelsById(uuid, options) {
 
   var sql;
 
-  // We do a LEFT JOIN here because stock and consumption are related by a
-  // tracking number.  For every consumption event, there was an initial stock
-  // entry, so we should be able to capture all stock entry and consumption
-  // events with this LEFT JOIN.
-  //
-  // TODO - is this optimal?
   sql =
-    'SELECT s.inventory_uuid AS uuid, ' +
-      'SUM(s.quantity - c.quantity) AS quantity ' +
+    'SELECT s.inventory_uuid, SUM(s.quantity - IFNULL(c.quantity, 0)) AS quantity ' +
     'FROM stock AS s LEFT JOIN consumption AS c ON ' +
       's.tracking_number = c.tracking_number ' +
-    'WHERE c.canceled <> 1 AND s.inventory_uuid = ? ' +
+    'WHERE s.inventory_uuid = ? ' +
     'GROUP BY s.inventory_uuid;';
 
   return db.exec(sql, [uuid]);
@@ -76,7 +69,7 @@ function getStockLevelsById(uuid, options) {
 * Compute the average stock quantity (entries - consumption) for all inventory
 * items over time.
 *
-* @function getStockLevelsById
+* @function getAverageStockLevelsById
 * @param {Object} options Filtering options for the SQL query
 * @returns {Promise} The database request promise
 */


### PR DESCRIPTION
This commit fixes a critical bug where stock levels were only given if
stock was being consumed.  This has been corrected to include stock with
no consumption events.