### PR TITLE
ci: update Semaphore with latest node

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -40,12 +40,6 @@ blocks:
           value: 'app,errors,app:uploader'
         - name: UPLOAD_DIR
           value: client/upload
-        - name: MAILGUN_API_KEY
-          value: key-XXX
-        - name: MAILGUN_DOMAIN
-          value: sandbox3ffc48c87d5e4c1c9fa257342faf6f75.mailgun.org
-        - name: MAILGUN_SERVER_ADDRESS
-          value: test@bhi.ma
         - name: BUILD_TIMEOUT
           value: '30'
       jobs:
@@ -74,6 +68,7 @@ blocks:
               values:
                 - '12'
                 - '14'
+                - '16'
 
   - name: Install Testing Matrix
     dependencies: ["Update Dependencies"]
@@ -101,12 +96,6 @@ blocks:
           value: 'app,errors'
         - name: UPLOAD_DIR
           value: client/upload
-        - name: MAILGUN_API_KEY
-          value: key-XXX
-        - name: MAILGUN_DOMAIN
-          value: sandbox3ffc48c87d5e4c1c9fa257342faf6f75.mailgun.org
-        - name: MAILGUN_SERVER_ADDRESS
-          value: test@bhi.ma
         - name: BUILD_TIMEOUT
           value: '30'
       jobs:
@@ -131,3 +120,4 @@ blocks:
               values:
                 - '12'
                 - '14'
+                - '16'


### PR DESCRIPTION
We haven't been testing on the latest NodeJS version.  This script updates our CI configuration to remove old variables and add in the latest nodejs release.