### PR TITLE
Updates for the Asset Registry

### DIFF
--- a/client/src/js/services/StockService.js
+++ b/client/src/js/services/StockService.js
@@ -227,6 +227,11 @@ function StockService(Api, StockFilterer, HttpCache, util, Periods) {
       });
   }
 
+  assets.getAssetLots = params => {
+    return assets.$http.get('/stock/assetLots', { params })
+      .then(util.unwrapHttpResponse);
+  };
+
   inventories.loadAMCForInventory = function loadAMCForInventory(inventoryUuid, depotUuid) {
     return inventories.$http.get(`/depots/${depotUuid}/inventories/${inventoryUuid}/cmm`)
       .then(util.unwrapHttpResponse);

--- a/client/src/modules/assets/assets-registry.js
+++ b/client/src/modules/assets/assets-registry.js
@@ -28,6 +28,8 @@ function AssetsRegistryController(
 
   vm.bhConstants = bhConstants;
 
+  vm.assetConditions = bhConstants.assetCondition;
+
   // grouping box
   vm.groupingBox = AssetsRegistry.groupingBox;
 
@@ -139,19 +141,25 @@ function AssetsRegistryController(
     }
     vm.hasError = false;
     toggleLoadingIndicator();
+    Stock.assets.getAssetLots(filters)
+      .then((assets) => {
 
-    Stock.lots.read(null, filters)
-      .then((lots) => {
-        lots.forEach((lot) => {
+        assets.forEach((asset) => {
           // serialize tag names for filters
-          lot.tagNames = lot.tags.map(tag => tag.name).join(',');
-          lot.tags.forEach(addColorStyle);
+          asset.tagNames = asset.tags.map(tag => tag.name).join(',');
+          asset.tags.forEach(addColorStyle);
+        });
+
+        // Add the asset scan condition
+        assets.forEach((asset) => {
+          const cond = vm.assetConditions.find(c => c.id === asset.scan_condition_id);
+          asset.scan_condition = cond ? cond.label : '';
         });
 
         // FIXME(@jniles): we should do this ordering on the server via an ORDER BY
-        lots.sort(AssetsRegistry.orderByDepot);
+        assets.sort(AssetsRegistry.orderByDepot);
 
-        vm.gridOptions.data = lots.filter(lot => lot.quantity > 0);
+        vm.gridOptions.data = assets.filter(asset => asset.quantity > 0);
 
         vm.grouping.unfoldAllGroups();
         vm.gridApi.core.notifyDataChange(uiGridConstants.dataChange.COLUMN);

--- a/client/src/modules/assets/assets-registry.service.js
+++ b/client/src/modules/assets/assets-registry.service.js
@@ -24,16 +24,16 @@ function AssetsRegistryService(uiGridConstants, Session) {
       headerTooltip : 'STOCK.DEPOT',
       headerCellFilter : 'translate',
     }, {
-      field : 'code',
+      field : 'inventory_code',
       displayName : 'STOCK.CODE',
-      headerTooltip : 'STOCK.CODE',
+      headerTooltip : 'INVENTORY.CODE',
       headerCellFilter : 'translate',
       sort : {
         direction : uiGridConstants.ASC,
         priority : 0,
       },
     }, {
-      field : 'text',
+      field : 'inventory_label',
       displayName : 'STOCK.INVENTORY',
       headerTooltip : 'STOCK.INVENTORY',
       headerCellFilter : 'translate',
@@ -90,14 +90,6 @@ function AssetsRegistryService(uiGridConstants, Session) {
       headerCellClass : 'wrappingColHeader',
       cellFilter : 'date',
     }, {
-      field : 'expiration_date',
-      displayName : 'STOCK.EXPIRATION_DATE',
-      headerTooltip : 'STOCK.EXPIRATION_DATE',
-      headerCellFilter : 'translate',
-      headerCellClass : 'wrappingColHeader',
-      cellFilter : 'date',
-      visible : false,
-    }, {
       field : 'assigned_to_name',
       displayName : 'ENTITY.ASSIGNED_TO',
       headerTooltip : 'ENTITY.ASSIGNED_TO',
@@ -119,6 +111,22 @@ function AssetsRegistryService(uiGridConstants, Session) {
       headerCellClass : 'wrappingColHeader',
       visible : false,
     }, {
+      field : 'scan_date',
+      displayName : 'ASSET.LAST_SCAN_DATE',
+      headerTooltip : 'ASSET.LAST_SCAN_DATE',
+      headerCellFilter : 'translate',
+      headerCellClass : 'wrappingColHeader',
+      cellFilter : 'date',
+      visible : false,
+    }, {
+      field : 'scan_condition',
+      displayName : 'ASSET.ASSET_CONDITION',
+      headerTooltip : 'ASSET.ASSET_CONDITION',
+      headerCellFilter : 'translate',
+      headerCellClass : 'wrappingColHeader',
+      cellFilter : 'translate',
+      visible : false,
+    }, {
       field : 'tagNames',
       displayName : 'TAG.LABEL',
       headerTooltip : 'TAG.LABEL',
@@ -133,18 +141,12 @@ function AssetsRegistryService(uiGridConstants, Session) {
       cellFilter : 'date',
       visible : false,
     }, {
-      field : 'status',
-      displayName : 'TABLE.COLUMNS.STATUS',
-      headerTooltip : 'TABLE.COLUMNS.STATUS',
-      headerCellFilter : 'translate',
-      cellFilter : 'translate',
-      visible : false,
-    }, {
       field : 'reference_number',
       displayName : 'FORM.LABELS.REFERENCE_NUMBER',
       headerCellFilter : 'translate',
       headerCellClass : 'wrappingColHeader',
       width : 100,
+      visible : false,
     }, {
       field : 'manufacturer_brand',
       displayName : 'FORM.LABELS.MANUFACTURER_BRAND',

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -853,6 +853,7 @@ exports.configure = function configure(app) {
 
   app.post('/stock/lots', stock.createStock);
   app.get('/stock/lots', stock.listLots);
+  app.get('/stock/assetLots', stock.listAssetLots);
 
   app.get('/stock/lots/depots/', stock.listLotsDepot);
   app.get('/stock/lots/depotsDetailed/', stock.listLotsDepotDetailed);


### PR DESCRIPTION
This PR adds the date of the last scan and its condition to the Assets Registry page (via hidden columns).
This PR also refactors things to use the getAssets instead of getLotsDepot query interface in core.js in the back end.

Partially addresses Issue https://github.com/IMA-WorldHealth/bhima/issues/6440.

Closes https://github.com/IMA-WorldHealth/bhima/issues/6687

**TESTING**
- Use bhima_test
- Go to:  Assets Management > Assets Registry
  - Use the [Menu] > Columns interface to show the "Last Scan Date" and "Condition"
  - Check the output
  - Use [Menu] > Save Grid Configuration
- Go to the Assets Management > Assets Scans Registry
  - Scan one (or more) of the assets (change the condition during the scan)
- Go back to the Assets Registry page and verify the changes.
