### PR TITLE
feat(journal): trial balance checks on cost centers

### DIFF
--- a/client/src/i18n/en/posting_journal.json
+++ b/client/src/i18n/en/posting_journal.json
@@ -45,6 +45,8 @@
       "LOCKED_DEBTOR_GROUP_ACCOUNT" : "These transactions use an account of a locked debtor group and may have been made in error.  To correct this, either modify the transactions or unlock the debtor group.",
       "LOCKED_PERIOD" : "An accountant has locked the periods used in these transactions. To correct this error, please unlock the periods in the fiscal year module.",
       "MISSING_ACCOUNTS" : "Accounts omitted",
+      "MISSING_COST_CENTER" : "Transaction concerns an income or expense account that does not have an associated cost center.",
+      "INVALID_COST_CENTER" : "Cost centers are associated with accounts that are not income or expense accounts.",
       "MISSING_DATES" : "Missing Dates",
       "MISSING_DESCRIPTION" : "Descriptions omitted",
       "MISSING_DOCUMENT_ID" : "Records without document ID",

--- a/client/src/i18n/fr/posting_journal.json
+++ b/client/src/i18n/fr/posting_journal.json
@@ -46,6 +46,8 @@
       "LOCKED_DEBTOR_GROUP_ACCOUNT" : "Ces transactions utilisent un compte d'un groupe de débiteurs verrouillé et peuvent avoir été faites par erreur. Pour corriger cela, modifiez les transactions ou déverrouillez le groupe de débiteurs.",
       "LOCKED_PERIOD" : "Periodes(s) verrouille(s)",
       "MISSING_ACCOUNTS" : "Compte(s) omis",
+      "MISSING_COST_CENTER" : "L'opération concerne un compte de produits ou de charges qui n'a pas de centre de coûts associé.",
+      "INVALID_COST_CENTER" : "Les centres de coûts sont associés à des comptes qui ne sont pas des comptes de revenus ou de dépenses.",
       "MISSING_DATES" : "Date(s) manquante(s)",
       "MISSING_DESCRIPTION" : "Descriptions omises",
       "MISSING_DOCUMENT_ID" : "Ligne(s) sans ID Document",


### PR DESCRIPTION
Implements trial balance checks on the cost centers  The following checks are implemented:

1. Every line in a transaction that concerns an income/expense account requires a cost center.
2. Every line in a transaction that has a cost center id should be an income/expense account.

Closes #6009.


![image](https://user-images.githubusercontent.com/896472/138262507-fb1017f5-617c-4516-8f7f-bbe789861901.png)
