### PR TITLE
perf(stock): add skip tags functionality

### DIFF
--- a/client/src/js/components/bhStockExpired/bhStockExpired.js
+++ b/client/src/js/components/bhStockExpired/bhStockExpired.js
@@ -56,6 +56,7 @@ function bhStockExpiredController(Stock, moment, Notify, Depot, $filter) {
       is_expired : 1,
       depot_uuid : $ctrl.depotUuid,
       includeEmptyLot : 0,
+      skipTags : 1,
       dateTo,
     })
       .then(inventories => {

--- a/client/src/modules/stock/exit/exit.js
+++ b/client/src/modules/stock/exit/exit.js
@@ -295,6 +295,7 @@ function StockExitController(
     Stock.inventories.read(null, {
       depot_uuid : depot.uuid,
       dateTo,
+      skipTags : 1,
       is_expired : loadExpiredOnlyForLoss,
     })
       .then(inventories => {
@@ -315,7 +316,7 @@ function StockExitController(
 
   function loadCurrentInventories(depot, dateTo = new Date()) {
     vm.loading = true;
-    Stock.lots.read(null, { depot_uuid : depot.uuid, dateTo })
+    Stock.lots.read(null, { depot_uuid : depot.uuid, dateTo, skipTags : 1 })
       .then(lots => {
         vm.currentInventories = lots.filter(item => item.quantity > 0);
       })

--- a/server/controllers/stock/index.js
+++ b/server/controllers/stock/index.js
@@ -889,8 +889,9 @@ async function listLotsDepot(req, res, next) {
   try {
     const data = await core.getLotsDepot(null, params);
 
-    // if we have an empty set, do not query tags.
-    if (data.length !== 0) {
+    // if no data is returned or if the skipTags flag is set, we don't need to do any processing
+    // of tags.  Skip the SQL query and JS loops.
+    if (data.length !== 0 && !params.skipTags) {
       const queryTags = `
         SELECT BUID(t.uuid) uuid, t.name, t.color, BUID(lt.lot_uuid) lot_uuid
         FROM tags t


### PR DESCRIPTION
Ensures that routes which do not need to query lot tags can opt out to give a little performance gain.

Related to #6027.