### PR TITLE
Fixing tax and cotisation labels

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -386,6 +386,8 @@
    "ACCOUNT"               : "Account",
    "ACCOUNT_ID"            : "Account ID",
    "ACCOUNT_NUMBER"        : "Account Number",
+   "ACCOUNT_TO_CREDIT"     : "Account to credit",
+   "ACCOUNT_TO_DEBIT"      : "Account to debit",
    "ACTION"                : "Action",
    "ACTIONS"               : "Actions",
    "ALERTS"                : "Alerts",

--- a/client/src/i18n/fr.json
+++ b/client/src/i18n/fr.json
@@ -387,6 +387,8 @@
    "ACCOUNT"               : "Compte",
    "ACCOUNT_ID"            : "ID Compte",
    "ACCOUNT_NUMBER"        : "Numéro Compte",
+   "ACCOUNT_TO_CREDIT"     : "Compte à créditer",
+   "ACCOUNT_TO_DEBIT"      : "Compte à débiter",
    "ACTION"                : "Action",
    "ACTIONS"               : "Actions",
    "ALERTS"                : "Alertes",

--- a/client/src/partials/cotisation/create/create_cotisation.html
+++ b/client/src/partials/cotisation/create/create_cotisation.html
@@ -34,8 +34,8 @@
               <th>{{ "COLUMNS.ABBR" | translate}}</th>
               <th>{{ "COLUMNS.STAFF_COST" | translate}}</th>
               <th>{{ "COLUMNS.IS_PERCENT" | translate}}</th>
-              <th>{{ "COLUMNS.FOUR_ACCOUNT" | translate}}</th>
-              <th>{{ "COLUMNS.SIX_ACCOUNT" | translate}}</th>
+              <th>{{ "COLUMNS.ACCOUNT_TO_CREDIT" | translate}}</th>
+              <th>{{ "COLUMNS.ACCOUNT_TO_DEBIT" | translate}}</th>
               <th>{{ "COLUMNS.VALUE" | translate}}</th>
               <th colspan="4">{{ "COLUMNS.ACTIONS" | translate }}</th>
             </tr>
@@ -106,7 +106,7 @@
           </div>
 
           <div class="form-group">
-            <label class="control-label col-xs-4 required">{{ "COLUMNS.FOUR_ACCOUNT" | translate }}</label>
+            <label class="control-label col-xs-4 required">{{ "COLUMNS.ACCOUNT_TO_CREDIT" | translate }}</label>
             <div class="col-xs-7">
               <select class="form-bhima" required ng-model="session.new.four_account_id" ng-options="account.id as account.account_number + ' -- ' + account.account_txt for account in accounts.data | orderBy:'account_number'">
               </select>
@@ -114,7 +114,7 @@
           </div>
 
           <div class="form-group">
-            <label class="control-label col-xs-4 required">{{ "COLUMNS.SIX_ACCOUNT" | translate }}</label>
+            <label class="control-label col-xs-4 required">{{ "COLUMNS.ACCOUNT_TO_DEBIT" | translate }}</label>
             <div class="col-xs-7">
               <select class="form-bhima" required ng-model="session.new.six_account_id" ng-options="account.id as account.account_number + ' -- ' + account.account_txt for account in accounts.data | orderBy:'account_number'">
               </select>
@@ -168,7 +168,7 @@
           </div>
 
           <div class="form-group">
-            <label class="control-label col-xs-4 required">{{ "COLUMNS.FOUR_ACCOUNT" | translate }}</label>
+            <label class="control-label col-xs-4 required">{{ "COLUMNS.ACCOUNT_TO_CREDIT" | translate }}</label>
             <div class="col-xs-7">
               <select class="form-bhima" ng-model="session.edit.four_account_id" ng-options="account.id as account.account_number + ' -- ' + account.account_txt for account in accounts.data | orderBy:'account_number'">
               </select>
@@ -176,7 +176,7 @@
           </div>
 
           <div class="form-group">
-            <label class="control-label col-xs-4 required">{{ "COLUMNS.SIX_ACCOUNT" | translate }}</label>
+            <label class="control-label col-xs-4 required">{{ "COLUMNS.ACCOUNT_TO_DEBIT" | translate }}</label>
             <div class="col-xs-7">
               <select class="form-bhima" ng-model="session.edit.six_account_id" ng-options="account.id as account.account_number + ' -- ' + account.account_txt for account in accounts.data | orderBy:'account_number'">
               </select>

--- a/client/src/partials/taxe/create/create_taxe.html
+++ b/client/src/partials/taxe/create/create_taxe.html
@@ -35,8 +35,8 @@
               <th>{{ "COLUMNS.ABBR" | translate}}</th>
               <th>{{ "COLUMNS.STAFF_COST" | translate}}</th>
               <th>{{ "COLUMNS.IS_PERCENT" | translate}}</th>
-              <th>{{ "COLUMNS.FOUR_ACCOUNT" | translate}}</th>
-              <th>{{ "COLUMNS.SIX_ACCOUNT" | translate}}</th>
+              <th>{{ "COLUMNS.ACCOUNT_TO_CREDIT" | translate}}</th>
+              <th>{{ "COLUMNS.ACCOUNT_TO_DEBIT" | translate}}</th>
               <th>{{ "COLUMNS.VALUE" | translate}}</th>
               <th colspan="4">{{ "COLUMNS.ACTIONS" | translate }}</th>
             </tr>
@@ -114,18 +114,18 @@
           </div>
 
           <div class="form-group">
-            <label class="control-label col-xs-4 required">{{ "COLUMNS.FOUR_ACCOUNT" | translate }}</label>
+            <label class="control-label col-xs-4 required">{{ "COLUMNS.ACCOUNT_TO_CREDIT" | translate }}</label>
             <div class="col-xs-7">
               <select class="form-bhima" required ng-model="session.new.four_account_id" ng-options="account.id as account.account_number + ' -- ' + account.account_txt for account in accounts.data | orderBy:'account_number'">
-              </select>  
+              </select>
             </div>
-          </div>        
+          </div>
 
           <div class="form-group">
-            <label class="control-label col-xs-4 required">{{ "COLUMNS.SIX_ACCOUNT" | translate }}</label>
+            <label class="control-label col-xs-4 required">{{ "COLUMNS.ACCOUNT_TO_DEBIT" | translate }}</label>
             <div class="col-xs-7">
               <select class="form-bhima" required ng-model="session.new.six_account_id" ng-options="account.id as account.account_number + ' -- ' + account.account_txt for account in accounts.data | orderBy:'account_number'">
-              </select>              
+              </select>
             </div>
           </div>
 
@@ -183,7 +183,7 @@
           </div>
 
           <div class="form-group">
-            <label class="control-label col-xs-4 required">{{ "COLUMNS.FOUR_ACCOUNT" | translate }}</label>
+            <label class="control-label col-xs-4 required">{{ "COLUMNS.ACCOUNT_TO_CREDIT" | translate }}</label>
             <div class="col-xs-7">
               <select class="form-bhima" ng-model="session.edit.four_account_id" ng-options="account.id as account.account_number + ' -- ' + account.account_txt for account in accounts.data | orderBy:'account_number'">
               </select>
@@ -191,7 +191,7 @@
           </div>
 
           <div class="form-group">
-            <label class="control-label col-xs-4 required">{{ "COLUMNS.SIX_ACCOUNT" | translate }}</label>
+            <label class="control-label col-xs-4 required">{{ "COLUMNS.ACCOUNT_TO_DEBIT" | translate }}</label>
             <div class="col-xs-7">
               <select class="form-bhima" required ng-model="session.edit.six_account_id" ng-options="account.id as account.account_number + ' -- ' + account.account_txt for account in accounts.data | orderBy:'account_number'">
               </select>
@@ -207,5 +207,3 @@
     </div>
   </div>
 </main>
-
-


### PR DESCRIPTION
This PR fix the `four` and `six` account labels in cotisations and tax management by replacing them by `account to credit` and `account to debit`