### PR TITLE
fix: test PID cleanup

### DIFF
--- a/sh/integration-tests.sh
+++ b/sh/integration-tests.sh
@@ -21,9 +21,8 @@ echo "[test] Spawning server process..."
 ./node_modules/.bin/gulp build
 cd bin
 node server/app.js &
-NODE_PID=$!
 
-echo "[test] Spawned node process $NODE_PID."
+echo "[test] Spawned node process."
 
 # make sure we have enough time for the server to start
 echo "[test] Sleeping for $TIMEOUT seconds."
@@ -33,8 +32,5 @@ echo "[test] running tests using mocha"
 
 # run the tests
 ../node_modules/.bin/mocha --recursive --bail ../test/integration/
-
-echo "[test] cleaning up node process $NODE_PID."
-kill -9 $NODE_PID
 
 echo "[/test]"

--- a/sh/test-ends.sh
+++ b/sh/test-ends.sh
@@ -23,16 +23,13 @@ echo "[test] Spawning server process..."
 ./node_modules/.bin/gulp build
 cd bin
 node server/app.js &
-NODE_PID=$!
 
-echo "[test] Spawned node process $NODE_PID."
+echo "[test] Spawned node process."
 
 echo "[test] Sleeping for $TIMEOUT seconds."
 sleep "$TIMEOUT"
 
 echo "[test] Running tests using protractor."
 ../node_modules/.bin/protractor ../protractor.conf.js
-
-echo "[test] cleaning up node process $NODE_PID."
 
 echo "[/test]"

--- a/test/server-unit/dates.spec.js
+++ b/test/server-unit/dates.spec.js
@@ -1,12 +1,11 @@
-const dates = require('../../server/lib/template/helpers/dates');
 const { expect } = require('chai');
-
+const dates = require('../../server/lib/template/helpers/dates');
 
 const DateHelperUnitTests = function () {
   it('#date() should format a date is "DD/MM/YYYY" format.', () => {
-    const dat = new Date('2015-03-25');
+    const date = new Date('2015-03-25 12:00:00');
     const expected = '25/03/2015';
-    const formated = dates.date(dat);
+    const formated = dates.date(date);
     expect(formated).to.equal(expected);
   });
 
@@ -50,15 +49,15 @@ const DateHelperUnitTests = function () {
   it('#age() should return 3 for the current date.', () => {
     const current = new Date();
     const dob = new Date((current.getFullYear() - 3), current.getMonth());
-    var formated = dates.age(dob);
-    var expected = 3;
+    const formated = dates.age(dob);
+    const expected = 3;
     expect(formated).to.equal(expected);
   });
 
   it('#month should return the full month name in English for a given month.', () => {
     const dat = new Date('2015-03-25 10:05:15');
-    var formated = dates.month(dat);
-    var expected = 'March';
+    const formated = dates.month(dat);
+    const expected = 'March';
     expect(formated).to.equal(expected);
   });
 };

--- a/test/server-unit/util.spec.js
+++ b/test/server-unit/util.spec.js
@@ -1,7 +1,7 @@
-const util = require('../../server/lib/util');
-
 const { expect } = require('chai');
 const _ = require('lodash');
+
+const util = require('../../server/lib/util');
 
 describe('util.js', () => {
   it('#take() should take values from one key of each object in an array of objects', () => {
@@ -19,9 +19,10 @@ describe('util.js', () => {
 
   it('#dateFormatter() should format each javascript datetime value in a array of objects', () => {
     const rows = [
-      { name : 'alice', dob : new Date('2015-03-25') },
-      { name : 'bob', dob : new Date('2015-03-30') },
+      { name : 'alice', dob : new Date('2015-03-25 12:00:00') },
+      { name : 'bob', dob : new Date('2015-03-30 12:00:00') },
     ];
+
     const expected = [
       { name : 'alice', dob : '25/03/2015' },
       { name : 'bob', dob : '30/03/2015' },

--- a/yarn.lock
+++ b/yarn.lock
@@ -407,6 +407,12 @@ async@^1.4.0, async@~1.5:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
+async@^2.6.1, async@~2.6.0:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.1.tgz#b245a23ca71930044ec53fa46aa00a3e87c6a610"
+  dependencies:
+    lodash "^4.17.10"
+
 async@~0.2.6:
   version "0.2.10"
   resolved "https://registry.yarnpkg.com/async/-/async-0.2.10.tgz#b6bbe0b0674b9d719708ca38de8c237cb526c3d1"
@@ -414,12 +420,6 @@ async@~0.2.6:
 async@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/async/-/async-1.0.0.tgz#f8fc04ca3a13784ade9e1641af98578cfbd647a9"
-
-async@~2.6.0:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.6.1.tgz#b245a23ca71930044ec53fa46aa00a3e87c6a610"
-  dependencies:
-    lodash "^4.17.10"
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -2731,6 +2731,14 @@ form-data@0.1.3:
     combined-stream "~0.0.4"
     mime "~1.2.11"
 
+form-data@^2.3.2, form-data@~2.3.0, form-data@~2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.2.tgz#4970498be604c20c005d4f5c23aecd21d6b49099"
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "1.0.6"
+    mime-types "^2.1.12"
+
 form-data@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.0.0.tgz#6f0aebadcc5da16c13e1ecc11137d85f9b883b25"
@@ -2745,14 +2753,6 @@ form-data@~2.1.1:
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
-    mime-types "^2.1.12"
-
-form-data@~2.3.0, form-data@~2.3.1:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.2.tgz#4970498be604c20c005d4f5c23aecd21d6b49099"
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "1.0.6"
     mime-types "^2.1.12"
 
 formidable@1.0.14:
@@ -4848,6 +4848,20 @@ mailgun-js@^0.18.0:
     proxy-agent "~3.0.0"
     tsscmp "~1.0.0"
 
+mailgun-js@^0.20.0:
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/mailgun-js/-/mailgun-js-0.20.0.tgz#ebec0f9da3408388e9d74e12008d9633b982f6d7"
+  dependencies:
+    async "^2.6.1"
+    debug "~3.1.0"
+    form-data "^2.3.2"
+    inflection "~1.12.0"
+    is-stream "^1.1.0"
+    path-proxy "~1.0.0"
+    promisify-call "^2.0.2"
+    proxy-agent "~3.0.0"
+    tsscmp "~1.0.0"
+
 make-dir@^1.0.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.3.0.tgz#79c1033b80515bd6d24ec9933e860ca75ee27f0c"
@@ -6336,7 +6350,20 @@ proxy-addr@~2.0.3:
     forwarded "~0.1.2"
     ipaddr.js "1.6.0"
 
-proxy-agent@^3.0.0, proxy-agent@~3.0.0:
+proxy-agent@^2.0.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/proxy-agent/-/proxy-agent-2.3.1.tgz#3d49d863d46cf5f37ca8394848346ea02373eac6"
+  dependencies:
+    agent-base "^4.2.0"
+    debug "^3.1.0"
+    http-proxy-agent "^2.1.0"
+    https-proxy-agent "^2.2.1"
+    lru-cache "^4.1.2"
+    pac-proxy-agent "^2.0.1"
+    proxy-from-env "^1.0.0"
+    socks-proxy-agent "^3.0.0"
+
+proxy-agent@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/proxy-agent/-/proxy-agent-3.0.0.tgz#f6768e202889b2285d39906d3a94768416f8f713"
   dependencies:
@@ -6806,7 +6833,7 @@ request@2.81.0:
     tunnel-agent "^0.6.0"
     uuid "^3.0.0"
 
-request@^2.0.0, request@^2.74.0, request@^2.78.0, request@^2.83.0, request@^2.85.0:
+request@^2.0.0, request@^2.74.0, request@^2.78.0, request@^2.83.0, request@^2.87.0:
   version "2.87.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.87.0.tgz#32f00235cd08d482b4d0d68db93a829c0ed5756e"
   dependencies:
@@ -7236,14 +7263,15 @@ snyk-config@2.1.0:
     debug "^3.1.0"
     nconf "^0.10.0"
 
-snyk-docker-plugin@1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/snyk-docker-plugin/-/snyk-docker-plugin-1.8.0.tgz#c4f063c989b06509cd1be7fbb94e433d0c61641f"
+snyk-docker-plugin@1.10.3:
+  version "1.10.3"
+  resolved "https://registry.yarnpkg.com/snyk-docker-plugin/-/snyk-docker-plugin-1.10.3.tgz#2ac2f05ab821e122a5e1851240d3c021bbb8223f"
   dependencies:
     debug "^3.1.0"
     fs-extra "^5.0.0"
     pkginfo "^0.4.1"
-    request "^2.85.0"
+    request "^2.87.0"
+    temp-dir "^1.0.0"
 
 snyk-go-plugin@1.5.1:
   version "1.5.1"
@@ -7270,9 +7298,9 @@ snyk-mvn-plugin@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/snyk-mvn-plugin/-/snyk-mvn-plugin-1.2.0.tgz#e23c60e35457ce5a26fd4252ddf120dbd7e9ef2a"
 
-snyk-nuget-plugin@1.6.2:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/snyk-nuget-plugin/-/snyk-nuget-plugin-1.6.2.tgz#ea21181be53c1e7c9183907c25a71d914c5888b9"
+snyk-nuget-plugin@1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/snyk-nuget-plugin/-/snyk-nuget-plugin-1.6.3.tgz#841a754d5b8d6eee8744e2f842d3fa5e07a9b602"
   dependencies:
     debug "^3.1.0"
     es6-promise "^4.1.1"
@@ -7302,9 +7330,9 @@ snyk-policy@1.12.0:
     snyk-try-require "^1.1.1"
     then-fs "^2.0.0"
 
-snyk-python-plugin@1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/snyk-python-plugin/-/snyk-python-plugin-1.6.1.tgz#eb3194b37b4710edebee3406a2adea4a0159e89f"
+snyk-python-plugin@1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/snyk-python-plugin/-/snyk-python-plugin-1.8.0.tgz#e38c57521616cfb36743fca0f1d777c8994cb8d0"
   dependencies:
     tmp "0.0.33"
 
@@ -7355,9 +7383,9 @@ snyk-try-require@1.3.1, snyk-try-require@^1.1.1:
     lru-cache "^4.0.0"
     then-fs "^2.0.0"
 
-snyk@1.84.0:
-  version "1.84.0"
-  resolved "https://registry.yarnpkg.com/snyk/-/snyk-1.84.0.tgz#3f163fcc1597e3fc9ebf470b171ed0e46926976f"
+snyk@1.90.0:
+  version "1.90.0"
+  resolved "https://registry.yarnpkg.com/snyk/-/snyk-1.90.0.tgz#ba37f66484e18a56fc98f64d565a517a53fc8562"
   dependencies:
     abbrev "^1.1.1"
     ansi-escapes "^3.1.0"
@@ -7370,20 +7398,20 @@ snyk@1.84.0:
     needle "^2.0.1"
     opn "^5.2.0"
     os-name "^2.0.1"
-    proxy-agent "^3.0.0"
+    proxy-agent "^2.0.0"
     proxy-from-env "^1.0.0"
     recursive-readdir "^2.2.2"
     semver "^5.5.0"
     snyk-config "2.1.0"
-    snyk-docker-plugin "1.8.0"
+    snyk-docker-plugin "1.10.3"
     snyk-go-plugin "1.5.1"
     snyk-gradle-plugin "1.3.0"
     snyk-module "1.8.2"
     snyk-mvn-plugin "1.2.0"
-    snyk-nuget-plugin "1.6.2"
+    snyk-nuget-plugin "1.6.3"
     snyk-php-plugin "1.5.1"
     snyk-policy "1.12.0"
-    snyk-python-plugin "1.6.1"
+    snyk-python-plugin "1.8.0"
     snyk-resolve "1.0.1"
     snyk-resolve-deps "3.1.0"
     snyk-sbt-plugin "1.3.0"


### PR DESCRIPTION
The test script does not check for the existence of a PID before killing it, causing the test to fail if the PID was cleaned up normally.  We've undone that behavior by checking if the PID exists.

Fixes PRs: https://github.com/IMA-WorldHealth/bhima-2.X/pull/2993, https://github.com/IMA-WorldHealth/bhima-2.X/pull/2988