### PR TITLE
Add display and editing of cost center to service registry

### DIFF
--- a/client/src/i18n/en/cost_center.json
+++ b/client/src/i18n/en/cost_center.json
@@ -21,6 +21,7 @@
     "PRINCIPAL": "Principal Cost Center",
     "NO_COST_CENTER_DEFINED": "** Cost Center Not Defined **",
     "SELECT_ALLOCATION_BASIS": "Select allocation basis",
+    "SELECT_COST_CENTER": "Select Cost Center",
     "STEP_DOWN_COST_ALLOCATION": "Step-down cost allocation",
     "STEP_ORDER": "Allocation Step Order",
     "ONLY_FOR_EXPLOITATION_ACCOUNTS": "Only for operating accounts (income and expenses). For others accounts, the cost center will not be considered",

--- a/client/src/i18n/fr/cost_center.json
+++ b/client/src/i18n/fr/cost_center.json
@@ -21,6 +21,7 @@
     "PRINCIPAL": "Centre de coût Principal",
     "NO_COST_CENTER_DEFINED": "** Aucun centre de cout **",
     "SELECT_ALLOCATION_BASIS": "Sélectionnez la base d'allocation",
+    "SELECT_COST_CENTER": "Sélectionnez le centre de coût",
     "STEP_DOWN_COST_ALLOCATION": "Allocation séquentielle des coûts",
     "STEP_ORDER": "Ordre des étapes de l'allocation",
     "ONLY_FOR_EXPLOITATION_ACCOUNTS": "Uniquement pour les comptes d'exploitations (produits et charges). Pour les autres comptes, le centre de cout ne sera pas pris en compte",

--- a/client/src/modules/services/modals/service.modal.html
+++ b/client/src/modules/services/modals/service.modal.html
@@ -21,6 +21,13 @@
       </div>
     </div>
 
+    <bh-cost-center-select
+      label="COST_CENTER.SELECT_COST_CENTER"
+      cost-center-id="ServiceModalCtrl.service.cost_center_id"
+      on-select-callback="ServiceModalCtrl.onCostCenterSelect(costCenter)"
+      required="true">
+    </bh-cost-center-select>
+
     <bh-project-select
       project-id="ServiceModalCtrl.service.project_id"
       on-select-callback="ServiceModalCtrl.onSelectProject(project)"

--- a/client/src/modules/services/modals/service.modal.js
+++ b/client/src/modules/services/modals/service.modal.js
@@ -17,6 +17,11 @@ function ServiceModalController(
   vm.submit = submit;
   vm.closeModal = closeModal;
 
+  vm.onCostCenterSelect = cc => {
+    vm.service.cost_center_id = cc.id;
+    vm.service.cost_center_name = cc.label;
+  };
+
   vm.onSelectProject = project => {
     vm.service.project_id = project.id;
   };

--- a/client/src/modules/services/services.js
+++ b/client/src/modules/services/services.js
@@ -32,6 +32,11 @@ function ServicesController(Services, ModalService, Notify, uiGridConstants, $st
         headerCellFilter : 'translate',
       },
       {
+        field : 'cost_center_name',
+        displayName : 'TABLE.COLUMNS.COST_CENTER',
+        headerCellFilter : 'translate',
+      },
+      {
         field : 'project_name',
         displayName : 'FORM.LABELS.PROJECT',
         headerCellFilter : 'translate',

--- a/client/src/modules/services/services.service.js
+++ b/client/src/modules/services/services.service.js
@@ -7,6 +7,7 @@ function ServiceService(Api) {
   const service = new Api('/services/');
   const baseUrl = '/services/';
 
+  service.create = create;
   service.count = count;
   service.update = update;
 
@@ -14,6 +15,11 @@ function ServiceService(Api) {
     const url = baseUrl.concat('count');
     return service.$http.get(url)
       .then(service.util.unwrapHttpResponse);
+  }
+
+  function create(data) {
+    delete data.cost_center_name;
+    return Api.create.call(service, data);
   }
 
   function update(uuid, data) {
@@ -25,7 +31,7 @@ function ServiceService(Api) {
     delete data.project_name;
     delete data.enterprise_id;
 
-    return Api.update.call(this, uuid, data);
+    return Api.update.call(service, uuid, data);
   }
 
   return service;

--- a/server/models/migrations/next/migrate.sql
+++ b/server/models/migrations/next/migrate.sql
@@ -250,3 +250,20 @@ INSERT IGNORE INTO `cost_center_allocation_basis`
 VALUES
   (7, 'ALLOCATION_BASIS_NUM_PATIENTS', '', 'ALLOCATION_BASIS_NUM_PATIENTS_DESCRIPTION', 1, 0, 0, 0),
   (8, 'ALLOCATION_BASIS_NUM_LAB_TESTS', '', 'ALLOCATION_BASIS_NUM_LAB_TESTS_DESCRIPTION', 1, 0, 0, 0);
+
+/*
+ * @author: jmcameron
+ * @date: 2021-10-15
+ * @desc: Delete service_cost_center entries when referenced service or cost_center is deleted
+ * NOTE: Had to to use drop_foreign_key() since it will not delete a constraint if it does not exist.
+ *       Older databases might have used the old table name 'fee_center' instead of 'cost_center',
+ *       so to be safe, we delete both the old and new names before re-adding the modified constraint.
+ */
+
+CALL drop_foreign_key('service_cost_center', 'service_fee_center__service');   -- old constraint name
+CALL drop_foreign_key('service_cost_center', 'service_cost_center__service');
+CALL add_constraint_if_missing('service_cost_center', 'service_cost_center__service', 'FOREIGN KEY (`service_uuid`) REFERENCES `service` (`uuid`) ON DELETE CASCADE');
+
+CALL drop_foreign_key('service_cost_center', 'service_fee_center__fee_center');   -- old constraint name
+CALL drop_foreign_key('service_cost_center', 'service_cost_center__cost_center');
+CALL add_constraint_if_missing('service_cost_center', 'service_cost_center__cost_center', 'FOREIGN KEY (`cost_center_id`) REFERENCES `cost_center` (`id`) ON DELETE CASCADE');

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -2253,8 +2253,8 @@ CREATE TABLE `service_cost_center` (
   UNIQUE KEY `service_cost_center_1` (`service_uuid`),
   KEY `cost_center_id` (`cost_center_id`),
   KEY `service_uuid` (`service_uuid`),
-  CONSTRAINT `service_cost_center__service` FOREIGN KEY (`service_uuid`) REFERENCES `service` (`uuid`),
-  CONSTRAINT `service_cost_center__cost_center`  FOREIGN KEY (`cost_center_id`) REFERENCES `cost_center` (`id`)
+  CONSTRAINT `service_cost_center__service` FOREIGN KEY (`service_uuid`) REFERENCES `service` (`uuid`) ON DELETE CASCADE,
+  CONSTRAINT `service_cost_center__cost_center` FOREIGN KEY (`cost_center_id`) REFERENCES `cost_center` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARACTER SET = utf8mb4 DEFAULT COLLATE = utf8mb4_unicode_ci;
 
 DROP TABLE IF EXISTS `cost_center_allocation_basis`;


### PR DESCRIPTION
This PR adds a column for the cost center to the Service registry.  It also adds support for selecting/changing the cost center when editing/creating services.

Although I'm closing issue 5995 (adding a filter for services without cost centers), I feel like this PR adequately addresses that issue.  To see the services without cost centers, simply sort on the Cost Centers column (click header cell twice) and all the lines with blanks instead of cost center names are the ones that do not have cost centers.

**CHANGED:**  Now this requires selecting a cost center when creating or editing a service

Closes https://github.com/IMA-WorldHealth/bhima/issues/5995

**TESTING**
- Use any database.  It might be easier with bhima_test since it has services without cost centers
- If you use bhima_test, load the sample cost center data
- Go to:  Administration > Services  (the services registry)
- Try sorting by Cost Center to easily group services with not cost centers
- Test these 5 combinations
   - --Create a service without specifying a cost center--
   - Create a service and specify a cost center
   - Edit a service that does not have a cost center, change the project,  and try to save.  The form should force you select a cost center.
   - Edit a service with a cost center, change the project, and save.  The updated service should keep the old cost center value
   - Edit a service with a cost center and change the cost center.
   - NOTE: I tested the migration with the imck database.  It might be good to try it with another production database.  Note that updating the constraints to 'ON DELETE CASCADE' turned out to be tedious and tricky!

**Also check that the new 'ON DELETE CASCADE' for the 'service_cost_center' table is working:**
- Create two test cost centers (do not select services)
- Create a new service and select one of the new cost centers
- Create a second new service and select the other cost center
- Delete one of the new services.
- Go to the cost centers registry and verify that the link is gone for the service just deleted
- In the cost centers registry, delete the other new cost center
- Go back to the services registry and verify that the corresponding service is not connected to a cost center.
- You might want to check the service_cost_center table in SQL to verify the changes.