### PR TITLE
refactor: replace cumsum with window functions

### DIFF
--- a/client/src/i18n/en/report.json
+++ b/client/src/i18n/en/report.json
@@ -308,13 +308,13 @@
     "VIEW_RECEIPT": "View Receipt",
     "VIEW_REQUISITION": "View requisition",
     "VIEW_VOUCHER": "View Vouchers",
-    "WARN_PREV_FY_NOT_CLOSED": "Attention! The previous Fiscal Year is not closed. The results in this report may not be accurate until is it closed! ",
+    "WARN_PREV_FY_NOT_CLOSED": "Attention! The previous fiscal year is not closed. The results in this report may not be accurate until is it closed! ",
     "ZERO_TO_THIRTY_DAYS": "Less Than 30 Days",
     "REPORT_ACCOUNTS": {
       "TITLE": "Account Report",
       "DESCRIPTION": "This report shows all transactions for an individual account given a set time period.",
       "WARN_MULTIPLE": "N.B. This report concerns an income/expense account and spans multiple fiscal years. Income/expense accounts are cleared to 0 at the beginning of every fiscal year. The cumulative balance displayed is for the transactions within this period of time. It is recommended to use this statement within a single fiscal year.",
-      "WARN_CURRENCY": "Attention! You are using a currency other than the enterprise currency.  Values on this report are subject to change with changes to the exchange rate and should not be considered final.  Please save a report in the enterprise currency for long term reference."
+      "WARN_CURRENCY": "Caution! You are using a currency other than the enterprise currency.  Values on this report are subject to change with changes to the exchange rate and should not be considered final.  Additionally, the running total in the converted currency may not equal the sum of all transactions in the report due to fluctuations in exchange rate over time.  Please save a report in the enterprise currency for long term reference."
     },
     "REPORT_ACCOUNTS_MULTIPLE": {
       "TITLE": "Multiple Accounts Report",

--- a/server/controllers/finance/accounts/transactions.js
+++ b/server/controllers/finance/accounts/transactions.js
@@ -10,74 +10,11 @@
  *
  */
 
-const _ = require('lodash');
+const debug = require('debug')('accounts:transactions');
 const db = require('../../../lib/db');
 const FilterParser = require('../../../lib/filter');
 const Exchange = require('../exchange');
 const Accounts = require('.');
-
-/**
- * @function getGeneralLedgerSQL
- *
- * @description
- * Used by the getAccountTransactions() function internally.  The internal SQL
- * just pulls out the values tied to a particular account.
- *
- * The exchange rate logic is complicated.  Here is the basic idea:
- *  1. If you are in the enterprise currency, you want the calculation to
- *    use ${amount} / rate to calculate the values.
- *  2. If the you not in the enterprise currency, you want to use ${amount} * rate
- *    to convert "back" to the enterprise currency.
- *
- */
-function getGeneralLedgerSQL(options) {
-  const filters = new FilterParser(options);
-
-  options.isEnterpriseCurrency = options.isEnterpriseCurrency || false;
-
-  // return the proper way to convert the values depending on if we are in the
-  // exchange rate currency or not.
-  const enterpriseCurrencyColumns = `
-    (debit / rate) AS exchangedDebit, (credit / rate) AS exchangedCredit,
-    (balance / rate) AS exchangedBalance, @cumsum := (balance / rate) + @cumsum AS cumsum
-  `;
-
-  const nonEnterpriseCurrencyColumns = `
-    (debit * rate) AS exchangedDebit, (credit * rate) AS exchangedCredit,
-    (balance * rate) AS exchangedBalance, @cumsum := (balance * rate) + @cumsum AS cumsum
-  `;
-
-  const columns = options.isEnterpriseCurrency ? enterpriseCurrencyColumns : nonEnterpriseCurrencyColumns;
-
-  // get the underlying table for posted/unposted
-  const subquery = getSubquery(options);
-  const sql = `
-    SELECT trans_id, description, trans_date, document_reference, debit, credit, posted, created_at,
-      transaction_type_id, debit_equiv, credit_equiv, currency_id, rate, IF(rate < 1, (1 / rate), rate) AS invertedRate,
-      ${columns}
-      FROM (
-      SELECT trans_id, description, trans_date, document_map.text AS document_reference,
-        IF(${options.isEnterpriseCurrency},
-          IFNULL(GetExchangeRate(${options.enterprise_id}, currency_id, trans_date), 1),
-          IF(${options.currency_id} = currency_id, 1,
-            IFNULL(GetExchangeRate(${options.enterprise_id}, ${options.currency_id}, trans_date), 1)
-        )) AS rate,
-        SUM(debit_equiv) as debit_equiv, SUM(credit_equiv) AS credit_equiv,
-        (SUM(debit) - SUM(credit)) AS balance, SUM(debit) AS debit,
-        SUM(credit) AS credit, MAX(currency_id) AS currency_id,
-        ${options.includeUnpostedValues ? 'posted' : '1 as posted'}, created_at, transaction_type_id
-      FROM ${subquery.query}
-      LEFT JOIN document_map ON record_uuid = document_map.uuid
-  `;
-
-  filters.setGroup('GROUP BY record_uuid');
-  filters.setOrder('ORDER BY trans_date ASC, created_at ASC');
-
-  const query = filters.applyQuery(sql);
-  const parameters = [...subquery.parameters, ...filters.parameters()];
-
-  return { query, parameters };
-}
 
 /**
  * @function getTableSubquery
@@ -86,16 +23,16 @@ function getGeneralLedgerSQL(options) {
  * This function creates the subquery for each table (posting_journal and general_ledger)
  * depending on which table is passed in.
  */
-function getTableSubquery(options, table) {
+function getTableSubquery(options, tableName) {
   const filters = new FilterParser(options);
 
   // selects 1 if the table is general_ledger or 0 if it is posting_journal
-  const postedValue = (table === 'posting_journal') ? 0 : 1;
+  const postedValue = (tableName === 'posting_journal') ? 0 : 1;
 
   const sql = `
   SELECT trans_id, description, trans_date, debit_equiv, credit_equiv, currency_id, debit, credit,
     account_id, record_uuid, reference_uuid, ${postedValue} as posted, created_at, transaction_type_id
-  FROM ${table}`;
+  FROM ${tableName}`;
 
   filters.equals('account_id');
   filters.dateFrom('dateFrom', 'trans_date');
@@ -121,12 +58,12 @@ function getSubquery(options) {
   const generalLedgerQuery = getTableSubquery(options, 'general_ledger');
 
   if (options.includeUnpostedValues) {
-    const query = `(${postingJournalQuery.query} UNION ALL ${generalLedgerQuery.query}) AS ledger`;
+    const query = `(${postingJournalQuery.query} UNION ALL ${generalLedgerQuery.query})`;
     const parameters = [...postingJournalQuery.parameters, ...generalLedgerQuery.parameters];
     return { query, parameters };
   }
 
-  const query = `(${generalLedgerQuery.query})z`;
+  const query = `(${generalLedgerQuery.query})`;
   const { parameters } = generalLedgerQuery;
   return { query, parameters };
 }
@@ -146,7 +83,7 @@ function getTotalsSQL(options) {
       SUM(ROUND(debit, 2)) AS debit, SUM(ROUND(credit, 2)) AS credit,
       SUM(ROUND(debit_equiv, 2)) AS debit_equiv, SUM(ROUND(credit_equiv, 2)) AS credit_equiv,
       (SUM(ROUND(debit_equiv, 2)) - SUM(ROUND(credit_equiv, 2))) AS balance
-    FROM ${subquery.query}
+    FROM (${subquery.query}) AS ledger
   `;
 
   const totalsParameters = subquery.parameters;
@@ -161,27 +98,19 @@ function getTotalsSQL(options) {
  * This function returns all the transactions for an account,
  */
 async function getAccountTransactions(options, openingBalance = 0) {
-  const { query, parameters } = getGeneralLedgerSQL(options);
-
-  // the running balance can only be in the enterprise currency.  It doesn't
-  // make sense to have the running balance in any other currency.
-  const sql = `
-    SELECT bhima_groups.trans_id, bhima_groups.debit, bhima_groups.credit, bhima_groups.debit_equiv,
-      bhima_groups.credit_equiv, bhima_groups.trans_date, bhima_groups.document_reference,
-      bhima_groups.exchangedCredit, bhima_groups.exchangedDebit, bhima_groups.exchangedBalance,
-      bhima_groups.rate, ROUND(bhima_groups.invertedRate, 2) AS invertedRate, bhima_groups.cumsum,
-      bhima_groups.description, bhima_groups.currency_id, bhima_groups.posted, created_at, transaction_type_id
-    FROM (${query})c, (SELECT @cumsum := ${openingBalance || 0})z) AS bhima_groups
-  `;
-
+  debug(`Fetching data for account_id: ${options.account_id}`);
+  const { query, parameters } = buildLedgerSQL(options, openingBalance);
   const { totalsQuery, totalsParameters } = getTotalsSQL(options);
 
   // fire all requests in parallel for performance reasons
   const [account, transactions, totals] = await Promise.all([
     Accounts.lookupAccount(options.account_id),
-    db.exec(sql, parameters),
+    db.exec(query, parameters),
     db.one(totalsQuery, totalsParameters),
   ]);
+
+  debug(`The account number is ${account.account_number} with a total of ${transactions.length} transactions.`);
+  debug(`Opening Balance of ${account.account_number} is ${openingBalance}.`);
 
   // alias the unposted record flag for styling with italics
   let hasUnpostedRecords = false;
@@ -191,10 +120,10 @@ async function getAccountTransactions(options, openingBalance = 0) {
   });
 
   // if there is data in the transaction array, use the date of the last transaction
-  const lastTransaction = transactions[transactions.length - 1];
+  const lastTransaction = transactions.at(-1);
   const lastDate = (lastTransaction && lastTransaction.trans_date) || options.dateTo;
 
-  const hasLastCumSum = !_.isUndefined(lastTransaction && lastTransaction.cumsum);
+  const hasLastCumSum = lastTransaction?.cumsum !== undefined;
   const lastCumSum = hasLastCumSum ? lastTransaction.cumsum : (totals.balance * totals.rate);
 
   // tells the report if it is safe to render the debit/credit sum.  It is only safe
@@ -219,6 +148,135 @@ async function getAccountTransactions(options, openingBalance = 0) {
   return {
     account, transactions, hasUnpostedRecords, footer,
   };
+}
+
+/**
+ * @function buildLedgerSQL
+ *
+ * @description
+ *
+ * Used by the getAccountTransactions() function internally.  The internal SQL
+ * just pulls out the values tied to a particular account.
+ *
+ * Constructs a single SQL statement (plus parameters) that:
+ * 1) Builds a combined ledger from general_ledger and (optionally) posting_journal
+ * 2) Joins the document_map
+ * 3) Sums results grouped by record_uuid
+ * 4) Converts amounts using a rate
+ * 5) Computes a running total (cumsum) using a window function
+ */
+function buildLedgerSQL(options, openingBalance = 0) {
+  const filters = new FilterParser(options);
+
+  // Decide if we include posted/unposted data or only posted
+  const tableQueries = [];
+  const tableParams = [];
+
+  // Always build the general ledger subquery
+  const { query : glQuery, parameters : glParams } = getTableSubquery(options, 'general_ledger');
+
+  tableQueries.push(glQuery);
+  tableParams.push(...glParams);
+
+  // Conditionally build the posting journal subquery for unposted records
+  if (options.includeUnpostedValues) {
+    const { query : pjQuery, parameters : pjParams } = getTableSubquery(options, 'posting_journal');
+
+    tableQueries.push(pjQuery);
+    tableParams.push(...pjParams);
+  }
+
+  // Combine data via UNION ALL if both posted/unposted are included
+  let unionSQL = tableQueries.join(' UNION ALL ');
+  if (tableQueries.length > 1) {
+    unionSQL = `(${unionSQL}) AS ledger`;
+  } else {
+    unionSQL = `(${unionSQL}) AS ledger`;
+  }
+
+  // Build grouping statement
+  // Once grouped per record_uuid, we apply the currency conversion logic
+  const groupingSQL = `
+    SELECT
+      trans_id,
+      description,
+      trans_date,
+      document_map.text AS document_reference,
+      created_at,
+      transaction_type_id,
+      MAX(currency_id) AS currency_id,
+      SUM(debit) AS debit,
+      SUM(credit) AS credit,
+      SUM(debit_equiv) AS debit_equiv,
+      SUM(credit_equiv) AS credit_equiv,
+      (SUM(debit) - SUM(credit)) AS balance,
+      posted,
+      IF(${options.isEnterpriseCurrency},
+        IFNULL(GetExchangeRate(${options.enterprise_id}, MAX(currency_id), trans_date), 1),
+        IF(${options.currency_id} = MAX(currency_id), 1,
+          IFNULL(GetExchangeRate(${options.enterprise_id}, ${options.currency_id}, trans_date), 1)
+        )
+      ) AS rate
+    FROM ${unionSQL}
+    LEFT JOIN document_map ON ledger.record_uuid = document_map.uuid
+  `;
+
+  // Apply grouping and ordering from FilterParser
+  filters.setGroup('GROUP BY ledger.record_uuid');
+  filters.setOrder('ORDER BY trans_date ASC, created_at ASC');
+  const groupedQuery = filters.applyQuery(groupingSQL);
+  const groupingParams = [...tableParams, ...filters.parameters()];
+
+  // Next, translate amounts to "exchanged" values plus cumsum in an outer SELECT
+  // Note: we handle enterprise-currency logic using the rate above
+  const columns = `
+    debit,
+    credit,
+    debit_equiv,
+    credit_equiv,
+    trans_date,
+    document_reference,
+    created_at,
+    transaction_type_id,
+    currency_id,
+    posted,
+    rate,
+    IF(rate < 1, (1 / rate), rate) AS invertedRate,
+    CASE
+      WHEN ${options.isEnterpriseCurrency} THEN (balance / rate)
+      ELSE (balance * rate)
+    END AS exchangedBalance,
+    CASE
+      WHEN ${options.isEnterpriseCurrency} THEN (debit / rate)
+      ELSE (debit * rate)
+    END AS exchangedDebit,
+    CASE
+      WHEN ${options.isEnterpriseCurrency} THEN (credit / rate)
+      ELSE (credit * rate)
+    END AS exchangedCredit,
+    SUM(
+      CASE
+        WHEN ${options.isEnterpriseCurrency} THEN (balance / rate) 
+        ELSE (balance * rate)
+      END
+    ) OVER (
+      ORDER BY trans_date ASC, created_at ASC
+      ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+    ) + ${openingBalance} AS cumsum
+  `;
+
+  const finalSQL = `
+    SELECT
+      trans_id,
+      description,
+      ${columns}
+    FROM (
+      ${groupedQuery}
+    ) AS groupedLedger
+    ORDER BY trans_date ASC, created_at ASC
+  `;
+
+  return { query : finalSQL, parameters : groupingParams };
 }
 
 exports.getAccountTransactions = getAccountTransactions;

--- a/server/controllers/finance/accounts/transactions.js
+++ b/server/controllers/finance/accounts/transactions.js
@@ -187,12 +187,7 @@ function buildLedgerSQL(options, openingBalance = 0) {
   }
 
   // Combine data via UNION ALL if both posted/unposted are included
-  let unionSQL = tableQueries.join(' UNION ALL ');
-  if (tableQueries.length > 1) {
-    unionSQL = `(${unionSQL}) AS ledger`;
-  } else {
-    unionSQL = `(${unionSQL}) AS ledger`;
-  }
+  const unionSQL = `(${tableQueries.join(' UNION ALL ')}) as ledger`;
 
   // Build grouping statement
   // Once grouped per record_uuid, we apply the currency conversion logic

--- a/server/controllers/finance/reports/cost_center_step_down/accounts_report.handlebars
+++ b/server/controllers/finance/reports/cost_center_step_down/accounts_report.handlebars
@@ -18,7 +18,6 @@
           <strong>{{ costCenterDetails.label }}</strong>
         </h3>
 
-        <!-- @TODO convert to exchangeRate partial -->
         {{#if this.lastRateUsed}}
           <h5 class="text-center">
             {{translate 'EXCHANGE.EXCHANGE_RATES'}} :

--- a/server/controllers/finance/reports/financial.employee.js
+++ b/server/controllers/finance/reports/financial.employee.js
@@ -5,9 +5,12 @@
  * This file contains code to create a PDF report for financial activities of an employee
  *
  * @requires Employee
+ * @requires Creditors
+ * @requires Debtors
+ * @requires db
+ * @requires Exchange
  * @requires ReportManager
  */
-const _ = require('lodash');
 const ReportManager = require('../../../lib/ReportManager');
 
 const Employee = require('../../payroll/employees');
@@ -30,12 +33,11 @@ const PDF_OPTIONS = {
  *
  * GET /reports/finance/employee_standing/:uuid
  */
-async function build(req, res, next) {
-  const options = req.query;
-  let report;
+async function build(req, res) {
+  let options = req.query;
   let dateExchangeRate;
 
-  options.currency_id = options.currency_id || req.session.enterprise.currency_id;
+  options.currency_id = (options.currency_id || req.session.enterprise.currency_id);
 
   options.limitTimeInterval = parseInt(options.limitTimeInterval, 10);
 
@@ -48,88 +50,81 @@ async function build(req, res, next) {
     dateExchangeRate = options.dateTo;
   }
 
-  _.defaults(options, PDF_OPTIONS);
+  options = { ...options, ...PDF_OPTIONS };
 
   // set up the report with report manager
-  try {
-    report = new ReportManager(TEMPLATE, req.session, options);
+  const report = new ReportManager(TEMPLATE, req.session, options);
 
-    const data = {};
+  const currencyId = Number(options.currency_id);
 
-    const currencyId = Number(options.currency_id);
+  const sql = `
+    SELECT BUID(p.debtor_uuid) as debtor_uuid
+    FROM patient p
+    JOIN employee em ON p.uuid = em.patient_uuid
+    WHERE em.uuid = ?`;
 
-    const sql = `
-      SELECT BUID(p.debtor_uuid) as debtor_uuid
-      FROM patient p
-      JOIN employee em ON p.uuid = em.patient_uuid
-      WHERE em.uuid = ?`;
+  const [employee, patient, exchange] = await Promise.all([
+    Employee.lookupEmployee(options.employee_uuid),
+    db.one(sql, db.bid(options.employee_uuid)),
+    Exchange.getExchangeRate(
+      req.session.enterprise.id,
+      currencyId,
+      dateExchangeRate,
+    ),
+  ]);
 
-    const [employee, patient, exchange] = await Promise.all([
-      Employee.lookupEmployee(options.employee_uuid),
-      db.one(sql, db.bid(options.employee_uuid)),
-      Exchange.getExchangeRate(
-        req.session.enterprise.id,
-        currencyId,
-        dateExchangeRate,
-      ),
-    ]);
+  const data = {
+    currencyId,
+    dateExchangeRate,
+    exchangeRate : exchange.rate || 1,
+  };
 
-    data.currencyId = currencyId;
-    data.exchangeRate = exchange.rate || 1;
-    data.dateExchangeRate = dateExchangeRate;
+  // get debtor/creditor information
+  const [creditorOperations, debtorOperations] = await Promise.all([
+    Creditors.getFinancialActivity(employee.creditor_uuid, options.dateFrom, options.dateTo),
+    Debtors.getFinancialActivity(patient.debtor_uuid, true),
+  ]);
 
-    // get debtor/creditor information
-    const [creditorOperations, debtorOperations] = await Promise.all([
-      Creditors.getFinancialActivity(employee.creditor_uuid, options.dateFrom, options.dateTo),
-      Debtors.getFinancialActivity(patient.debtor_uuid, true),
-    ]);
+  Object.assign(data, {
+    employee,
+    creditorTransactions : creditorOperations.transactions,
+    creditorAggregates : creditorOperations.aggregates,
+    debtorTransactions : debtorOperations.transactions,
+    debtorAggregates : debtorOperations.aggregates,
+  });
 
-    _.extend(data, {
-      employee,
-      creditorTransactions : creditorOperations.transactions,
-      creditorAggregates : creditorOperations.aggregates,
-      debtorTransactions : debtorOperations.transactions,
-      debtorAggregates : debtorOperations.aggregates,
+  if (creditorOperations.openingBalance) {
+    Object.assign(data, {
+      creditorOpeningBalance : creditorOperations.openingBalance[0],
     });
-
-    if (creditorOperations.openingBalance) {
-      _.extend(data, {
-        creditorOpeningBalance : creditorOperations.openingBalance[0],
-      });
-    }
-
-    // provides the latest element of the table,
-    // as the request is ordered by date, the last line item will
-    // also be the employee's balance for the search period
-    if (options.limitTimeInterval) {
-
-      const lastTxn = _.last(creditorOperations.transactions);
-      data.lastTransaction = lastTxn || { cumsum : 0 };
-      data.extratCreditorText = data.lastTransaction.cumsum >= 0
-        ? 'FORM.LABELS.CREDIT_BALANCE' : 'FORM.LABELS.DEBIT_BALANCE';
-
-      data.dates = {
-        dateFrom : options.dateFrom,
-        dateTo : options.dateTo,
-      };
-    }
-
-    // employee balance
-    data.includeMedicalCare = parseInt(options.includeMedicalCare, 10) === 1;
-    data.limitTimeInterval = options.limitTimeInterval === 1;
-    data.employeeStandingReport = !data.limitTimeInterval;
-
-    // For the Employee Standing report, it must be mentioned if the employee has a credit or debit balance
-    data.balanceCreditorText = data.creditorAggregates.balance >= 0
-      ? 'FORM.LABELS.CREDIT_BALANCE' : 'FORM.LABELS.DEBIT_BALANCE';
-
-    // let render
-    const result = await report.render(data);
-    return res.set(result.headers).send(result.report);
-  } catch (e) {
-    return next(e);
   }
 
+  // provides the latest element of the table,
+  // as the request is ordered by date, the last line item will
+  // also be the employee's balance for the search period
+  if (options.limitTimeInterval) {
+    const lastTxn = creditorOperations.transactions.at(-1);
+    data.lastTransaction = lastTxn || { cumsum : 0 };
+    data.extratCreditorText = data.lastTransaction.cumsum >= 0
+      ? 'FORM.LABELS.CREDIT_BALANCE' : 'FORM.LABELS.DEBIT_BALANCE';
+
+    data.dates = {
+      dateFrom : options.dateFrom,
+      dateTo : options.dateTo,
+    };
+  }
+
+  // employee balance
+  data.includeMedicalCare = parseInt(options.includeMedicalCare, 10) === 1;
+  data.limitTimeInterval = options.limitTimeInterval === 1;
+  data.employeeStandingReport = !data.limitTimeInterval;
+
+  // For the Employee Standing report, it must be mentioned if the employee has a credit or debit balance
+  data.balanceCreditorText = data.creditorAggregates.balance >= 0
+    ? 'FORM.LABELS.CREDIT_BALANCE' : 'FORM.LABELS.DEBIT_BALANCE';
+
+  const result = await report.render(data);
+  res.set(result.headers).send(result.report);
 }
 
 exports.report = build;

--- a/server/controllers/finance/reports/reportAccounts/report.handlebars
+++ b/server/controllers/finance/reports/reportAccounts/report.handlebars
@@ -1,3 +1,5 @@
+<!doctype html>
+<html>
 {{> head }}
 
 <body>
@@ -117,3 +119,4 @@
     </table>
   </section>
 </body>
+</html>


### PR DESCRIPTION
This PR replaces the hacky `@cumsum` temporary SQL variables with window functions.  It reduces the code complexity by using modern SQL tools instead of temporary counters to work around previous limitations.

I did not measure performance for this change in detail, except to test the changes.  I did not notice any notable improvement or degradation.

To test this, take snapshots of the patient financial activity, employee financial activity, and the account reports on `master`.   Then, regenerate them with this PR and ensure that the `balance` column is the same.

Closes #5838.