### PR TITLE
Added allocation basis to each auxiliary center in step-down cost analysis

### DIFF
--- a/server/controllers/finance/cost_center_allocation_registry.js
+++ b/server/controllers/finance/cost_center_allocation_registry.js
@@ -90,7 +90,9 @@ async function fetch(session, params) {
     const row = {
       name : ei.cost_center_label,
       principal : ei.principal,
+      auxiliary : ei.auxiliary,
       direct : ei.directCost,
+      allocation_basis : ei.allocation_basis_id,
       values : [],
       total : 0,
     };

--- a/server/controllers/finance/reports/cost_center_step_down/report.handlebars
+++ b/server/controllers/finance/reports/cost_center_step_down/report.handlebars
@@ -36,6 +36,7 @@
             <tr>
               <th>{{translate 'FORM.LABELS.SERVICE'}}</th>
               <th>{{translate 'COST_CENTER.DIRECT_COST'}}</th>
+              <th>{{translate 'COST_CENTER.ALLOCATION_BASIS'}}</th>
               {{#each data as | service |}}
                 {{#unless service.is_principal}}
                 <th>{{ service.cost_center_label }}</th>
@@ -56,6 +57,11 @@
                   {{/if}}
                 </td>
                 <td class="text-right">{{debcred service.direct ../currencyId}}</td>
+                <td>
+                  {{#if service.auxiliary}}
+                    {{translate service.allocation_basis}}
+                  {{/if}}
+                </td>
                 {{#each service.values as | distribution |}}
                   {{#if distribution.selfCenter}}
                     <td class="text-right">{{debcred distribution.selfCenterValue ../../currencyId}}</td>
@@ -72,6 +78,7 @@
             <tr>
               <th>{{translate 'TABLE.COLUMNS.TOTAL'}}</th>
               <th class="text-right">{{debcred directCostTotal currencyId}}</th>
+              <th></th>
               {{#each cumulatedAllocatedCosts as | value |}}
                 <th class="text-right">{{debcred value ../currencyId}}</th>
                 <th></th>


### PR DESCRIPTION
Updated the step-down cost center allocation report to include a new column indicated which allocation basis is used for each auxiliary center.

Closes https://github.com/IMA-WorldHealth/bhima/issues/6033

Tested with bhima_test with sample cost allocation data.  
It would be useful to test this PR with the Vanga data.