### PR TITLE
Fix setting computed cost center allocation basis quantities

### DIFF
--- a/client/src/modules/cost_center/allocation_bases/allocation_bases.js
+++ b/client/src/modules/cost_center/allocation_bases/allocation_bases.js
@@ -89,6 +89,8 @@ function CostCenterAllocationBasesController(
           cellFilter : 'translate',
           aggregationHideLabel : true,
           aggregationType : uiGridConstants.aggregationTypes.count,
+          enableSorting : true,
+          sort : { direction : uiGridConstants.ASC, priority : 0 },
         }];
 
         // Build other columns for ui-grid
@@ -102,6 +104,7 @@ function CostCenterAllocationBasesController(
             footerCellClass : 'text-right',
             cellFilter : 'number: 2',
             footerCellFilter : 'number:2',
+            enableSorting : true,
             aggregationHideLabel : true,
             aggregationType : uiGridConstants.aggregationTypes.sum,
           };

--- a/client/src/modules/cost_center/cost_center.js
+++ b/client/src/modules/cost_center/cost_center.js
@@ -41,6 +41,8 @@ function CostCenterController(CostCenters, ModalService, Notify, uiGridConstants
         field : 'label',
         displayName : 'FORM.LABELS.DESIGNATION',
         headerCellFilter : 'translate',
+        enableSorting : true,
+        sort : { direction : uiGridConstants.ASC, priority : 0 },
       },
       {
         field : 'abbrs',


### PR DESCRIPTION
Redo setting computed cost center allocation basis quantities to delete previous values in order to avoid stale duplicate values.

This PR also updates the Cost Center registry page and the Allocation Bases page to list the cost centers alphabetically.

NOTE: This re-work zeros out the values of all allocation basis values (for all cost centers) that do not have computed values.

Closes https://github.com/IMA-WorldHealth/bhima/issues/6011

Tested: 

- bhima_test (with sample data).  This setup only has one employee currently assigned to any cost center so is not very interesting.
- vanga (JNiles version of Oct 5, 2021).   The fix works with this dataset.  However before applying the update, the total number of employees is 232.  After the update, the total is 200.  I suspect this has to do with issues with the vanga dataset, not this update/computation.

**TESTING**
- Use the vanga dataset from JNiles (Oct 5 or newer).
- Try  Cost Centers registry.  Note the before and after values below.  Some centers with zero employees are now showing (because we set them to zero if the computation does not provide a value).  Some centers with had some employees. Doing the [Update] set them to zero.  That is probably due to an issue with the Vanga dataset.
   
![image](https://user-images.githubusercontent.com/62145/136797102-fa1d3cda-c32d-41ee-ac77-8719e338eac8.png)

