### PR TITLE
Transpose the table of allocation values in the cost center step-down report

### DIFF
--- a/client/src/i18n/en/cost_center.json
+++ b/client/src/i18n/en/cost_center.json
@@ -37,7 +37,9 @@
     "REPORT" : {
       "COST_CENTER_BY_ACCOUNTS" : "Cost center value by accounts",
       "COST_CENTER_BY_ACCOUNTS_DESCRIPTION" : "This report displays cost center value by accounts"
-    }
+    },
+    "SHOW_ALLOCATIONS_TABLE" : "Show allocations table?",
+    "SHOW_ALLOCATIONS_TABLE_HELP_TEXT" : "Show the table of allocation basis values for each cost center"
   },
   "ALLOCATION_METHOD": "Allocation method",
   "ALLOCATION_METHOD_FLAT": "Flat",

--- a/client/src/i18n/fr/cost_center.json
+++ b/client/src/i18n/fr/cost_center.json
@@ -37,7 +37,9 @@
     "REPORT" : {
       "COST_CENTER_BY_ACCOUNTS" : "Centre de coût par comptes",
       "COST_CENTER_BY_ACCOUNTS_DESCRIPTION" : "Ce rapport affiche la valeur des centres de cout par comptes"
-    }
+    },
+    "SHOW_ALLOCATIONS_TABLE" : "Afficher le tableau des allocations ?",
+    "SHOW_ALLOCATIONS_TABLE_HELP_TEXT" : "Afficher le tableau des valeurs de la base d'allocations pour chaque centre de coûts"
   },
   "ALLOCATION_METHOD": "Méthode d'allocation séquentielle des coûts",
   "ALLOCATION_METHOD_FLAT": "Uniform",

--- a/client/src/modules/reports/generate/cost_center_step_down/cost_center_step_down.config.js
+++ b/client/src/modules/reports/generate/cost_center_step_down/cost_center_step_down.config.js
@@ -20,6 +20,7 @@ function CostCenterStepdownReportConfigController($sce, Notify, SavedReports, Ap
   vm.previewGenerated = false;
   vm.reportDetails = {
     include_revenue : false,
+    show_allocations_table : true,
     currency_id : Session.enterprise.currency_id,
   };
 
@@ -37,6 +38,10 @@ function CostCenterStepdownReportConfigController($sce, Notify, SavedReports, Ap
 
   vm.onToggleRevenueCenter = function onToggleRevenueCenter(bool) {
     vm.reportDetails.include_revenue = bool;
+  };
+
+  vm.onToggleShowAllocationsTable = function onToggleShowAllocationsTable(bool) {
+    vm.reportDetails.show_allocations_table = bool;
   };
 
   vm.onSelectCurrency = (currency) => {

--- a/client/src/modules/reports/generate/cost_center_step_down/cost_center_step_down.html
+++ b/client/src/modules/reports/generate/cost_center_step_down/cost_center_step_down.html
@@ -36,6 +36,14 @@
               on-change-callback="ReportConfigCtrl.onToggleRevenueCenter(value)">
             </bh-yes-no-radios>
 
+            <bh-yes-no-radios
+              label="COST_CENTER.SHOW_ALLOCATIONS_TABLE"
+              value="ReportConfigCtrl.reportDetails.show_allocations_table"
+              name="show_allocations_table"
+              help-text="COST_CENTER.SHOW_ALLOCATIONS_TABLE_HELP_TEXT"
+              on-change-callback="ReportConfigCtrl.onToggleShowAllocationsTable(value)">
+            </bh-yes-no-radios>
+
             <!-- currency selection -->
             <bh-currency-select
               currency-id="ReportConfigCtrl.reportDetails.currency_id"

--- a/server/controllers/finance/cost_center_allocation_registry.js
+++ b/server/controllers/finance/cost_center_allocation_registry.js
@@ -82,7 +82,7 @@ async function fetch(session, params) {
   const hView = [];
   let totalAfterAllocation = 0;
 
-  // heck to get the correct number of colums
+  // heck to get the correct number of columns
   const numAuxiliaryCenters = data.filter(value => !value.is_principal).length;
 
   for (let i = 0; i < data.length; i++) {
@@ -123,14 +123,25 @@ async function fetch(session, params) {
   // cost center allocation keys details
   const { costCenterList, costCenterIndexes } = await ccAllocationKeys.fetch();
 
+  // Transpose the allocation columns
+  const allocationColumns = costCenterIndexes.map(item => item.index);
+  const allocationRows = [];
+  costCenterList.forEach((cName, i) => {
+    allocationRows.push({
+      centerName : cName,
+      allocationValues : costCenterIndexes.map(item => (item.distribution ? item.distribution[i].value : null)),
+    });
+  });
+
   return {
     dateFrom : range.dateFrom,
     dateTo : range.dateTo,
     currencyId : params.currency_id,
+    showAllocationsTable : Number(params.show_allocations_table),
     data,
     cumulatedAllocatedCosts,
-    costCenterIndexes,
-    costCenterList,
+    allocationColumns,
+    allocationRows,
     directCostTotal,
     totalAfterAllocation,
     hView,

--- a/server/controllers/finance/reports/cost_center_step_down/report.handlebars
+++ b/server/controllers/finance/reports/cost_center_step_down/report.handlebars
@@ -20,16 +20,16 @@
           <strong class="text-capitalize">{{date dateTo "MMMM YYYY"}}</strong>
         </h4>
 
+        {{#if this.rate}}
         <h5 class="text-center">
-          {{#if this.rate}}
             {{translate 'EXCHANGE.EXCHANGE_RATES'}} :
             {{currency 1 this.firstCurrency}} = {{currency this.rate this.secondCurrency}}
             <i>(<span>{{translate 'EXCHANGE.AT_THE_DATE'}}</span> {{date this.dateTo}})</i>
-          {{/if}}
         </h5>
+        {{/if}}
 
         {{!-- VIEW OF COST CENTER ALLOCATION --}}
-        <p>{{translate 'COST_CENTER.ALLOCATION_BY_COST_CENTERS'}}</p>
+        <p><strong>{{translate 'COST_CENTER.ALLOCATION_BY_COST_CENTERS'}}</strong></p>
         <p>P : {{translate 'COST_CENTER.PRINCIPAL'}}</p>
         <table style="page-break-after: always;" class="table table-striped table-condensed table-report table-bordered">
           <thead>
@@ -88,30 +88,32 @@
           </tfoot>
         </table>
 
+        {{#if this.showAllocationsTable}}
         <hr>
 
-        <p><i>{{translate 'COST_CENTER.ALLOCATION_BASIS_TABLE'}}</i></p>
+        <p><strong>{{translate 'COST_CENTER.ALLOCATION_BASIS_TABLE'}}</strong></p>
 
-        <table style="page-break-after: always;" class="table table-striped table-condensed table-report table-bordered">
+        <table style="width: auto; page-break-after: always;" class="table table-striped table-condensed table-report table-bordered">
           <thead>
             <tr>
-              <th>{{translate 'COST_CENTER.ALLOCATION_BASIS'}}</th>
-              {{#each costCenterList as | value |}}
-                <th>{{ value }}</th>
+              <th>{{translate 'COST_CENTER.TITLE'}}</th>
+              {{#each allocationColumns as | value |}}
+                <th>{{translate value }}</th>
               {{/each}}
             </tr>
           </thead>
           <tbody>
-            {{#each costCenterIndexes as | fcIndex |}}
+            {{#each allocationRows as | row |}}
               <tr>
-                <td>{{translate fcIndex.index }}</td>
-                {{#each fcIndex.distribution as | dist |}}
-                  <td class="text-right">{{ dist.value }}</td>
+                <td>{{translate row.centerName }}</td>
+                {{#each row.allocationValues as | value |}}
+                  <td class="text-right">{{ value }}</td>
                 {{/each}}
               </tr>
             {{/each}}
           </tbody>
         </table>
+        {{/if}}
       </div>
     </div>
   </div>


### PR DESCRIPTION
Also adds option to suppress or display the table of allocation values.

Closes https://github.com/IMA-WorldHealth/bhima/issues/6039

**TESTING**
- Use bhima_test with sample cost center data (select showing the table)
- Compare to original data.   Here is a screenshot of the un-transposed table:
![image](https://user-images.githubusercontent.com/62145/138309771-b5e95682-8030-4023-9e2d-d26d68e7e93c.png)
- Try suppressing the table
