### PR TITLE
Fix(Exchange rate) display correctly the exchange rate

### DIFF
--- a/client/src/css/structure.css
+++ b/client/src/css/structure.css
@@ -1023,9 +1023,10 @@ td.center {
 /* -------------------------------------
     Segment Statistic Card
 --------------------------------------- */
-.ima-stat-card .ui.statistic > .value {
+.ima-stat-card .ui.statistic > .value, .exchange-rate {
   color: var(--ima-blue);
 }
+
 .ima-stat-card .ui.statistic > .ui-hidable-label {
   color: black;
 }
@@ -1038,6 +1039,9 @@ td.center {
   color: white;
 }
 
+.exchange-rate {
+  font-size: 19px !important;
+}
 .voucher-tools-top-spacer {
   margin-top: 20px;
 }

--- a/client/src/modules/home/home.ctrl.js
+++ b/client/src/modules/home/home.ctrl.js
@@ -22,7 +22,7 @@ function HomeController(Currencies, Rates, Session, Notify, Fiscal, DashboardSer
 
   vm.today = new Date();
 
-  vm.primaryExchange = {};
+  vm.primaryExchange = [];
 
   // this limits the number of places that the page displays for the exchange rate
   vm.EXCHANGE_RATE_DISPLAY_SIZE = 6;
@@ -31,13 +31,6 @@ function HomeController(Currencies, Rates, Session, Notify, Fiscal, DashboardSer
   vm.project = Session.project;
   vm.user = Session.user;
   vm.enterprise = Session.enterprise;
-  /*
-    vm.isFirstCurencyLabel is used to check the exchange Rate
-    is lower then 1  the program show display something
-    much better for reading
-  */
-  vm.isFirstCurencyLabel = false;
-
   // load exchange rates
   Currencies.read(true)
     .then((currencies) => {
@@ -51,24 +44,20 @@ function HomeController(Currencies, Rates, Session, Notify, Fiscal, DashboardSer
     })
     .then(() => {
       vm.currencies.forEach((currency) => {
+        /*
+          currency.isFirstCurencyLabel is used to check the exchange Rate
+          is lower then 1  the program show display something
+          much better for reading
+        */
+        currency.isFirstCurencyLabel = false;
         const exchange = Rates.getCurrentExchange(currency.id);
         currency.rate = exchange.rate;
         currency.date = exchange.date;
-        /*
-          Let check is the currency rate is lower the 1
-          so that we could format it in a readable way
-        */
-
-        if (currency.rate < 1) {
-          currency.rate = (1 / currency.rate);
-          vm.isFirstCurencyLabel = true;
-        }
-
         currency.formattedDate = new Moment(currency.date).format('LL');
       });
 
       // @TODO Method for selecting primary exchange
-      [vm.primaryExchange] = vm.currencies;
+      vm.primaryExchange = vm.currencies;
 
     })
     .catch(err => {

--- a/client/src/modules/home/home.html
+++ b/client/src/modules/home/home.html
@@ -62,22 +62,18 @@
       <div class="col-md-4">
 
         <div class="panel panel-default segment ima-stat-card">
-          <div class="panel-body text-center">
+          <div class="panel-body text-center" style="min-height: 124px;">
             <div class="segment-title" translate>TABLE.COLUMNS.EXCHANGE_RATE</div>
-            <div class="ui huge statistic" title="{{ HomeCtrl.primaryExchange.rate}} ({{ HomeCtrl.primaryExchange.symbol }})">
+            <div 
+              ng-repeat="currency in HomeCtrl.primaryExchange"
+              class="col-sm-12" title="{{ HomeCtrl.primaryExchange.rate}} ({{ currency.symbol }})">
 
-              <div class="value" ng-show ='!HomeCtrl.isFirstCurencyLabel'>
-                {{ HomeCtrl.primaryExchange.rate | limitTo:HomeCtrl.EXCHANGE_RATE_DISPLAY_SIZE }}({{ HomeCtrl.primaryExchange.symbol }})</div>
-
-                <div class="value" style='font-size:45px !important; padding-top:16px' ng-show ='HomeCtrl.isFirstCurencyLabel'>
-
-               1{{HomeCtrl.primaryExchange.symbol}} = {{ HomeCtrl.primaryExchange.rate | limitTo:HomeCtrl.EXCHANGE_RATE_DISPLAY_SIZE }}({{ HomeCtrl.enterprise.currencySymbol }})
-
+              <div class="exchange-rate">
+              {{ currency.rate | limitTo:HomeCtrl.EXCHANGE_RATE_DISPLAY_SIZE }} {{ currency.symbol }} = 
+              1 {{HomeCtrl.enterprise.currencySymbol}}
               </div>
 
-
-
-              <div class="uilabel"><span translate>HOME.EXCHANGE_SET</span> {{ HomeCtrl.primaryExchange.formattedDate }}</div>
+              <div><span translate>HOME.EXCHANGE_SET</span> {{ currency.formattedDate }}</div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
I propose to display the exchange rates as follow :

![new_rate](https://user-images.githubusercontent.com/25838121/138668693-b73266d7-2c46-4c08-8c7c-1857cc7214f4.PNG)

closes #6056