### PR TITLE
fix: clean up nodejs PIDs

### DIFF
--- a/sh/integration-tests.sh
+++ b/sh/integration-tests.sh
@@ -9,6 +9,7 @@ set -a
 source .env.development
 set +a
 
+
 ./sh/build-database.sh
 
 echo "[test]"
@@ -20,7 +21,13 @@ echo "[test] Spawning server process..."
 # build and start the server
 ./node_modules/.bin/gulp build
 cd bin
+
 node server/app.js &
+NODE_PID=$!
+echo "PID is: $NODE_PID"
+echo ""
+echo "process: $(ps aux | grep $NODE_PID | head -n 1)"
+echo ""
 
 echo "[test] Spawned node process."
 
@@ -32,5 +39,13 @@ echo "[test] running tests using mocha"
 
 # run the tests
 ../node_modules/.bin/mocha --recursive --bail ../test/integration/
+
+# kill process if exists
+echo "[test] checking to see if node process exists"
+if ps -p $NODE_PID > /dev/null; then
+  echo "[test] killing node process"
+  kill -9 $NODE_PID
+  echo "[test] killed node process $NODE_PID"
+fi
 
 echo "[/test]"

--- a/sh/test-ends.sh
+++ b/sh/test-ends.sh
@@ -21,8 +21,15 @@ TIMEOUT=${BUILD_TIMEOUT:-8}
 echo "[test] Spawning server process..."
 # build and start the server
 ./node_modules/.bin/gulp build
+
 cd bin
+
 node server/app.js &
+NODE_PID=$!
+echo "PID is: $NODE_PID"
+echo ""
+echo "process: $(ps aux | grep $NODE_PID | head -n 1)"
+echo ""
 
 echo "[test] Spawned node process."
 
@@ -31,5 +38,13 @@ sleep "$TIMEOUT"
 
 echo "[test] Running tests using protractor."
 ../node_modules/.bin/protractor ../protractor.conf.js
+
+# kill process if exists
+echo "[test] checking to see if node process exists"
+if ps -p $NODE_PID > /dev/null; then
+  echo "[test] killing node process"
+  kill -9 $NODE_PID
+  echo "[test] killed node process $NODE_PID"
+fi
 
 echo "[/test]"


### PR DESCRIPTION
This commit cleans up the node PIDS in the bash script by killing them if an error occurred.