### PR TITLE
Improve cost center allocation basis table and editor

### DIFF
--- a/client/src/modules/cost_center/allocation_bases/allocation_bases.js
+++ b/client/src/modules/cost_center/allocation_bases/allocation_bases.js
@@ -7,7 +7,9 @@ CostCenterAllocationBasesController.$inject = [
   'AllocationBasisQuantityService',
   'uiGridConstants',
   'NotifyService',
+  'SessionService',
   '$uibModal',
+  '$translate',
 ];
 
 function CostCenterAllocationBasesController(
@@ -16,9 +18,13 @@ function CostCenterAllocationBasesController(
   AllocationBasisQuantity,
   uiGridConstants,
   Notify,
+  Session,
   $modal,
+  $translate,
 ) {
   const vm = this;
+
+  vm.enterprise = Session.enterprise;
 
   // global variables
   vm.gridApi = {};
@@ -95,17 +101,24 @@ function CostCenterAllocationBasesController(
 
         // Build other columns for ui-grid
         const otherColumns = rows.costCenterIndexes.map((item) => {
+
+          let label = $translate.instant(item.index);
+          if (item.units) {
+            label += ` (${$translate.instant(item.units)})`;
+          }
+
           return {
             field : item.index,
-            displayName : item.index,
+            displayName : label,
             type : 'number',
-            headerCellFilter : 'translate',
             cellClass : 'text-right',
             footerCellClass : 'text-right',
-            cellFilter : 'number: 2',
-            footerCellFilter : 'number:2',
+            cellFilter : `number: ${item.decimal_places}`,
+            footerCellFilter : `number: ${item.decimal_places}`,
             enableSorting : true,
             aggregationHideLabel : true,
+            cellTemplate : item.is_currency && item.index === 'ALLOCATION_BASIS_DIRECT_COST'
+              ? '/modules/cost_center/allocation_bases/templates/direct_cost.tmpl.html' : null,
             aggregationType : uiGridConstants.aggregationTypes.sum,
           };
         });

--- a/client/src/modules/cost_center/allocation_bases/modals/action.modal.html
+++ b/client/src/modules/cost_center/allocation_bases/modals/action.modal.html
@@ -17,7 +17,7 @@
     </bh-cost-center-select>
 
     <div ng-repeat="basis in CCAllocationBasisModalCtrl.allocationBases track by basis.id" class="form-group" ng-class="{ 'has-error' : CCAllocationBasisForm.$submitted && CCAllocationBasisForm.text.$invalid }">
-      <label class="control-label" translate>{{ basis.name }}</label>
+      <label class="control-label">{{ basis.label }}</label>
       <input name="text" ng-model="CCAllocationBasisModalCtrl.ccAllocation[basis.name]" autocomplete="off" class="form-control">
       <div class="help-block" ng-messages="CCAllocationBasisForm[basis.name].$error" ng-show="CCAllocationBasisForm.$submitted">
         <div ng-messages-include="modules/templates/messages.tmpl.html"></div>

--- a/client/src/modules/cost_center/allocation_bases/modals/action.modal.js
+++ b/client/src/modules/cost_center/allocation_bases/modals/action.modal.js
@@ -3,12 +3,12 @@ angular.module('bhima.controllers')
 
 CCAllocationBasisModalController.$inject = [
   '$state', 'AllocationBasisService', 'AllocationBasisQuantityService',
-  'NotifyService', 'parameters', 'appcache',
+  'NotifyService', 'parameters', 'appcache', '$translate',
 ];
 
 function CCAllocationBasisModalController(
   $state, AllocationBasis, AllocationBasisQuantity,
-  Notify, parameters, AppCache,
+  Notify, parameters, AppCache, $translate,
 ) {
   const vm = this;
 
@@ -37,6 +37,7 @@ function CCAllocationBasisModalController(
   function onSelectCostCenter(cc) {
     vm.costCenter = cc;
     vm.costCenterId = cc.id;
+    loadAllocationBasisQuantity();
   }
 
   function load() {
@@ -50,6 +51,13 @@ function CCAllocationBasisModalController(
   function loadAllocationBasis() {
     return AllocationBasis.read(null, { cost_center_id : vm.costCenterId })
       .then(result => {
+        // Process the labels
+        result.forEach(item => {
+          item.label = $translate.instant(item.name);
+          if (item.units) {
+            item.label += ` (${$translate.instant(item.units)})`;
+          }
+        });
         vm.allocationBases = result || {};
       });
   }

--- a/client/src/modules/cost_center/allocation_bases/templates/direct_cost.tmpl.html
+++ b/client/src/modules/cost_center/allocation_bases/templates/direct_cost.tmpl.html
@@ -1,0 +1,3 @@
+<div class="ui-grid-cell-contents">
+  {{ row.entity.ALLOCATION_BASIS_DIRECT_COST | currency : grid.appscope.enterprise.currency_id }}
+</div>

--- a/server/controllers/finance/cost_center_allocation_bases.js
+++ b/server/controllers/finance/cost_center_allocation_bases.js
@@ -9,14 +9,14 @@ const db = require('../../lib/db');
 
 async function fetch() {
   const queryCostCenterIndexesList = `
-    SELECT 
-      cc.id, 
-      ccb.name AS cost_center_allocation_basis_label, 
+    SELECT
+      cc.id, ccb.is_currency, ccb.decimal_places, ccb.units,
+      ccb.name AS cost_center_allocation_basis_label,
       ccbv.quantity,
       cc.label AS cost_center_label,
-      cc.step_order 
-    FROM cost_center cc 
-      JOIN cost_center_allocation_basis_value ccbv ON ccbv.cost_center_id = cc.id 
+      cc.step_order
+    FROM cost_center cc
+      JOIN cost_center_allocation_basis_value ccbv ON ccbv.cost_center_id = cc.id
       JOIN cost_center_allocation_basis ccb ON ccb.id = ccbv.basis_id
     ORDER BY cc.step_order ASC;
   `;
@@ -32,10 +32,21 @@ async function fetch() {
     .map((index) => {
       const ccIndex = _.sortBy(indexes[index], 'step_order');
 
-      const line = { index, distribution : [] };
+      const [first] = indexes[index];
+      const line = {
+        index,
+        distribution : [],
+        units : first.units,
+        is_currency : first.is_currency,
+        decimal_places : first.decimal_places,
+      };
 
       ccIndex.forEach((item) => {
-        line.distribution.push({ id : item.id, cost_center_label : item.cost_center_label, value : item.quantity });
+        line.distribution.push({
+          id : item.id,
+          cost_center_label : item.cost_center_label,
+          value : item.quantity,
+        });
       });
 
       return line;


### PR DESCRIPTION
Improve the user interface for cost center allocation basis tables and value editor
- Allocation Keys registry: Add units to column headers
- Allocation Keys registry: Handle number of decimal places for various values
- Allocation Keys registry: Show direct cost as currency (currently only in the enterprise currency)
- Allocation basis value editor:  Show units in item labels
- Allocation basis value editor:  When using the [Edit] button, when you select a Cost Center, the known basis values for that cost center are now filled in

**TESTING**
- Use bhima_test with the sample data
- Cost Centers > Allocation Keys
  -  Note the units in some of the header cells
  -  Note appropriate numbers of decimal places (eg, none for whole numbers)
  - Click on the [Edit] button and note the added units labels
    - Select a cost center (eg Daycare Center).  Note the existing values are filled in

This should also be tested with a production database to test the migration file (I did not do that).