### PR TITLE
Refactor async await express routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "helmet": "^8.1.0",
         "inline-source": "^8.0.3",
         "jaro-winkler": "^0.2.8",
-        "jquery": "^3.7.1",
+        "jquery": "^4.0.0",
         "jsbarcode": "^3.12.1",
         "json-2-csv": "^5.5.10",
         "jsonwebtoken": "^9.0.3",
@@ -3266,9 +3266,9 @@
       }
     },
     "node_modules/chromium-bidi": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-12.0.1.tgz",
-      "integrity": "sha512-fGg+6jr0xjQhzpy5N4ErZxQ4wF7KLEvhGZXD6EgvZKDhu7iOhZXnZhcDxPJDcwTcrD48NPzOCo84RP2lv3Z+Cg==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-13.0.1.tgz",
+      "integrity": "sha512-c+RLxH0Vg2x2syS9wPw378oJgiJNXtYXUvnVAldUlt5uaHekn0CCU7gPksNgHjrH1qFhmjVXQj4esvuthuC7OQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "mitt": "^3.0.1",
@@ -4393,9 +4393,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1534754",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1534754.tgz",
-      "integrity": "sha512-26T91cV5dbOYnXdJi5qQHoTtUoNEqwkHcAyu/IKtjIAxiEqPMrDiRkDOPWVsGfNZGmlQVHQbZRSjD8sxagWVsQ==",
+      "version": "0.0.1551306",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1551306.tgz",
+      "integrity": "sha512-CFx8QdSim8iIv+2ZcEOclBKTQY6BI1IEDa7Tm9YkwAXzEWFndTEzpTo5jAUhSnq24IC7xaDw0wvGcm96+Y3PEg==",
       "license": "BSD-3-Clause",
       "peer": true
     },
@@ -4619,9 +4619,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.267",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
-      "integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
+      "version": "1.5.277",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.277.tgz",
+      "integrity": "sha512-wKXFZw4erWmmOz5N/grBoJ2XrNJGDFMu2+W5ACHza5rHtvsqrK4gb6rnLC7XxKB9WlJ+RmyQatuEXmtm86xbnw==",
       "dev": true,
       "license": "ISC"
     },
@@ -8750,9 +8750,9 @@
       }
     },
     "node_modules/jquery": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
-      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-4.0.0.tgz",
+      "integrity": "sha512-TXCHVR3Lb6TZdtw1l3RTLf8RBWVGexdxL6AC8/e0xZKEpBflBsjh9/8LXw+dkNFuOyW9B7iB3O1sP7hS0Kiacg==",
       "license": "MIT"
     },
     "node_modules/js-tokens": {
@@ -12344,18 +12344,18 @@
       "license": "MIT"
     },
     "node_modules/puppeteer": {
-      "version": "24.35.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.35.0.tgz",
-      "integrity": "sha512-sbjB5JnJ+3nwgSdRM/bqkFXqLxRz/vsz0GRIeTlCk+j+fGpqaF2dId9Qp25rXz9zfhqnN9s0krek1M/C2GDKtA==",
+      "version": "24.36.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.36.0.tgz",
+      "integrity": "sha512-BD/VCyV/Uezvd6o7Fd1DmEJSxTzofAKplzDy6T9d4WbLTQ5A+06zY7VwO91ZlNU22vYE8sidVEsTpTrKc+EEnQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@puppeteer/browsers": "2.11.1",
-        "chromium-bidi": "12.0.1",
+        "chromium-bidi": "13.0.1",
         "cosmiconfig": "^9.0.0",
-        "devtools-protocol": "0.0.1534754",
-        "puppeteer-core": "24.35.0",
+        "devtools-protocol": "0.0.1551306",
+        "puppeteer-core": "24.36.0",
         "typed-query-selector": "^2.12.0"
       },
       "bin": {
@@ -12378,17 +12378,17 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "24.35.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.35.0.tgz",
-      "integrity": "sha512-vt1zc2ME0kHBn7ZDOqLvgvrYD5bqNv5y2ZNXzYnCv8DEtZGw/zKhljlrGuImxptZ4rq+QI9dFGrUIYqG4/IQzA==",
+      "version": "24.36.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.36.0.tgz",
+      "integrity": "sha512-P3Ou0MAFDCQ0dK1d9F9+8jTrg6JvXjUacgG0YkJQP4kbEnUOGokSDEMmMId5ZhXD5HwsHM202E9VwEpEjWfwxg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@puppeteer/browsers": "2.11.1",
-        "chromium-bidi": "12.0.1",
+        "chromium-bidi": "13.0.1",
         "debug": "^4.4.3",
-        "devtools-protocol": "0.0.1534754",
+        "devtools-protocol": "0.0.1551306",
         "typed-query-selector": "^2.12.0",
-        "webdriver-bidi-protocol": "0.3.10",
+        "webdriver-bidi-protocol": "0.4.0",
         "ws": "^8.19.0"
       },
       "engines": {
@@ -15633,9 +15633,9 @@
       }
     },
     "node_modules/webdriver-bidi-protocol": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.3.10.tgz",
-      "integrity": "sha512-5LAE43jAVLOhB/QqX4bwSiv0Hg1HBfMmOuwBSXHdvg4GMGu9Y0lIq7p4R/yySu6w74WmaR4GM4H9t2IwLW7hgw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.0.tgz",
+      "integrity": "sha512-U9VIlNRrq94d1xxR9JrCEAx5Gv/2W7ERSv8oWRoNe/QYbfccS0V3h/H6qeNeCRJxXGMhhnkqvwNrvPAYeuP9VA==",
       "license": "Apache-2.0"
     },
     "node_modules/which": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -160,28 +160,29 @@
       }
     },
     "node_modules/@cacheable/memory/node_modules/@keyv/bigmap": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.0.tgz",
-      "integrity": "sha512-KT01GjzV6AQD5+IYrcpoYLkCu1Jod3nau1Z7EsEuViO3TZGRacSbO9MfHmbJ1WaOXFtWLxPVj169cn2WNKPkIg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
+      "integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hashery": "^1.2.0",
-        "hookified": "^1.13.0"
+        "hashery": "^1.4.0",
+        "hookified": "^1.15.0"
       },
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
-        "keyv": "^5.5.4"
+        "keyv": "^5.6.0"
       }
     },
     "node_modules/@cacheable/memory/node_modules/keyv": {
-      "version": "5.5.5",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.5.tgz",
-      "integrity": "sha512-FA5LmZVF1VziNc0bIdCSA1IoSVnDCqE8HJIZZv2/W8YmoAM50+tnUgJR/gQZwEeIMleuIOnRnHA/UaZRNeV4iQ==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -198,9 +199,9 @@
       }
     },
     "node_modules/@cacheable/utils/node_modules/keyv": {
-      "version": "5.5.5",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.5.tgz",
-      "integrity": "sha512-FA5LmZVF1VziNc0bIdCSA1IoSVnDCqE8HJIZZv2/W8YmoAM50+tnUgJR/gQZwEeIMleuIOnRnHA/UaZRNeV4iQ==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -233,6 +234,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -276,6 +278,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1204,6 +1207,7 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -1504,6 +1508,7 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.10.0.tgz",
       "integrity": "sha512-JXmM4XCoso6C75Mr3lhKA3eNxSzkYi3nCzxDIKY+YOszYsJjuKbFgVtguVPbLMOttN4iu2fXoc2BGhdnYhIOxA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
@@ -1688,9 +1693,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.0.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.9.tgz",
-      "integrity": "sha512-/rpCXHlCWeqClNBwUhDcusJxXYDjZTyE8v5oTO7WbL8eij2nKhUeU89/6xgjU7N4/Vh3He0BtyhJdQbDyhiXAw==",
+      "version": "25.0.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.10.tgz",
+      "integrity": "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -1732,9 +1737,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.53.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.53.0.tgz",
-      "integrity": "sha512-Bmh9KX31Vlxa13+PqPvt4RzKRN1XORYSLlAE+sO1i28NkisGbTtSLFVB3l7PWdHtR3E0mVMuC7JilWJ99m2HxQ==",
+      "version": "8.53.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.53.1.tgz",
+      "integrity": "sha512-jr/swrr2aRmUAUjW5/zQHbMaui//vQlsZcJKijZf3M26bnmLj8LyZUpj8/Rd6uzaek06OWsqdofN/Thenm5O8A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1763,6 +1768,7 @@
       "resolved": "https://registry.npmjs.org/@uirouter/core/-/core-6.1.2.tgz",
       "integrity": "sha512-pYcg+cxVd9E9poC7AJf7ZrlQQrwAV6KVkiPvlbLJX5km+pBWrUOGQhdd87oIGc7/5iVQ7qSiAdl9QD+l55yegg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -1798,6 +1804,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1868,7 +1875,8 @@
       "resolved": "https://registry.npmjs.org/angular/-/angular-1.8.3.tgz",
       "integrity": "sha512-5qjkWIQQVsHj4Sb5TcEs4WZWpFeVFHXwxEBHUhrny41D8UrBAd6T/6nPPAsLngJCReIOqi95W3mxdveveutpZw==",
       "deprecated": "For the actively supported Angular, see https://www.npmjs.com/package/@angular/core. AngularJS support has officially ended. For extended AngularJS support options, see https://goo.gle/angularjs-path-forward.",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/angular-animate": {
       "version": "1.8.3",
@@ -2453,6 +2461,7 @@
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -2571,9 +2580,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.15",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.15.tgz",
-      "integrity": "sha512-kX8h7K2srmDyYnXRIppo4AH/wYgzWVCs+eKr3RusRSQ5PvRYoEFmR/I0PbdTjKFAoKqp5+kbxnNTFO9jOfSVJg==",
+      "version": "2.9.17",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.17.tgz",
+      "integrity": "sha512-agD0MgJFUP/4nvjqzIB29zRPUuCF7Ge6mEv9s8dHrtYD7QWXRcx75rOADE/d5ah1NI+0vkDl0yorDd5U852IQQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2743,6 +2752,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2912,23 +2922,23 @@
       }
     },
     "node_modules/cacheable": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.1.tgz",
-      "integrity": "sha512-yr+FSHWn1ZUou5LkULX/S+jhfgfnLbuKQjE40tyEd4fxGZVMbBL5ifno0J0OauykS8UiCSgHi+DV/YD+rjFxFg==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.2.tgz",
+      "integrity": "sha512-w+ZuRNmex9c1TR9RcsxbfTKCjSL0rh1WA5SABbrWprIHeNBdmyQLSYonlDy9gpD+63XT8DgZ/wNh1Smvc9WnJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cacheable/memory": "^2.0.6",
-        "@cacheable/utils": "^2.3.2",
-        "hookified": "^1.14.0",
+        "@cacheable/memory": "^2.0.7",
+        "@cacheable/utils": "^2.3.3",
+        "hookified": "^1.15.0",
         "keyv": "^5.5.5",
-        "qified": "^0.5.3"
+        "qified": "^0.6.0"
       }
     },
     "node_modules/cacheable/node_modules/keyv": {
-      "version": "5.5.5",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.5.tgz",
-      "integrity": "sha512-FA5LmZVF1VziNc0bIdCSA1IoSVnDCqE8HJIZZv2/W8YmoAM50+tnUgJR/gQZwEeIMleuIOnRnHA/UaZRNeV4iQ==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3019,9 +3029,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001764",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001764.tgz",
-      "integrity": "sha512-9JGuzl2M+vPL+pz70gtMF9sHdMFbY9FJaQBi186cHKH3pSzDvzoUJUPV6fqiKIMyXbud9ZLg4F3Yza1vJ1+93g==",
+      "version": "1.0.30001765",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001765.tgz",
+      "integrity": "sha512-LWcNtSyZrakjECqmpP4qdg0MMGdN368D7X8XvvAqOcqMv0RxnlqVKZl2V6/mBR68oYMxOZPLw/gO7DuisMHUvQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -3044,6 +3054,7 @@
       "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.3",
@@ -3119,6 +3130,7 @@
       "integrity": "sha512-ikaUhQvQWchRYj2K54itFp3nrcxaFRpSDQxDlRzSn9aWgu9Pi7lD8yFxTso4WnQ39+WZ69oB/qOvqp+isJIIWA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4.0.0"
       },
@@ -3185,6 +3197,7 @@
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
       "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -4383,7 +4396,8 @@
       "version": "0.0.1534754",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1534754.tgz",
       "integrity": "sha512-26T91cV5dbOYnXdJi5qQHoTtUoNEqwkHcAyu/IKtjIAxiEqPMrDiRkDOPWVsGfNZGmlQVHQbZRSjD8sxagWVsQ==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/dezalgo": {
       "version": "1.0.4",
@@ -4997,6 +5011,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5123,6 +5138,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5217,9 +5233,9 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc/node_modules/espree": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-11.0.0.tgz",
-      "integrity": "sha512-+gMeWRrIh/NsG+3NaLeWHuyeyk70p2tbvZIWBYcqQ4/7Xvars6GYTZNhF1sIeLcc6Wb11He5ffz3hsHyXFrw5A==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.1.0.tgz",
+      "integrity": "sha512-WFWYhO1fV4iYkqOOvq8FbqIhr2pYfoDY0kCotMkDeNtGpiGGkZ1iov2u8ydjtgM8yF8rzK7oaTbw2NAzbAbehw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -5581,6 +5597,7 @@
       "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.2.tgz",
       "integrity": "sha512-SZjssGQC7TzTs9rpPDuUrR23GNZ9+2+IkA/+IJWmvQilTr5OSliEHGF+D9scbIpdC6yGtTI0/VhaHoVes2AN/A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cookie": "0.7.2",
         "cookie-signature": "1.0.7",
@@ -8727,6 +8744,7 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -8907,6 +8925,7 @@
       "integrity": "sha512-LrtUxbdvt1gOpo3gxG+VAJlJAEMhbWlM4YrFQgql98FwF7+K8K12LYO4hnDdUkNjeztYrOXEMqgTajSWgmtI/w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@colors/colors": "1.5.0",
         "body-parser": "^1.19.0",
@@ -8946,6 +8965,7 @@
       "integrity": "sha512-mqKCkHwzPMhgTYca10S90aCEX9+HjVjjrBFAsw36Zj7BlQNbokXXCAe6Ji04VUMsxcY5RLP7YphpfO06XOubdg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "chai": "*",
         "karma": ">=0.10.9"
@@ -9396,9 +9416,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
     },
     "node_modules/lodash.capitalize": {
@@ -9927,6 +9947,7 @@
       "integrity": "sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "browser-stdout": "^1.3.1",
         "chokidar": "^4.0.1",
@@ -10646,24 +10667,29 @@
       }
     },
     "node_modules/nypm": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.2.tgz",
-      "integrity": "sha512-7eM+hpOtrKrBDCh7Ypu2lJ9Z7PNZBdi/8AT3AX8xoCj43BBVHD0hPSTEvMtkMpfs8FCqBGhxB+uToIQimA111g==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.4.tgz",
+      "integrity": "sha512-1TvCKjZyyklN+JJj2TS3P4uSQEInrM/HkkuSXsEzm1ApPgBffOn8gFguNnZf07r/1X6vlryfIqMUkJKQMzlZiw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "citty": "^0.1.6",
-        "consola": "^3.4.2",
+        "citty": "^0.2.0",
         "pathe": "^2.0.3",
-        "pkg-types": "^2.3.0",
-        "tinyexec": "^1.0.1"
+        "tinyexec": "^1.0.2"
       },
       "bin": {
         "nypm": "dist/cli.mjs"
       },
       "engines": {
-        "node": "^14.16.0 || >=16.10.0"
+        "node": ">=18"
       }
+    },
+    "node_modules/nypm/node_modules/citty": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.0.tgz",
+      "integrity": "sha512-8csy5IBFI2ex2hTVpaHN2j+LNE199AgiI7y4dMintrr8i0lQiFn+0AWMZrWdHKIgMOer65f8IThysYhoReqjWA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -11413,9 +11439,9 @@
       "license": "MIT"
     },
     "node_modules/perfect-debounce": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.0.0.tgz",
-      "integrity": "sha512-fkEH/OBiKrqqI/yIgjR92lMfs2K8105zt/VT6+7eTjNwisrsh47CeIED9z58zI7DfKdH3uHAn25ziRZn3kgAow==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
+      "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
       "dev": true,
       "license": "MIT"
     },
@@ -11576,6 +11602,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -12070,6 +12097,7 @@
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -12321,6 +12349,7 @@
       "integrity": "sha512-sbjB5JnJ+3nwgSdRM/bqkFXqLxRz/vsz0GRIeTlCk+j+fGpqaF2dId9Qp25rXz9zfhqnN9s0krek1M/C2GDKtA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@puppeteer/browsers": "2.11.1",
         "chromium-bidi": "12.0.1",
@@ -12367,13 +12396,13 @@
       }
     },
     "node_modules/qified": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/qified/-/qified-0.5.3.tgz",
-      "integrity": "sha512-kXuQdQTB6oN3KhI6V4acnBSZx8D2I4xzZvn9+wFLLFCoBNQY/sFnCW6c43OL7pOQ2HvGV4lnWIXNmgfp7cTWhQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/qified/-/qified-0.6.0.tgz",
+      "integrity": "sha512-tsSGN1x3h569ZSU1u6diwhltLyfUWDp3YbFHedapTmpBl0B3P6U3+Qptg7xu+v+1io1EwhdPyyRHYbEw0KN2FA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hookified": "^1.13.0"
+        "hookified": "^1.14.0"
       },
       "engines": {
         "node": ">=20"
@@ -12539,6 +12568,7 @@
       "resolved": "https://registry.npmjs.org/redis/-/redis-5.10.0.tgz",
       "integrity": "sha512-0/Y+7IEiTgVGPrLFKy8oAEArSyEJkU0zvgV5xyi9NzNQ+SLZmyFbUsWIbgPcd4UdUh00opXGKlXJwMmsis5Byw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@redis/bloom": "5.10.0",
         "@redis/client": "5.10.0",
@@ -14273,25 +14303,25 @@
       }
     },
     "node_modules/stylelint/node_modules/file-entry-cache": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.1.tgz",
-      "integrity": "sha512-TPVFSDE7q91Dlk1xpFLvFllf8r0HyOMOlnWy7Z2HBku5H3KhIeOGInexrIeg2D64DosVB/JXkrrk6N/7Wriq4A==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.2.tgz",
+      "integrity": "sha512-N2WFfK12gmrK1c1GXOqiAJ1tc5YE+R53zvQ+t5P8S5XhnmKYVB5eZEiLNZKDSmoG8wqqbF9EXYBBW/nef19log==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "flat-cache": "^6.1.19"
+        "flat-cache": "^6.1.20"
       }
     },
     "node_modules/stylelint/node_modules/flat-cache": {
-      "version": "6.1.19",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.19.tgz",
-      "integrity": "sha512-l/K33newPTZMTGAnnzaiqSl6NnH7Namh8jBNjrgjprWxGmZUuxx/sJNIRaijOh3n7q7ESbhNZC+pvVZMFdeU4A==",
+      "version": "6.1.20",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.20.tgz",
+      "integrity": "sha512-AhHYqwvN62NVLp4lObVXGVluiABTHapoB57EyegZVmazN+hhGhLTn3uZbOofoTw4DSDvVCadzzyChXhOAvy8uQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cacheable": "^2.2.0",
+        "cacheable": "^2.3.2",
         "flatted": "^3.3.3",
-        "hookified": "^1.13.0"
+        "hookified": "^1.15.0"
       }
     },
     "node_modules/stylelint/node_modules/global-modules": {
@@ -14784,6 +14814,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -15050,6 +15081,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3762,9 +3762,9 @@
       "license": "MIT"
     },
     "node_modules/cors": {
-      "version": "2.8.5",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
-      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3773,6 +3773,10 @@
       },
       "engines": {
         "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/cosmiconfig": {
@@ -5593,23 +5597,27 @@
       }
     },
     "node_modules/express-session": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.2.tgz",
-      "integrity": "sha512-SZjssGQC7TzTs9rpPDuUrR23GNZ9+2+IkA/+IJWmvQilTr5OSliEHGF+D9scbIpdC6yGtTI0/VhaHoVes2AN/A==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.19.0.tgz",
+      "integrity": "sha512-0csaMkGq+vaiZTmSMMGkfdCOabYv192VbytFypcvI0MANrp+4i/7yEkJ0sbAEhycQjntaKGzYfjfXQyVb7BHMA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "cookie": "0.7.2",
-        "cookie-signature": "1.0.7",
-        "debug": "2.6.9",
+        "cookie": "~0.7.2",
+        "cookie-signature": "~1.0.7",
+        "debug": "~2.6.9",
         "depd": "~2.0.0",
         "on-headers": "~1.1.0",
         "parseurl": "~1.3.3",
-        "safe-buffer": "5.2.1",
+        "safe-buffer": "~5.2.1",
         "uid-safe": "~2.1.5"
       },
       "engines": {
         "node": ">= 0.8.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/express-session/node_modules/cookie-signature": {

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "helmet": "^8.1.0",
     "inline-source": "^8.0.3",
     "jaro-winkler": "^0.2.8",
-    "jquery": "^3.7.1",
+    "jquery": "^4.0.0",
     "jsbarcode": "^3.12.1",
     "json-2-csv": "^5.5.10",
     "jsonwebtoken": "^9.0.3",

--- a/server/controllers/admin/choicesListManagement.js
+++ b/server/controllers/admin/choicesListManagement.js
@@ -18,7 +18,7 @@ function lookupchoicesListManagement(id) {
   return db.one(sql, [id]);
 }
 
-function list(req, res, next) {
+async function list(req, res) {
   const filters = new FilterParser(req.query);
 
   const sql = `
@@ -35,12 +35,8 @@ function list(req, res, next) {
   const query = filters.applyQuery(sql);
   const parameters = filters.parameters();
 
-  db.exec(query, parameters)
-    .then((rows) => {
-      res.status(200).json(rows);
-    })
-    .catch(next);
-
+  const rows = await db.exec(query, parameters);
+  res.status(200).json(rows);
 }
 
 /**
@@ -48,63 +44,45 @@ function list(req, res, next) {
 *
 * Returns the detail of a single choices_list_management
 */
-function detail(req, res, next) {
+async function detail(req, res) {
   const { id } = req.params;
 
-  lookupchoicesListManagement(id)
-    .then((record) => {
-      res.status(200).json(record);
-    })
-    .catch(next);
-
+  const record = await lookupchoicesListManagement(id);
+  res.status(200).json(record);
 }
 
 // POST /choices_list_management
-function create(req, res, next) {
+async function create(req, res) {
   const sql = `INSERT INTO choices_list_management SET ?`;
   const data = req.body;
   // Set 0 (root) like default parent
   data.parent = data.parent || 0;
 
-  db.exec(sql, [data])
-    .then((row) => {
-      res.status(201).json({ id : row.insertId });
-    })
-    .catch(next);
-
+  const row = await db.exec(sql, [data]);
+  res.status(201).json({ id : row.insertId });
 }
 
 // PUT /choices_list_management /:id
-function update(req, res, next) {
+async function update(req, res) {
   const sql = `UPDATE choices_list_management SET ? WHERE id = ?;`;
 
-  db.exec(sql, [req.body, req.params.id])
-    .then(() => {
-      return lookupchoicesListManagement(req.params.id);
-    })
-    .then((record) => {
-    // all updates completed successfull, return full object to client
-      res.status(200).json(record);
-    })
-    .catch(next);
-
+  await db.exec(sql, [req.body, req.params.id]);
+  const record = await lookupchoicesListManagement(req.params.id);
+  // all updates completed successfull, return full object to client
+  res.status(200).json(record);
 }
 
 // DELETE /choices_list_management/:id
-function remove(req, res, next) {
+async function remove(req, res) {
   const sql = `DELETE FROM choices_list_management WHERE id = ?;`;
 
-  db.exec(sql, [req.params.id])
-    .then((row) => {
-    // if nothing happened, let the client know via a 404 error
-      if (row.affectedRows === 0) {
-        throw new NotFound(`Could not find a choices list with id ${req.params.id}`);
-      }
+  const row = await db.exec(sql, [req.params.id]);
+  // if nothing happened, let the client know via a 404 error
+  if (row.affectedRows === 0) {
+    throw new NotFound(`Could not find a choices list with id ${req.params.id}`);
+  }
 
-      res.status(204).json();
-    })
-    .catch(next);
-
+  res.sendStatus(204);
 }
 
 // get list of choicesListManagement

--- a/server/controllers/admin/cron/index.js
+++ b/server/controllers/admin/cron/index.js
@@ -10,28 +10,23 @@ exports.update = update;
 exports.remove = remove;
 exports.create = create;
 
-function list(req, res, next) {
-  const query = `
-    SELECT id, label FROM cron
-  `;
-  db.exec(query)
-    .then(rows => res.status(200).json(rows))
-    .catch(next);
+async function list(req, res) {
+  const query = `SELECT id, label FROM cron`;
+  const rows = await db.exec(query);
+  res.status(200).json(rows);
 
 }
 
-function details(req, res, next) {
+async function details(req, res) {
   const query = `
     SELECT id, label FROM cron
     WHERE id = ?;
   `;
-  db.one(query, [req.params.id])
-    .then(rows => res.status(200).json(rows))
-    .catch(next);
-
+  const rows = await db.one(query, [req.params.id]);
+  res.status(200).json(rows);
 }
 
-function update(req, res, next) {
+async function update(req, res) {
   const query = `
     UPDATE cron SET ? WHERE id = ?;
   `;
@@ -39,31 +34,24 @@ function update(req, res, next) {
   if (params.id) {
     delete params.id;
   }
-  db.exec(query, [params, req.params.id])
-    .then(() => res.sendStatus(204))
-    .catch(next);
-
+  await db.exec(query, [params, req.params.id]);
+  res.sendStatus(204);
 }
 
-function remove(req, res, next) {
+async function remove(req, res) {
   const query = `
     DELETE FROM cron WHERE id = ?;
   `;
-  db.exec(query, [req.params.id])
-    .then(() => res.sendStatus(204))
-    .catch(next);
+  await db.exec(query, [req.params.id]);
+  res.sendStatus(204);
 
 }
 
-function create(req, res, next) {
+async function create(req, res) {
   const query = `
     INSERT INTO cron SET ?;
   `;
   const params = req.body;
-  db.exec(query, [params])
-    .then((result) => {
-      res.status(201).json({ id : result.insertId });
-    })
-    .catch(next);
-
+  const result = await db.exec(query, [params]);
+  res.status(201).json({ id : result.insertId });
 }

--- a/server/controllers/admin/dataCollectorManagement.js
+++ b/server/controllers/admin/dataCollectorManagement.js
@@ -4,6 +4,7 @@
 * This controller exposes an API to the client for reading and writing Data Collector Management
 */
 
+const debug = require('debug')('controller:dataCollectorManagement');
 const db = require('../../lib/db');
 const NotFound = require('../../lib/errors/NotFound');
 const FilterParser = require('../../lib/filter');
@@ -56,6 +57,8 @@ async function list(req, res) {
       }
     });
   });
+
+  debug(`Found ${dataCollector.length} submissions.`);
 
   res.status(200).json(dataCollector);
 }

--- a/server/controllers/admin/dataCollectorManagement.js
+++ b/server/controllers/admin/dataCollectorManagement.js
@@ -97,12 +97,13 @@ async function remove(req, res) {
   const sql = `DELETE FROM data_collector_management WHERE id = ?;`;
 
   const row = await db.exec(sql, [req.params.id]);
+
   // if nothing happened, let the client know via a 404 error
   if (row.affectedRows === 0) {
     throw new NotFound(`Could not find a function with id ${req.params.id}`);
   }
 
-  res.sentStatus(204);
+  res.sendStatus(204);
 }
 
 // get list of dataCollectorManagement

--- a/server/controllers/admin/displayMetadata.js
+++ b/server/controllers/admin/displayMetadata.js
@@ -260,27 +260,19 @@ function lookupData(params) {
 
 }
 
-function list(req, res, next) {
+async function list(req, res) {
   const params = req.query;
 
-  lookupData(params)
-    .then((dataSurvey) => {
-      res.status(200).json(dataSurvey);
-    })
-    .catch(next);
-
+  const dataSurvey = await lookupData(params);
+  res.status(200).json(dataSurvey);
 }
 
 // DELETE /display_metadata/:uuid
-function remove(req, res, next) {
+async function remove(req, res) {
   const sql = `UPDATE survey_data SET is_deleted = 1 WHERE uuid = ?;`;
 
-  db.exec(sql, [db.bid(req.params.uuid)])
-    .then(() => {
-      res.status(204).json();
-    })
-    .catch(next);
-
+  await db.exec(sql, [db.bid(req.params.uuid)]);
+  res.status(204).json();
 }
 
 // get list of Display Metadata

--- a/server/controllers/admin/entities/types/index.js
+++ b/server/controllers/admin/entities/types/index.js
@@ -10,28 +10,24 @@ exports.update = update;
 exports.remove = remove;
 exports.create = create;
 
-function list(req, res, next) {
+async function list(req, res) {
   const query = `
     SELECT id, label, translation_key FROM entity_type
   `;
-  db.exec(query)
-    .then(rows => res.status(200).json(rows))
-    .catch(next);
-
+  const rows = await db.exec(query);
+  res.status(200).json(rows);
 }
 
-function details(req, res, next) {
+async function details(req, res) {
   const query = `
     SELECT id, label, translation_key FROM entity_type
     WHERE id = ?;
   `;
-  db.one(query, [req.params.id])
-    .then(rows => res.status(200).json(rows))
-    .catch(next);
-
+  const row = await db.one(query, [req.params.id]);
+  res.status(200).json(row);
 }
 
-function update(req, res, next) {
+async function update(req, res) {
   const query = `
     UPDATE entity_type SET ? WHERE id = ?;
   `;
@@ -39,31 +35,24 @@ function update(req, res, next) {
   if (params.id) {
     delete params.id;
   }
-  db.exec(query, [params, req.params.id])
-    .then(() => res.sendStatus(204))
-    .catch(next);
-
+  await db.exec(query, [params, req.params.id]);
+  res.sendStatus(204);
 }
 
-function remove(req, res, next) {
+async function remove(req, res) {
   const query = `
     DELETE FROM entity_type WHERE id = ?;
   `;
-  db.exec(query, [req.params.id])
-    .then(() => res.sendStatus(204))
-    .catch(next);
-
+  await db.exec(query, [req.params.id]);
+  res.sendStatus(204);
 }
 
-function create(req, res, next) {
+async function create(req, res) {
   const query = `
     INSERT INTO entity_type SET ?;
   `;
   const params = req.body;
-  db.exec(query, [params])
-    .then((result) => {
-      res.status(201).json({ id : result.insertId });
-    })
-    .catch(next);
+  const result = await db.exec(query, [params]);
+  res.status(201).json({ id : result.insertId });
 
 }

--- a/server/controllers/admin/fillFormsData.js
+++ b/server/controllers/admin/fillFormsData.js
@@ -11,7 +11,7 @@ const surveyForm = require('./surveyForm');
 const { uuid } = require('../../lib/util');
 
 // POST /fill_from
-function create(req, res, next) {
+async function create(req, res) {
   const data = req.body;
 
   let medicalSheet;
@@ -25,89 +25,84 @@ function create(req, res, next) {
   };
 
   const surveyUuid = uuid();
-  surveyForm.getSurveyFormElement(dataCollectorManagementId)
-    .then((survey) => {
-      // Data Survey
-      const surveyDataItem = [];
-      Object.keys(data).forEach((key) => {
-        survey.forEach(s => {
+  const survey = await surveyForm.getSurveyFormElement(dataCollectorManagementId);
+  // Data Survey
+  const surveyDataItem = [];
+  Object.keys(data).forEach((key) => {
+    survey.forEach(s => {
 
-          if (key === s.name) {
-            if (s.typeForm === 'date') {
-              data[key] = moment(data[key]).format('YYYY-MM-DD');
-            } else if (s.typeForm === 'time') {
-              data[key] = moment(data[key]).format('HH:mm');
-            } else if (s.typeForm === 'select_multiple') {
-              // Set Element for multiple choice
-              data[key].forEach((element) => {
-                surveyDataItem.push([
-                  db.bid(util.uuid()),
-                  db.bid(surveyUuid),
-                  s.id,
-                  s.name,
-                  element,
-                ]);
-              });
-            }
+      if (key === s.name) {
+        if (s.typeForm === 'date') {
+          data[key] = moment(data[key]).format('YYYY-MM-DD');
+        } else if (s.typeForm === 'time') {
+          data[key] = moment(data[key]).format('HH:mm');
+        } else if (s.typeForm === 'select_multiple') {
+          // Set Element for multiple choice
+          data[key].forEach((element) => {
+            surveyDataItem.push([
+              db.bid(util.uuid()),
+              db.bid(surveyUuid),
+              s.id,
+              s.name,
+              element,
+            ]);
+          });
+        }
 
-            if (s.typeForm === 'calculation') {
-              data[key] = surveyForm.getCalculation(s, req.body);
-            }
+        if (s.typeForm === 'calculation') {
+          data[key] = surveyForm.getCalculation(s, req.body);
+        }
 
-            // Put In DataSurvey
-            if (s.typeForm !== 'select_multiple' && s.typeForm !== 'image') {
-              surveyDataItem.push([
-                db.bid(util.uuid()),
-                db.bid(surveyUuid),
-                s.id,
-                s.name,
-                data[key],
-              ]);
-            }
-          }
-        });
-      });
-
-      if (patientUuid) {
-        medicalSheet = {
-          survey_data_uuid : db.bid(surveyUuid),
-          patient_uuid : db.bid(patientUuid),
-        };
+        // Put In DataSurvey
+        if (s.typeForm !== 'select_multiple' && s.typeForm !== 'image') {
+          surveyDataItem.push([
+            db.bid(util.uuid()),
+            db.bid(surveyUuid),
+            s.id,
+            s.name,
+            data[key],
+          ]);
+        }
       }
+    });
+  });
 
-      const transaction = db.transaction();
-      const sqlSurveyData = `INSERT INTO survey_data SET ?`;
-      const surveyData = {
-        uuid : db.bid(surveyUuid),
-        data_collector_management_id : data.data_collector_management_id,
-        user_id : req.session.user.id,
-      };
+  if (patientUuid) {
+    medicalSheet = {
+      survey_data_uuid : db.bid(surveyUuid),
+      patient_uuid : db.bid(patientUuid),
+    };
+  }
 
-      const sqlSurveyDataItem = `INSERT INTO survey_data_item
+  const transaction = db.transaction();
+  const sqlSurveyData = `INSERT INTO survey_data SET ?`;
+  const surveyData = {
+    uuid : db.bid(surveyUuid),
+    data_collector_management_id : data.data_collector_management_id,
+    user_id : req.session.user.id,
+  };
+
+  const sqlSurveyDataItem = `INSERT INTO survey_data_item
         (uuid, survey_data_uuid, survey_form_id, survey_form_label, value) VALUES ?`;
 
-      const saveLinkSurveyPatient = `
+  const saveLinkSurveyPatient = `
         INSERT INTO medical_sheet SET ?`;
 
-      transaction
-        .addQuery(sqlSurveyData, [surveyData])
-        .addQuery(sqlSurveyDataItem, [surveyDataItem]);
+  transaction
+    .addQuery(sqlSurveyData, [surveyData])
+    .addQuery(sqlSurveyDataItem, [surveyDataItem]);
 
-      if (patientUuid) {
-        transaction
-          .addQuery(saveLinkSurveyPatient, [medicalSheet]);
-      }
+  if (patientUuid) {
+    transaction
+      .addQuery(saveLinkSurveyPatient, [medicalSheet]);
+  }
 
-      return transaction.execute();
-    })
-    .then(() => {
-      res.status(201).json({ uuid : surveyUuid });
-    })
-    .catch(next);
+  await transaction.execute();
+  res.status(201).json({ uuid : surveyUuid });
 
 }
 
-function uploadImage(req, res, next) {
+async function uploadImage(req, res) {
   const sqlSurveyDataItem = `INSERT INTO survey_data_item SET ?`;
 
   const surveyDataItem = {
@@ -117,15 +112,12 @@ function uploadImage(req, res, next) {
     value : req.files[0].link,
   };
 
-  db.exec(sqlSurveyDataItem, [surveyDataItem])
-    .then(() => {
-      res.status(201);
-    })
-    .catch(next);
+  await db.exec(sqlSurveyDataItem, [surveyDataItem]);
+  res.status(201);
 
 }
 
-function restoreImage(req, res, next) {
+async function restoreImage(req, res) {
   const sqlSurveyDataItem = `INSERT INTO survey_data_item SET ?`;
   const surveyDataItem = {
     uuid : db.bid(util.uuid()),
@@ -134,12 +126,8 @@ function restoreImage(req, res, next) {
     value : req.body.data.old,
   };
 
-  db.exec(sqlSurveyDataItem, [surveyDataItem])
-    .then(() => {
-      res.status(201);
-    })
-    .catch(next);
-
+  await db.exec(sqlSurveyDataItem, [surveyDataItem]);
+  res.status(201);
 }
 
 /**
@@ -147,15 +135,11 @@ function restoreImage(req, res, next) {
 *
 * Returns the detail of a single survey_form
 */
-function detail(req, res, next) {
+async function detail(req, res) {
   const surveyUuid = req.params.uuid;
 
-  lookupFillForm(surveyUuid)
-    .then((record) => {
-      res.status(200).json(record);
-    })
-    .catch(next);
-
+  const record = await lookupFillForm(surveyUuid);
+  res.status(200).json(record);
 }
 
 function lookupFillForm(surveyUuid) {
@@ -170,7 +154,7 @@ function lookupFillForm(surveyUuid) {
 }
 
 // PUT /fill_form /:uuid
-function update(req, res, next) {
+async function update(req, res) {
   let medicalSheet;
 
   const dataCollectorManagementId = {
@@ -189,120 +173,114 @@ function update(req, res, next) {
 
   const surveyUuid = req.params.uuid;
 
-  surveyForm.getSurveyFormElement(dataCollectorManagementId)
-    .then((survey) => {
-      // Data Survey
-      const surveyNewDataItem = [];
-      const surveyOldDataItem = [];
-      const logUuid = uuid();
+  const survey = await surveyForm.getSurveyFormElement(dataCollectorManagementId);
+  // Data Survey
+  const surveyNewDataItem = [];
+  const surveyOldDataItem = [];
+  const logUuid = uuid();
 
-      Object.keys(newData).forEach((key) => {
-        survey.forEach(s => {
-          if (key === s.name) {
-            if (s.typeForm === 'date') {
-              newData[key] = moment(newData[key]).format('YYYY-MM-DD');
-              newData[key] = moment(newData[key]).format('YYYY-MM-DD');
-            } else if (s.typeForm === 'time') {
-              newData[key] = moment(newData[key]).format('HH:mm');
-            } else if (s.typeForm === 'select_multiple') {
-              // Set Element for multiple choice
-              newData[key].forEach((element) => {
-                surveyNewDataItem.push([
-                  db.bid(util.uuid()),
-                  db.bid(surveyUuid),
-                  s.id,
-                  s.name,
-                  element,
-                ]);
-              });
-            }
+  Object.keys(newData).forEach((key) => {
+    survey.forEach(s => {
+      if (key === s.name) {
+        if (s.typeForm === 'date') {
+          newData[key] = moment(newData[key]).format('YYYY-MM-DD');
+          newData[key] = moment(newData[key]).format('YYYY-MM-DD');
+        } else if (s.typeForm === 'time') {
+          newData[key] = moment(newData[key]).format('HH:mm');
+        } else if (s.typeForm === 'select_multiple') {
+          // Set Element for multiple choice
+          newData[key].forEach((element) => {
+            surveyNewDataItem.push([
+              db.bid(util.uuid()),
+              db.bid(surveyUuid),
+              s.id,
+              s.name,
+              element,
+            ]);
+          });
+        }
 
-            if (s.typeForm === 'calculation') {
-              newData[key] = surveyForm.getCalculation(s, newData);
-            }
+        if (s.typeForm === 'calculation') {
+          newData[key] = surveyForm.getCalculation(s, newData);
+        }
 
-            // Put In DataSurvey
-            if (s.typeForm !== 'select_multiple' && s.typeForm !== 'image') {
-              surveyNewDataItem.push([
-                db.bid(util.uuid()),
-                db.bid(surveyUuid),
-                s.id,
-                s.name,
-                newData[key],
-              ]);
-            }
-          }
-        });
-      });
+        // Put In DataSurvey
+        if (s.typeForm !== 'select_multiple' && s.typeForm !== 'image') {
+          surveyNewDataItem.push([
+            db.bid(util.uuid()),
+            db.bid(surveyUuid),
+            s.id,
+            s.name,
+            newData[key],
+          ]);
+        }
+      }
+    });
+  });
 
-      Object.keys(oldData).forEach((key) => {
-        survey.forEach(s => {
-          if (key === s.name) {
-            if (s.typeForm === 'date') {
-              oldData[key] = moment(oldData[key]).format('YYYY-MM-DD');
-              oldData[key] = moment(oldData[key]).format('YYYY-MM-DD');
-            } else if (s.typeForm === 'time') {
-              oldData[key] = moment(oldData[key]).format('HH:mm');
-            } else if (s.typeForm === 'select_multiple') {
-              // Set Element for multiple choice
-              oldData[key].forEach((element) => {
-                surveyOldDataItem.push([
-                  db.bid(util.uuid()),
-                  db.bid(logUuid),
-                  s.id,
-                  s.name,
-                  db.bid(surveyUuid),
-                  req.session.user.id,
-                  'updated',
-                  element,
-                ]);
-              });
-            }
+  Object.keys(oldData).forEach((key) => {
+    survey.forEach(s => {
+      if (key === s.name) {
+        if (s.typeForm === 'date') {
+          oldData[key] = moment(oldData[key]).format('YYYY-MM-DD');
+          oldData[key] = moment(oldData[key]).format('YYYY-MM-DD');
+        } else if (s.typeForm === 'time') {
+          oldData[key] = moment(oldData[key]).format('HH:mm');
+        } else if (s.typeForm === 'select_multiple') {
+          // Set Element for multiple choice
+          oldData[key].forEach((element) => {
+            surveyOldDataItem.push([
+              db.bid(util.uuid()),
+              db.bid(logUuid),
+              s.id,
+              s.name,
+              db.bid(surveyUuid),
+              req.session.user.id,
+              'updated',
+              element,
+            ]);
+          });
+        }
 
-            if (s.typeForm !== 'select_multiple') {
-              surveyOldDataItem.push([
-                db.bid(util.uuid()),
-                db.bid(logUuid),
-                s.id,
-                s.name,
-                db.bid(surveyUuid),
-                req.session.user.id,
-                'updated',
-                oldData[key],
-              ]);
-            }
-          }
-        });
-      });
+        if (s.typeForm !== 'select_multiple') {
+          surveyOldDataItem.push([
+            db.bid(util.uuid()),
+            db.bid(logUuid),
+            s.id,
+            s.name,
+            db.bid(surveyUuid),
+            req.session.user.id,
+            'updated',
+            oldData[key],
+          ]);
+        }
+      }
+    });
+  });
 
-      const transaction = db.transaction();
-      const deleteSurveyDataItem = `
+  const transaction = db.transaction();
+  const deleteSurveyDataItem = `
         DELETE FROM survey_data_item WHERE survey_data_uuid = ?;
       `;
-      const sqlSurveyDataItem = `INSERT INTO survey_data_item
+  const sqlSurveyDataItem = `INSERT INTO survey_data_item
         (uuid, survey_data_uuid, survey_form_id, survey_form_label, value) VALUES ?`;
 
-      const sqlSurveyDataLog = `INSERT INTO survey_data_log
+  const sqlSurveyDataLog = `INSERT INTO survey_data_log
         (uuid, log_uuid, survey_form_id, survey_form_label, survey_data_uuid, user_id, status, value) VALUES ?`;
 
-      const saveLinkSurveyPatient = `INSERT INTO medical_sheet SET ?`;
+  const saveLinkSurveyPatient = `INSERT INTO medical_sheet SET ?`;
 
-      if (req.body.new.patient_uuid) {
-        transaction
-          .addQuery(saveLinkSurveyPatient, [medicalSheet]);
-      }
+  if (req.body.new.patient_uuid) {
+    transaction
+      .addQuery(saveLinkSurveyPatient, [medicalSheet]);
+  }
 
-      transaction
-        .addQuery(deleteSurveyDataItem, [db.bid(surveyUuid)])
-        .addQuery(sqlSurveyDataItem, [surveyNewDataItem])
-        .addQuery(sqlSurveyDataLog, [surveyOldDataItem]);
-      return transaction.execute();
-    })
-    .then(() => {
-      res.status(201).json({ uuid : surveyUuid });
-    })
-    .catch(next);
-
+  transaction
+    .addQuery(deleteSurveyDataItem, [db.bid(surveyUuid)])
+    .addQuery(sqlSurveyDataItem, [surveyNewDataItem])
+    .addQuery(sqlSurveyDataLog, [surveyOldDataItem]);
+  await transaction.execute();
+  res.status(201).json({ uuid : surveyUuid });
 }
 // create a new survey data
 exports.create = create;

--- a/server/controllers/admin/functions.js
+++ b/server/controllers/admin/functions.js
@@ -58,9 +58,9 @@ async function update(req, res) {
 }
 
 // DELETE /function/:id
-function del(req, res, next) {
-  db.delete(
-    'fonction', 'id', req.params.id, res, next, `Could not find a function with id ${req.params.id}`,
+async function del(req, res) {
+  await db.delete(
+    'fonction', 'id', req.params.id, res, `Could not find a fonction with id ${req.params.id}`,
   );
 }
 

--- a/server/controllers/admin/fundingSources.js
+++ b/server/controllers/admin/fundingSources.js
@@ -9,43 +9,37 @@ module.exports = {
 };
 
 // add a new funding source
-function create(req, res, next) {
+async function create(req, res) {
   const sql = `INSERT INTO funding_source SET ?`;
   const data = req.body;
   const indentifier = data.uuid;
   data.uuid = data.uuid ? db.bid(data.uuid) : db.uuid();
-  db.exec(sql, data)
-    .then(() => {
-      res.status(201).json({ uuid : indentifier });
-    }).catch(next);
+  await db.exec(sql, data);
+  res.status(201).json({ uuid : indentifier });
 }
 
 // update funding source information
-function update(req, res, next) {
+async function update(req, res) {
   const sql = `UPDATE funding_source SET ?  WHERE uuid =?`;
   const data = req.body;
   delete data.uuid;
   const uuid = db.bid(req.params.uuid);
 
-  db.exec(sql, [data, uuid])
-    .then(() => {
-      const value = getDetails(uuid);
-      res.status(200).json(value);
-    }).catch(next);
+  await db.exec(sql, [data, uuid]);
+  const value = await getDetails(uuid);
+  res.status(200).json(value);
 }
 
 // get all funding sources
-function read(req, res, next) {
+async function read(req, res) {
   const sql = `
     SELECT BUID(uuid) as uuid, label, code
     FROM funding_source
     ORDER BY label ASC
   `;
 
-  db.exec(sql)
-    .then(rows => {
-      res.status(200).json(rows);
-    }).catch(next);
+  const rows = await db.exec(sql);
+  res.status(200).json(rows);
 }
 
 function getDetails(uuid) {
@@ -54,26 +48,23 @@ function getDetails(uuid) {
     FROM funding_source
     WHERE uuid =?
   `;
+
   return db.one(sql, uuid);
 }
 
 // get a funding source detail
-function detail(req, res, next) {
+async function detail(req, res) {
   const uuid = db.bid(req.params.uuid);
-  getDetails(uuid)
-    .then(value => {
-      res.status(200).json(value);
-    }).catch(next);
+  const value = await getDetails(uuid);
+  res.status(200).json(value);
 }
 
 // get a funding source detail
-function remove(req, res, next) {
+async function remove(req, res) {
   const sql = `
     DELETE FROM funding_source WHERE uuid =?
   `;
   const uuid = db.bid(req.params.uuid);
-  db.exec(sql, uuid)
-    .then(rows => {
-      res.status(204).json(rows);
-    }).catch(next);
+  const rows = await db.exec(sql, uuid);
+  res.status(204).json(rows);
 }

--- a/server/controllers/admin/grades.js
+++ b/server/controllers/admin/grades.js
@@ -69,21 +69,17 @@ async function update(req, res) {
 }
 
 // DELETE /grade/:uuid
-async function del(req, res, next) {
-  try {
-    const sql = 'DELETE FROM grade WHERE uuid = ?;';
-    const uid = db.bid(req.params.uuid);
+async function del(req, res) {
+  const sql = 'DELETE FROM grade WHERE uuid = ?;';
+  const uid = db.bid(req.params.uuid);
 
-    const row = await db.exec(sql, [uid]);
+  const row = await db.exec(sql, [uid]);
 
-    if (row.affectedRows === 0) {
-      throw new NotFound(`Could not find a grade with uuid ${uid}`);
-    }
-
-    res.status(204).json();
-  } catch (err) {
-    next(err);
+  if (row.affectedRows === 0) {
+    throw new NotFound(`Could not find a grade with uuid ${uid}`);
   }
+
+  res.status(204).json();
 }
 
 // get list of Grade

--- a/server/controllers/admin/helpdesk.js
+++ b/server/controllers/admin/helpdesk.js
@@ -16,15 +16,13 @@ exports.read = helpdeskInfo;
  * Should update to support a passed-in enterprise id
  */
 
-function helpdeskInfo(req, res, next) {
+async function helpdeskInfo(req, res) {
 
   const sql = `select helpdesk
     FROM enterprise
     LIMIT 1;
   `;
 
-  db.one(sql, [], 1, 'enterprise')
-    .then((row) => res.status(200).json(row))
-    .catch(next);
-
+  const row = await db.one(sql, [], 1, 'enterprise');
+  res.status(200).json(row);
 }

--- a/server/controllers/admin/holidays.js
+++ b/server/controllers/admin/holidays.js
@@ -112,9 +112,9 @@ async function update(req, res) {
 }
 
 // DELETE /holiday/:id
-function del(req, res, next) {
-  db.delete(
-    'holiday', 'id', req.params.id, res, next, `Could not find a Holiday with id ${req.params.id}`,
+async function del(req, res) {
+  await db.delete(
+    'holiday', 'id', req.params.id, res, `Could not find a Holiday with id ${req.params.id}`,
   );
 }
 

--- a/server/controllers/admin/iprTax.js
+++ b/server/controllers/admin/iprTax.js
@@ -61,8 +61,8 @@ async function update(req, res) {
 }
 
 // DELETE /IprTax/:id
-function del(req, res, next) {
-  db.delete('taxe_ipr', 'id', req.params.id, res, next, `Could not find a IprTax with id ${req.params.id}`);
+async function del(req, res) {
+  await db.delete('taxe_ipr', 'id', req.params.id, res, `Could not find a IprTax with id ${req.params.id}`);
 }
 
 // GET /IprTaxConfig
@@ -134,9 +134,9 @@ async function updateConfig(req, res) {
 }
 
 // DELETE /IprTaxConfig/:id
-function deleteConfig(req, res, next) {
-  db.delete(
-    'taxe_ipr_configuration', 'id', req.params.id, res, next,
+async function deleteConfig(req, res) {
+  await db.delete(
+    'taxe_ipr_configuration', 'id', req.params.id, res,
     `Could not find a IprTax Configuration with id ${req.params.id}`,
   );
 }

--- a/server/controllers/admin/languages.js
+++ b/server/controllers/admin/languages.js
@@ -13,16 +13,12 @@ const db = require('../../lib/db');
 exports.list = list;
 
 // GET /languages
-function list(req, res, next) {
+async function list(req, res) {
   const sql = `
     SELECT lang.id, lang.name, lang.key, lang.locale_key AS localeKey
     FROM language AS lang;
   `;
 
-  db.exec(sql)
-    .then((rows) => {
-      res.status(200).json(rows);
-    })
-    .catch(next);
-
+  const rows = await db.exec(sql);
+  res.status(200).json(rows);
 }

--- a/server/controllers/admin/locations.js
+++ b/server/controllers/admin/locations.js
@@ -257,7 +257,6 @@ exports.list = async function list(req, res) {
 
   const data = await db.exec(sql);
   res.status(200).json(data);
-
 };
 
 /** bindings for creation methods */
@@ -290,7 +289,7 @@ exports.create.country = async function createCountry(req, res) {
  * @method createProvince
  * @returns {string} uuid - the uuid for the province.
  */
-exports.create.province = function createProvince(req, res, next) {
+exports.create.province = async function createProvince(req, res) {
   const data = db.convert(req.body, [
     'village_uuid', 'sector_uuid', 'province_uuid', 'country_uuid',
   ]);
@@ -300,12 +299,8 @@ exports.create.province = function createProvince(req, res, next) {
 
   const sql = 'INSERT INTO province (uuid, name, country_uuid) VALUES (?);';
 
-  db.exec(sql, [[db.bid(data.uuid), data.name, data.country_uuid]])
-    .then(() => {
-      res.status(201).json({ uuid : data.uuid });
-    })
-    .catch(next);
-
+  await db.exec(sql, [[db.bid(data.uuid), data.name, data.country_uuid]]);
+  res.status(201).json({ uuid : data.uuid });
 };
 
 /**
@@ -317,7 +312,7 @@ exports.create.province = function createProvince(req, res, next) {
  * @method createSector
  * @returns {string} uuid - the unique id for the sector.
  */
-exports.create.sector = function createSector(req, res, next) {
+exports.create.sector = async function createSector(req, res) {
   const data = db.convert(req.body, ['province_uuid']);
 
   // create a UUID if not provided
@@ -325,12 +320,8 @@ exports.create.sector = function createSector(req, res, next) {
 
   const sql = `INSERT INTO sector (uuid, name, province_uuid) VALUES (?);`;
 
-  db.exec(sql, [[db.bid(data.uuid), data.name, data.province_uuid]])
-    .then(() => {
-      res.status(201).json({ uuid : data.uuid });
-    })
-    .catch(next);
-
+  await db.exec(sql, [[db.bid(data.uuid), data.name, data.province_uuid]]);
+  res.status(201).json({ uuid : data.uuid });
 };
 
 /**
@@ -342,7 +333,7 @@ exports.create.sector = function createSector(req, res, next) {
  * @method createVillage
  * @returns {string} uuid - the unique id for the village.
  */
-exports.create.village = function createVillage(req, res, next) {
+exports.create.village = async function createVillage(req, res) {
   const data = db.convert(req.body, ['sector_uuid']);
 
   // create a UUID if not provided
@@ -350,12 +341,8 @@ exports.create.village = function createVillage(req, res, next) {
 
   const sql = `INSERT INTO village (uuid, name, sector_uuid, longitude, latitude) VALUES (?);`;
 
-  db.exec(sql, [[db.bid(data.uuid), data.name, data.sector_uuid, data.longitude, data.latitude]])
-    .then(() => {
-      res.status(201).json({ uuid : data.uuid });
-    })
-    .catch(next);
-
+  await db.exec(sql, [[db.bid(data.uuid), data.name, data.sector_uuid, data.longitude, data.latitude]]);
+  res.status(201).json({ uuid : data.uuid });
 };
 
 /** bindings for update methods */
@@ -368,7 +355,7 @@ exports.update = {};
  *
  * @method updateCountry
  */
-exports.update.country = function updateCountry(req, res, next) {
+exports.update.country = async function updateCountry(req, res) {
   const bid = db.bid(req.params.uuid);
   const sql = 'UPDATE country SET ? WHERE uuid = ?;';
 
@@ -379,15 +366,9 @@ exports.update.country = function updateCountry(req, res, next) {
     'village_uuid', 'sector_uuid', 'province_uuid', 'country_uuid',
   ]);
 
-  db.exec(sql, [data, bid])
-    .then(() => {
-      return lookupCountry(req.params.uuid);
-    })
-    .then((record) => {
-      res.status(200).json(record);
-    })
-    .catch(next);
-
+  await db.exec(sql, [data, bid]);
+  const record = await lookupCountry(req.params.uuid);
+  res.status(200).json(record);
 };
 
 /**
@@ -397,7 +378,7 @@ exports.update.country = function updateCountry(req, res, next) {
  *
  * @method updateProvince
  */
-exports.update.province = function updateProvince(req, res, next) {
+exports.update.province = async function updateProvince(req, res) {
   const bid = db.bid(req.params.uuid);
   const sql = 'UPDATE province SET ? WHERE uuid = ?;';
 
@@ -408,14 +389,9 @@ exports.update.province = function updateProvince(req, res, next) {
     'village_uuid', 'sector_uuid', 'province_uuid', 'country_uuid',
   ]);
 
-  db.exec(sql, [data, bid])
-    .then(() => {
-      return lookupProvince(req.params.uuid);
-    })
-    .then((record) => {
-      res.status(200).json(record);
-    })
-    .catch(next);
+  await db.exec(sql, [data, bid]);
+  const record = await lookupProvince(req.params.uuid);
+  res.status(200).json(record);
 
 };
 
@@ -426,7 +402,7 @@ exports.update.province = function updateProvince(req, res, next) {
  *
  * @method updateSector
  */
-exports.update.sector = function updateSector(req, res, next) {
+exports.update.sector = async function updateSector(req, res) {
   const bid = db.bid(req.params.uuid);
   const sql = `UPDATE sector SET ? WHERE uuid = ?;`;
 
@@ -437,14 +413,9 @@ exports.update.sector = function updateSector(req, res, next) {
     'village_uuid', 'sector_uuid', 'province_uuid', 'country_uuid',
   ]);
 
-  db.exec(sql, [data, bid])
-    .then(() => {
-      return lookupSector(req.params.uuid);
-    })
-    .then((record) => {
-      res.status(200).json(record);
-    })
-    .catch(next);
+  await db.exec(sql, [data, bid]);
+  const record = await lookupSector(req.params.uuid);
+  res.status(200).json(record);
 
 };
 
@@ -455,7 +426,7 @@ exports.update.sector = function updateSector(req, res, next) {
  *
  * @method updateVillage
  */
-exports.update.village = function updateVillage(req, res, next) {
+exports.update.village = async function updateVillage(req, res) {
   const bid = db.bid(req.params.uuid);
 
   const sql = `UPDATE village SET ? WHERE uuid = ?;`;
@@ -467,52 +438,43 @@ exports.update.village = function updateVillage(req, res, next) {
     'village_uuid', 'sector_uuid', 'province_uuid', 'country_uuid',
   ]);
 
-  db.exec(sql, [data, bid])
-    .then(() => {
-      return lookupVillage(req.params.uuid);
-    })
-    .then((record) => {
-      res.status(200).json(record);
-    })
-    .catch(next);
+  await db.exec(sql, [data, bid]);
+  const record = await lookupVillage(req.params.uuid);
+  res.status(200).json(record);
 
 };
 
 exports.delete = {};
 
-exports.delete.country = (req, res, next) => {
+exports.delete.country = async (req, res) => {
   const sql = 'DELETE FROM country WHERE uuid=?';
   const _uuid = db.bid(req.params.uuid);
-  db.exec(sql, _uuid).then(() => {
-    res.sendStatus(204);
-  }).catch(next);
+  await db.exec(sql, _uuid);
+  res.sendStatus(204);
 };
 
-exports.delete.province = (req, res, next) => {
+exports.delete.province = async (req, res) => {
   const sql = 'DELETE FROM province WHERE uuid=?';
   const _uuid = db.bid(req.params.uuid);
-  db.exec(sql, _uuid).then(() => {
-    res.sendStatus(204);
-  }).catch(next);
+  await db.exec(sql, _uuid);
+  res.sendStatus(204);
 };
 
-exports.delete.sector = (req, res, next) => {
+exports.delete.sector = async (req, res) => {
   const sql = 'DELETE FROM sector WHERE uuid=?';
   const _uuid = db.bid(req.params.uuid);
-  db.exec(sql, _uuid).then(() => {
-    res.sendStatus(204);
-  }).catch(next);
+  await db.exec(sql, _uuid);
+  res.sendStatus(204);
 };
 
-exports.delete.village = (req, res, next) => {
+exports.delete.village = async (req, res) => {
   const sql = 'DELETE FROM village WHERE uuid=?';
   const _uuid = db.bid(req.params.uuid);
-  db.exec(sql, _uuid).then(() => {
-    res.sendStatus(204);
-  }).catch(next);
+  await db.exec(sql, _uuid);
+  res.sendStatus(204);
 };
 
-exports.merge = (req, res, next) => {
+exports.merge = async (req, res) => {
   const { selected, other, locationStatus } = req.body;
 
   const transaction = db.transaction();
@@ -577,7 +539,6 @@ exports.merge = (req, res, next) => {
       .addQuery(removeOtherVillage, [db.bid(other)]);
   }
 
-  transaction.execute().then(() => {
-    res.sendStatus(200);
-  }).catch(next);
+  await transaction.execute();
+  res.sendStatus(200);
 };

--- a/server/controllers/admin/offdays.js
+++ b/server/controllers/admin/offdays.js
@@ -57,9 +57,9 @@ async function update(req, res) {
 }
 
 // DELETE /Offday/:id
-function del(req, res, next) {
-  db.delete(
-    'offday', 'id', req.params.id, res, next, `Could not find a Offday with id ${req.params.id}`,
+async function del(req, res) {
+  await db.delete(
+    'offday', 'id', req.params.id, res, `Could not find a Offday with id ${req.params.id}`,
   );
 }
 

--- a/server/controllers/admin/projects.js
+++ b/server/controllers/admin/projects.js
@@ -125,6 +125,6 @@ exports.update = async function update(req, res) {
  *
  * Deletes a project.
  */
-exports.delete = function del(req, res, next) {
-  db.delete('project', 'id', req.params.id, res, next, `No project found by id ${req.params.id}.`);
+exports.delete = async function del(req, res) {
+  await db.delete('project', 'id', req.params.id, res, `No project found by id ${req.params.id}.`);
 };

--- a/server/controllers/admin/services.js
+++ b/server/controllers/admin/services.js
@@ -139,8 +139,8 @@ async function update(req, res) {
  * @description
  * Remove a service in the database.
  */
-function remove(req, res, next) {
-  db.delete('service', 'uuid', db.bid(req.params.uuid), res, next,
+async function remove(req, res) {
+  await db.delete('service', 'uuid', db.bid(req.params.uuid), res,
     `Could not find a service with uuid ${req.params.uuid}`);
 }
 

--- a/server/controllers/admin/surveyForm.js
+++ b/server/controllers/admin/surveyForm.js
@@ -5,6 +5,7 @@
 * This controller exposes an API to the client for reading and writing SURVEY FORM
 */
 
+const debug = require('debug')('bhima:data-collection:surveyForm');
 const db = require('../../lib/db');
 const NotFound = require('../../lib/errors/NotFound');
 const FilterParser = require('../../lib/filter');
@@ -104,9 +105,11 @@ async function remove(req, res) {
   res.status(204).json();
 }
 
-function getCalculation(survey) {
+function getCalculation(survey, data) { // eslint-disable-line no-unused-vars
   // the params data is used in function eval
   let formula = survey.calculation;
+
+  debug(`Getting calculation for survey form id ${survey.id} with formula ${formula}`);
 
   formula = formula.replace(/.{/g, 'data.');
   formula = formula.replace(/}/g, '');

--- a/server/controllers/admin/surveyForm.js
+++ b/server/controllers/admin/surveyForm.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-eval */
-/* eslint-disable no-unused-vars */
 /**
 * SURVEY FORM Controller
 *
@@ -48,25 +47,17 @@ function getSurveyFormElement(params) {
   return db.exec(query, parameters);
 }
 
-function list(req, res, next) {
-  getSurveyFormElement(req.query)
-    .then((rows) => {
-      res.status(200).json(rows);
-    })
-    .catch(next);
-
+async function list(req, res) {
+  const rows = await getSurveyFormElement(req.query);
+  res.status(200).json(rows);
 }
 
 // List of Survey Form Type
-function listSurveyformtype(req, res, next) {
+async function listSurveyformtype(req, res) {
   const sql = `SELECT id, label, type, is_list FROM survey_form_type;`;
 
-  db.exec(sql)
-    .then((rows) => {
-      res.status(200).json(rows);
-    })
-    .catch(next);
-
+  const rows = await db.exec(sql);
+  res.status(200).json(rows);
 }
 
 /**
@@ -74,64 +65,46 @@ function listSurveyformtype(req, res, next) {
 *
 * Returns the detail of a single survey_form
 */
-function detail(req, res, next) {
+async function detail(req, res) {
   const { id } = req.params;
 
-  lookupSurveyForm(id)
-    .then((record) => {
-      res.status(200).json(record);
-    })
-    .catch(next);
-
+  const record = await lookupSurveyForm(id);
+  res.status(200).json(record);
 }
 
 // POST /survey_form
-function create(req, res, next) {
+async function create(req, res) {
   const sql = `INSERT INTO survey_form SET ?`;
   const data = req.body;
 
-  db.exec(sql, [data])
-    .then((row) => {
-      res.status(201).json({ id : row.insertId });
-    })
-    .catch(next);
-
+  const row = await db.exec(sql, [data]);
+  res.status(201).json({ id : row.insertId });
 }
 
 // PUT /survey_form /:id
-function update(req, res, next) {
+async function update(req, res) {
   const sql = `UPDATE survey_form SET ? WHERE id = ?;`;
 
-  db.exec(sql, [req.body, req.params.id])
-    .then(() => {
-      return lookupSurveyForm(req.params.id);
-    })
-    .then((record) => {
-      // all updates completed successfull, return full object to client
-      res.status(200).json(record);
-    })
-    .catch(next);
-
+  await db.exec(sql, [req.body, req.params.id]);
+  const record = await lookupSurveyForm(req.params.id);
+  // all updates completed successfull, return full object to client
+  res.status(200).json(record);
 }
 
 // DELETE /survey_form/:id
-function remove(req, res, next) {
+async function remove(req, res) {
   const sql = `DELETE FROM survey_form WHERE id = ?;`;
 
-  db.exec(sql, [req.params.id])
-    .then((row) => {
-      // if nothing happened, let the client know via a 404 error
-      if (row.affectedRows === 0) {
-        throw new NotFound(`Could not find a function with id ${req.params.id}`);
-      }
+  const row = await db.exec(sql, [req.params.id]);
+  // if nothing happened, let the client know via a 404 error
+  if (row.affectedRows === 0) {
+    throw new NotFound(`Could not find a function with id ${req.params.id}`);
+  }
 
-      res.status(204).json();
-    })
-    .catch(next);
-
+  res.status(204).json();
 }
 
-function getCalculation(survey, data) {
+function getCalculation(survey) {
   // the params data is used in function eval
   let formula = survey.calculation;
 

--- a/server/controllers/admin/tags.js
+++ b/server/controllers/admin/tags.js
@@ -9,65 +9,55 @@ module.exports = {
 };
 
 // add a new tag
-function create(req, res, next) {
+async function create(req, res) {
   const sql = `INSERT INTO tags SET ?`;
   const data = req.body;
   data.uuid = data.uuid ? db.bid(data.uuid) : db.uuid();
-  db.exec(sql, data)
-    .then(() => {
-      res.sendStatus(201);
-    }).catch(next);
+  await db.exec(sql, data);
+  res.sendStatus(201);
 }
 
 // update tag information
-function update(req, res, next) {
+async function update(req, res) {
   const sql = `UPDATE tags SET ?  WHERE uuid =?`;
   const data = req.body;
   delete data.uuid;
   const uuid = db.bid(req.params.uuid);
 
-  db.exec(sql, [data, uuid])
-    .then(() => {
-      res.sendStatus(200);
-    }).catch(next);
+  await db.exec(sql, [data, uuid]);
+  res.sendStatus(200);
 }
 
 // get all tags
-function read(req, res, next) {
+async function read(req, res) {
   const sql = `
     SELECT BUID(uuid) as uuid, name, color
     FROM tags
     ORDER BY name ASC
   `;
 
-  db.exec(sql)
-    .then(rows => {
-      res.status(200).json(rows);
-    }).catch(next);
+  const rows = await db.exec(sql);
+  res.status(200).json(rows);
 }
 
 // get a tag detail
-function detail(req, res, next) {
+async function detail(req, res) {
   const sql = `
     SELECT BUID(uuid) as uuid, name, color
     FROM tags
     WHERE uuid =?
   `;
   const uuid = db.bid(req.params.uuid);
-  db.one(sql, uuid)
-    .then(tag => {
-      res.status(200).json(tag);
-    }).catch(next);
+  const tag = await db.one(sql, uuid);
+  res.status(200).json(tag);
 }
 
 // get a tag detail
-function remove(req, res, next) {
+async function remove(req, res) {
   const sql = `
     DELETE FROM tags WHERE uuid =?
   `;
   const uuid = db.bid(req.params.uuid);
-  db.exec(sql, uuid)
-    .then(rows => {
-      res.status(204).json(rows);
-    }).catch(next);
+  const rows = await db.exec(sql, uuid);
+  res.status(204).json(rows);
 }

--- a/server/controllers/admin/titles.js
+++ b/server/controllers/admin/titles.js
@@ -54,9 +54,9 @@ async function update(req, res) {
 }
 
 // DELETE /title/:id
-function del(req, res, next) {
-  db.delete(
-    'title_employee', 'id', req.params.id, res, next, `Could not find a title with id ${req.params.id}`,
+async function del(req, res) {
+  await db.delete(
+    'title_employee', 'id', req.params.id, res, `Could not find a title with id ${req.params.id}`,
   );
 }
 

--- a/server/controllers/admin/transactionType.js
+++ b/server/controllers/admin/transactionType.js
@@ -24,11 +24,9 @@ exports.remove = remove;
  * @description
  * List all transaction types
  */
-function list(req, res, next) {
-  getTransactionType()
-    .then(rows => res.status(200).json(rows))
-    .catch(next);
-
+async function list(req, res) {
+  const rows = await getTransactionType();
+  res.status(200).json(rows);
 }
 
 /**
@@ -37,11 +35,9 @@ function list(req, res, next) {
  * @description
  * Find a single transaction type by its ID.
  */
-function detail(req, res, next) {
-  getTransactionType(req.params.id)
-    .then(rows => res.status(200).json(rows[0]))
-    .catch(next);
-
+async function detail(req, res) {
+  const rows = await getTransactionType(req.params.id);
+  res.status(200).json(rows[0]);
 }
 
 /**
@@ -50,15 +46,11 @@ function detail(req, res, next) {
  * @description
  * Creates a new transaction type.
  */
-function create(req, res, next) {
+async function create(req, res) {
   const sql = `INSERT INTO transaction_type SET ?`;
 
-  db.exec(sql, [req.body])
-    .then(rows => {
-      res.status(201).json({ id : rows.insertId });
-    })
-    .catch(next);
-
+  const rows = await db.exec(sql, [req.body]);
+  res.status(201).json({ id : rows.insertId });
 }
 
 /**
@@ -67,20 +59,16 @@ function create(req, res, next) {
  * @description
  * Updates a transaction type.
  */
-function update(req, res, next) {
+async function update(req, res) {
   const sql = `UPDATE transaction_type SET ? WHERE id = ? AND fixed <> 1`;
 
   delete req.body.fixed;
-  db.exec(sql, [req.body, req.params.id])
-    .then(rows => {
-      if (!rows.affectedRows) {
-        throw new BadRequest('ERRORS.NOT_ALLOWED');
-      }
-      return getTransactionType(req.params.id);
-    })
-    .then(rows => res.status(200).json(rows))
-    .catch(next);
-
+  const rows = await db.exec(sql, [req.body, req.params.id]);
+  if (!rows.affectedRows) {
+    throw new BadRequest('ERRORS.NOT_ALLOWED');
+  }
+  const results = await getTransactionType(req.params.id);
+  res.status(200).json(results);
 }
 
 /**
@@ -90,13 +78,11 @@ function update(req, res, next) {
  * Deletes a transaction type by id.  Note that "fixed" transaction types are
  * not considered.
  */
-function remove(req, res, next) {
+async function remove(req, res) {
   const sql = `DELETE FROM transaction_type WHERE id = ? AND fixed <> 1`;
 
-  db.exec(sql, [req.params.id])
-    .then(() => res.sendStatus(204))
-    .catch(next);
-
+  await db.exec(sql, [req.params.id]);
+  res.sendStatus(204);
 }
 
 /**

--- a/server/controllers/admin/users/depots.js
+++ b/server/controllers/admin/users/depots.js
@@ -18,7 +18,7 @@ exports.create = create;
  *
  * Lists all the user depots for user with :id
  */
-function list(req, res, next) {
+async function list(req, res) {
   let sql;
 
   if (req.query.details) {
@@ -28,11 +28,9 @@ function list(req, res, next) {
       WHERE depot_permission.user_id = ?;
     `;
 
-    return db.exec(sql, [req.params.id])
-      .then((rows) => {
-        res.status(200).json(rows);
-      })
-      .catch(next);
+    const rows = await db.exec(sql, [req.params.id]);
+    res.status(200).json(rows);
+    return;
 
   }
 
@@ -41,12 +39,9 @@ function list(req, res, next) {
     WHERE depot_permission.user_id = ?;
   `;
 
-  return db.exec(sql, [req.params.id])
-    .then((rows) => {
-      const data = rows.map(row => row.depot_uuid);
-      res.status(200).json(data);
-    })
-    .catch(next);
+  const rows = await db.exec(sql, [req.params.id]);
+  const data = rows.map(row => row.depot_uuid);
+  res.status(200).json(data);
 
 }
 
@@ -56,7 +51,7 @@ function list(req, res, next) {
  * Creates and updates a user's depots.  This works by completely deleting
  * the user's depots and then replacing them with the new depots set.
  */
-function create(req, res, next) {
+async function create(req, res) {
   const transaction = db.transaction();
 
   transaction
@@ -73,10 +68,6 @@ function create(req, res, next) {
       .addQuery('INSERT INTO depot_permission (depot_uuid, user_id) VALUES ?', [data]);
   }
 
-  transaction.execute()
-    .then(() => {
-      res.sendStatus(201);
-    })
-    .catch(next);
-
+  await transaction.execute();
+  res.sendStatus(201);
 }

--- a/server/controllers/admin/users/depotsSupervision.js
+++ b/server/controllers/admin/users/depotsSupervision.js
@@ -18,18 +18,15 @@ exports.create = create;
  *
  * Lists all the user depots supervision for user with :id
  */
-function list(req, res, next) {
+async function list(req, res) {
   const sql = `
     SELECT BUID(depot_supervision.depot_uuid) AS depot_uuid FROM depot_supervision
     WHERE depot_supervision.user_id = ?;
   `;
 
-  db.exec(sql, [req.params.id])
-    .then((rows) => {
-      const data = rows.map(row => row.depot_uuid);
-      res.status(200).json(data);
-    })
-    .catch(next);
+  const rows = await db.exec(sql, [req.params.id]);
+  const data = rows.map(row => row.depot_uuid);
+  res.status(200).json(data);
 
 }
 
@@ -39,7 +36,7 @@ function list(req, res, next) {
  * Creates and updates a user's depots for supervision.  This works by completely deleting
  * the user's depots and then replacing them with the new depots set.
  */
-function create(req, res, next) {
+async function create(req, res) {
   const transaction = db.transaction();
 
   transaction
@@ -57,10 +54,6 @@ function create(req, res, next) {
       .addQuery('INSERT INTO depot_supervision (depot_uuid, user_id) VALUES ?', [data]);
   }
 
-  transaction.execute()
-    .then(() => {
-      res.sendStatus(201);
-    })
-    .catch(next);
-
+  await transaction.execute();
+  res.sendStatus(201);
 }

--- a/server/controllers/admin/users/projects.js
+++ b/server/controllers/admin/users/projects.js
@@ -17,17 +17,13 @@ exports.list = list;
  *
  * Lists all the user project permissions for user with :id
  */
-function list(req, res, next) {
+async function list(req, res) {
   const sql = `
     SELECT pp.id, pp.project_id, project.name
     FROM project_permission AS pp JOIN project ON pp.project_id = project.id
     WHERE pp.user_id = ?;
   `;
 
-  db.exec(sql, [req.params.id])
-    .then((rows) => {
-      res.status(200).json(rows);
-    })
-    .catch(next);
-
+  const rows = await db.exec(sql, [req.params.id]);
+  res.status(200).json(rows);
 }

--- a/server/controllers/asset_management/shipment/reports/shipments.js
+++ b/server/controllers/asset_management/shipment/reports/shipments.js
@@ -1,5 +1,3 @@
-const _ = require('lodash');
-
 const {
   ReportManager,
   formatFilters,
@@ -7,36 +5,33 @@ const {
   SHIPMENTS_REPORT_TEMPLATE,
 } = require('./common');
 
-async function getReport(req, res, next) {
+async function getReport(req, res) {
   let display = {};
-  const params = req.query;
-  const optionReport = _.extend(params, {
+  const params = structuredClone(req.query);
+  const options = {
+    ...params,
     filename : 'SHIPMENT.SHIPMENTS',
     csvKey : 'rows',
     renameKeys : false,
     orientation : 'landscape',
-  });
+  };
 
-  try {
-    if (params.displayNames) {
-      display = JSON.parse(params.displayNames);
-      delete params.displayNames;
-    }
-
-    const report = new ReportManager(SHIPMENTS_REPORT_TEMPLATE, req.session, optionReport);
-    const rows = await Shipment.find(params);
-
-    const data = {
-      rows,
-      display,
-      filters : formatFilters(params),
-    };
-
-    const result = await report.render(data);
-    res.set(result.headers).send(result.report);
-  } catch (e) {
-    next(e);
+  if (params.displayNames) {
+    display = JSON.parse(params.displayNames);
+    delete params.displayNames;
   }
+
+  const report = new ReportManager(SHIPMENTS_REPORT_TEMPLATE, req.session, options);
+  const rows = await Shipment.find(params);
+
+  const data = {
+    rows,
+    display,
+    filters : formatFilters(params),
+  };
+
+  const result = await report.render(data);
+  res.set(result.headers).send(result.report);
 }
 
 exports.getReport = getReport;

--- a/server/controllers/dashboard/debtorGroups.js
+++ b/server/controllers/dashboard/debtorGroups.js
@@ -10,7 +10,7 @@ let timestamp;
 
 exports.getReport = getReport;
 
-function getReport(req, res, next) {
+async function getReport(req, res) {
   const requestTime = new Moment();
 
   // if the current request is made within the cache life - send the cached report
@@ -24,13 +24,10 @@ function getReport(req, res, next) {
   // the cache has expired or has never been created - calculate the report
   // ensure the latest data from both the posting journal and the general ledger
   // is used
-  report.context({ combinedLedger : 1 })
-    .then((result) => {
-      timestamp = new Moment();
-      cachedReport = result;
-      res.status(200).send(formatResponse(result));
-    })
-    .catch(next);
+  const result = await report.context({ combinedLedger : 1 });
+  timestamp = new Moment();
+  cachedReport = result;
+  res.status(200).send(formatResponse(result));
 }
 
 function formatResponse(reportData) {

--- a/server/controllers/finance/accounts/accountReferenceType.js
+++ b/server/controllers/finance/accounts/accountReferenceType.js
@@ -17,15 +17,11 @@ function lookupAccountReferenceType(id) {
 }
 
 // Lists
-function list(req, res, next) {
+async function list(req, res) {
   const sql = `SELECT id, label, fixed FROM account_reference_type;`;
 
-  db.exec(sql)
-    .then((rows) => {
-      res.status(200).json(rows);
-    })
-    .catch(next);
-
+  const rows = await db.exec(sql);
+  res.status(200).json(rows);
 }
 
 /**
@@ -33,65 +29,48 @@ function list(req, res, next) {
 *
 * Returns the detail of a single account_reference_type
 */
-function detail(req, res, next) {
+async function detail(req, res) {
   const { id } = req.params;
 
-  lookupAccountReferenceType(id)
-    .then((record) => {
-      res.status(200).json(record);
-    })
-    .catch(next);
+  const record = await lookupAccountReferenceType(id);
+  res.status(200).json(record);
 
 }
 
 // POST /account_reference_type
-function create(req, res, next) {
+async function create(req, res) {
   const sql = `INSERT INTO account_reference_type SET ?`;
   const data = req.body;
 
-  db.exec(sql, [data])
-    .then((row) => {
-      res.status(201).json({ id : row.insertId });
-    })
-    .catch(next);
-
+  const row = await db.exec(sql, [data]);
+  res.status(201).json({ id : row.insertId });
 }
 
 // PUT /account_reference_type /:id
-function update(req, res, next) {
+async function update(req, res) {
   if (req.body.id) {
     delete req.body.id;
   }
 
   const sql = `UPDATE account_reference_type SET ? WHERE id = ?;`;
 
-  db.exec(sql, [req.body, req.params.id])
-    .then(() => {
-      return lookupAccountReferenceType(req.params.id);
-    })
-    .then((record) => {
-    // all updates completed successfull, return full object to client
-      res.status(200).json(record);
-    })
-    .catch(next);
-
+  await db.exec(sql, [req.body, req.params.id]);
+  const record = await lookupAccountReferenceType(req.params.id);
+  // all updates completed successfull, return full object to client
+  res.status(200).json(record);
 }
 
 // DELETE /account_reference_type/:id
-function remove(req, res, next) {
+async function remove(req, res) {
   const sql = `DELETE FROM account_reference_type WHERE id = ?;`;
 
-  db.exec(sql, [req.params.id])
-    .then((row) => {
-    // if nothing happened, let the client know via a 404 error
-      if (row.affectedRows === 0) {
-        throw new NotFound(`Could not find an account reference type with id ${req.params.id}`);
-      }
+  const row = await db.exec(sql, [req.params.id]);
+  // if nothing happened, let the client know via a 404 error
+  if (row.affectedRows === 0) {
+    throw new NotFound(`Could not find an account reference type with id ${req.params.id}`);
+  }
 
-      res.status(204).json();
-    })
-    .catch(next);
-
+  res.status(204).json();
 }
 
 // get list of accountReferenceType

--- a/server/controllers/finance/accounts/categories.js
+++ b/server/controllers/finance/accounts/categories.js
@@ -25,13 +25,9 @@ const db = require('../../../lib/db');
  *
  * GET /accounts/categories/:id
  */
-function detail(req, res, next) {
-  lookupAccountCategory(req.params.id)
-    .then((row) => {
-      res.status(200).json(row);
-    })
-    .catch(next);
-
+async function detail(req, res) {
+  const row = await lookupAccountCategory(req.params.id);
+  res.status(200).json(row);
 }
 
 /**
@@ -42,18 +38,14 @@ function detail(req, res, next) {
  *
  * GET /accounts/categories
  */
-function list(req, res, next) {
+async function list(req, res) {
   const sql = `
     SELECT id, category, translation_key
     FROM account_category;
   `;
 
-  db.exec(sql)
-    .then((rows) => {
-      res.status(200).json(rows);
-    })
-    .catch(next);
-
+  const rows = await db.exec(sql);
+  res.status(200).json(rows);
 }
 
 /**
@@ -64,7 +56,7 @@ function list(req, res, next) {
  *
  * POST /accounts/categories
  */
-function create(req, res, next) {
+async function create(req, res) {
   const record = req.body;
   const sql = 'INSERT INTO account_category SET ?';
 
@@ -77,12 +69,8 @@ function create(req, res, next) {
    * */
   record.translation_key = '';
 
-  db.exec(sql, [record])
-    .then((result) => {
-      res.status(201).json({ id : result.insertId });
-    })
-    .catch(next);
-
+  const result = await db.exec(sql, [record]);
+  res.status(201).json({ id : result.insertId });
 }
 
 /**
@@ -93,21 +81,17 @@ function create(req, res, next) {
  *
  * PUT /accounts/categories/:id
  */
-function update(req, res, next) {
+async function update(req, res) {
   const data = req.body;
   const { id } = req.params;
   const sql = 'UPDATE account_category SET ? WHERE id = ?';
 
   delete data.id;
 
-  lookupAccountCategory(id)
-    .then(() => db.exec(sql, [data, id]))
-    .then(() => lookupAccountCategory(id))
-    .then((accountCategory) => {
-      res.status(200).json(accountCategory);
-    })
-    .catch(next);
-
+  await lookupAccountCategory(id);
+  await db.exec(sql, [data, id]);
+  const accountCategory = await lookupAccountCategory(id);
+  res.status(200).json(accountCategory);
 }
 
 /**
@@ -118,19 +102,13 @@ function update(req, res, next) {
  *
  * DELETE /accounts/categories/:id
  */
-function remove(req, res, next) {
+async function remove(req, res) {
   const { id } = req.params;
   const sql = 'DELETE FROM account_category WHERE id = ?';
 
-  lookupAccountCategory(id)
-    .then(() => {
-      return db.exec(sql, [id]);
-    })
-    .then(() => {
-      res.sendStatus(204);
-    })
-    .catch(next);
-
+  await lookupAccountCategory(id);
+  await db.exec(sql, [id]);
+  res.sendStatus(204);
 }
 
 /**
@@ -144,7 +122,6 @@ function remove(req, res, next) {
  */
 function lookupAccountCategory(id) {
   const sql = 'SELECT ac.id, ac.category FROM account_category AS ac WHERE ac.id = ?;';
-
   return db.one(sql, id);
 }
 

--- a/server/controllers/finance/accounts/transactions.js
+++ b/server/controllers/finance/accounts/transactions.js
@@ -10,7 +10,7 @@
  *
  */
 
-const debug = require('debug')('accounts:transactions');
+const debug = require('debug')('bhima:accounts:transactions');
 const db = require('../../../lib/db');
 const FilterParser = require('../../../lib/filter');
 const Exchange = require('../exchange');
@@ -167,6 +167,8 @@ async function getAccountTransactions(options, openingBalance = 0) {
  */
 function buildLedgerSQL(options, openingBalance = 0) {
   const filters = new FilterParser(options);
+
+  debug('Using opening balance of %d', openingBalance);
 
   // Decide if we include posted/unposted data or only posted
   const tableQueries = [];

--- a/server/controllers/finance/accounts/types.js
+++ b/server/controllers/finance/accounts/types.js
@@ -25,13 +25,9 @@ const db = require('../../../lib/db');
  *
  * GET /accounts/types/:id
  */
-function detail(req, res, next) {
-  lookupAccountType(req.params.id)
-    .then((row) => {
-      res.status(200).json(row);
-    })
-    .catch(next);
-
+async function detail(req, res) {
+  const row = await lookupAccountType(req.params.id);
+  res.status(200).json(row);
 }
 
 /**
@@ -42,15 +38,11 @@ function detail(req, res, next) {
  *
  * GET /accounts/types
  */
-function list(req, res, next) {
+async function list(req, res) {
   const sql = 'SELECT `id`, `type`, `translation_key` FROM account_type;';
 
-  db.exec(sql)
-    .then((rows) => {
-      res.status(200).json(rows);
-    })
-    .catch(next);
-
+  const rows = await db.exec(sql);
+  res.status(200).json(rows);
 }
 
 /**
@@ -61,7 +53,7 @@ function list(req, res, next) {
  *
  * POST /accounts/types
  */
-function create(req, res, next) {
+async function create(req, res) {
   const record = req.body;
   const sql = 'INSERT INTO account_type SET ?';
 
@@ -74,12 +66,8 @@ function create(req, res, next) {
    */
   record.translation_key = '';
 
-  db.exec(sql, [record])
-    .then((result) => {
-      res.status(201).json({ id : result.insertId });
-    })
-    .catch(next);
-
+  const result = await db.exec(sql, [record]);
+  res.status(201).json({ id : result.insertId });
 }
 
 /**
@@ -90,21 +78,17 @@ function create(req, res, next) {
  *
  * PUT /accounts/types/:id
  */
-function update(req, res, next) {
+async function update(req, res) {
   const data = req.body;
   const { id } = req.params;
   const sql = 'UPDATE account_type SET ? WHERE id = ?';
 
   delete data.id;
 
-  lookupAccountType(id)
-    .then(() => db.exec(sql, [data, id]))
-    .then(() => lookupAccountType(id))
-    .then((accountType) => {
-      res.status(200).json(accountType);
-    })
-    .catch(next);
-
+  await lookupAccountType(id);
+  await db.exec(sql, [data, id]);
+  const accountType = await lookupAccountType(id);
+  res.status(200).json(accountType);
 }
 
 /**
@@ -115,19 +99,13 @@ function update(req, res, next) {
  *
  * DELETE /accounts/types/:id
  */
-function remove(req, res, next) {
+async function remove(req, res) {
   const { id } = req.params;
   const sql = 'DELETE FROM account_type WHERE id = ?';
 
-  lookupAccountType(id)
-    .then(() => {
-      return db.exec(sql, [id]);
-    })
-    .then(() => {
-      res.sendStatus(204);
-    })
-    .catch(next);
-
+  await lookupAccountType(id);
+  await db.exec(sql, [id]);
+  res.sendStatus(204);
 }
 
 /**

--- a/server/controllers/finance/allocationCostCenter/breakDown.js
+++ b/server/controllers/finance/allocationCostCenter/breakDown.js
@@ -1,48 +1,47 @@
 /**
-  *Distribution Cost Center Controller
-  *This function allows you to make the distributions of
-  *one or more transactions at the same time while specifying the percentage distribution rate
+ *Distribution Cost Center Controller
+ *This function allows you to make the distributions of
+ *one or more transactions at the same time while specifying the percentage distribution rate
 */
 const db = require('../../../lib/db');
 
-async function breakDown(req, res, next) {
-  try {
-    const { data } = req.body;
+async function breakDown(req, res) {
+  const { data } = req.body;
 
-    const isCost = data.is_cost;
-    const dataValues = data.values;
+  const isCost = data.is_cost;
+  const dataValues = data.values;
 
-    const dataToDistribute = [];
-    const userId = req.session.user.id;
+  const dataToDistribute = [];
+  const userId = req.session.user.id;
 
-    data.transactions.forEach((transaction) => {
-      Object.keys(dataValues).forEach((principalCenterId) => {
-        const percentageValue = dataValues[principalCenterId];
+  data.transactions.forEach((transaction) => {
+    Object.keys(dataValues).forEach((principalCenterId) => {
+      const percentageValue = dataValues[principalCenterId];
 
-        if (percentageValue) {
-          const debitValuePercent = transaction.debit_equiv * (percentageValue / 100);
-          const creditValuePercent = transaction.credit_equiv * (percentageValue / 100);
-          if (debitValuePercent > 0 || creditValuePercent > 0) {
-            dataToDistribute.push([
-              db.bid(transaction.uuid),
-              transaction.trans_id,
-              transaction.account_id,
-              isCost,
-              transaction.is_variable,
-              transaction.is_turnover,
-              transaction.cost_center_id,
-              principalCenterId,
-              debitValuePercent,
-              creditValuePercent,
-              new Date(),
-              userId,
-            ]);
-          }
+      if (percentageValue) {
+        const debitValuePercent = transaction.debit_equiv * (percentageValue / 100);
+        const creditValuePercent = transaction.credit_equiv * (percentageValue / 100);
+        if (debitValuePercent > 0 || creditValuePercent > 0) {
+          dataToDistribute.push([
+            db.bid(transaction.uuid),
+            transaction.trans_id,
+            transaction.account_id,
+            isCost,
+            transaction.is_variable,
+            transaction.is_turnover,
+            transaction.cost_center_id,
+            principalCenterId,
+            debitValuePercent,
+            creditValuePercent,
+            new Date(),
+            userId,
+          ]);
         }
-      });
+      }
     });
+  });
 
-    const sql = `INSERT INTO cost_center_allocation (
+  const sql = `INSERT INTO cost_center_allocation (
       row_uuid,
       trans_id,
       account_id,
@@ -55,15 +54,11 @@ async function breakDown(req, res, next) {
       credit_equiv,
       date_distribution, user_id) VALUES ?`;
 
-    if (dataToDistribute.length) {
-      await db.exec(sql, [dataToDistribute]);
-    }
-
-    res.sendStatus(201);
-  } catch (err) {
-    next(err);
+  if (dataToDistribute.length) {
+    await db.exec(sql, [dataToDistribute]);
   }
 
+  res.sendStatus(201);
 }
 
 exports.breakDown = breakDown;

--- a/server/controllers/finance/allocationCostCenter/configuration.js
+++ b/server/controllers/finance/allocationCostCenter/configuration.js
@@ -9,70 +9,66 @@ const referenceAccount = require('./referenceAccount');
 const generalLedger = require('../generalLedger');
 const fiscal = require('../fiscal');
 
-async function configuration(req, res, next) {
-  try {
-    const { query } = req;
-    const params = {
-      typeCostCenter : query.typeCostCenter,
-      cost_center_id : query.cost_center_id,
+async function configuration(req, res) {
+  const { query } = req;
+  const params = {
+    typeCostCenter : query.typeCostCenter,
+    cost_center_id : query.cost_center_id,
+  };
+
+  const accounts = await referenceAccount.auxilliary(params);
+
+  const refAccounts = accounts;
+  const accountsId = accounts.map(account => account.account_id);
+
+  if (accountsId.length === 0) {
+    res.status(200).json([]);
+    return;
+  }
+
+  const options = {
+    accounts_id : accountsId,
+    excludes_distributed : true,
+    account_id : query.account_id,
+    trans_id : query.trans_id,
+    hrRecord : query.hrRecord,
+    limit : 100,
+  };
+
+  // get max and min date from period ids.
+  if (query.periodFrom && query.periodTo) {
+    const periods = {
+      periodFrom : query.periodFrom,
+      periodTo : query.periodTo,
     };
 
-    const accounts = await referenceAccount.auxilliary(params);
+    const result = await fiscal.getDateRangeFromPeriods(periods);
+    options.custom_period_start = result.dateFrom;
+    options.custom_period_end = result.dateTo;
+  }
 
-    const refAccounts = accounts;
-    const accountsId = accounts.map(account => account.account_id);
+  if (query.cost_center_id || query.trans_id) {
+    delete options.limit;
+  }
 
-    if (accountsId.length === 0) {
-      res.status(200).json([]);
-      return;
-    }
+  const rows = await generalLedger.findTransactions(options);
 
-    const options = {
-      accounts_id : accountsId,
-      excludes_distributed : true,
-      account_id : query.account_id,
-      trans_id : query.trans_id,
-      hrRecord : query.hrRecord,
-      limit : 100,
-    };
-
-    // get max and min date from period ids.
-    if (query.periodFrom && query.periodTo) {
-      const periods = {
-        periodFrom : query.periodFrom,
-        periodTo : query.periodTo,
-      };
-
-      const result = await fiscal.getDateRangeFromPeriods(periods);
-      options.custom_period_start = result.dateFrom;
-      options.custom_period_end = result.dateTo;
-    }
-
-    if (query.cost_center_id || query.trans_id) {
-      delete options.limit;
-    }
-
-    const rows = await generalLedger.findTransactions(options);
-
-    rows.forEach(item => {
-      refAccounts.forEach(ref => {
-        if (ref.account_id === item.account_id) {
-          item.cost_center_id = ref.id;
-          item.cost_center_label = ref.label;
-          item.is_variable = ref.is_variable;
-          item.is_turnover = ref.is_turnover;
-          item.is_cost = ref.is_cost;
-        }
-      });
-
-      item.amount = item.credit ? item.credit : item.debit;
-      item.amount_equiv = item.credit_equiv ? item.credit_equiv : item.debit_equiv;
+  rows.forEach(item => {
+    refAccounts.forEach(ref => {
+      if (ref.account_id === item.account_id) {
+        item.cost_center_id = ref.id;
+        item.cost_center_label = ref.label;
+        item.is_variable = ref.is_variable;
+        item.is_turnover = ref.is_turnover;
+        item.is_cost = ref.is_cost;
+      }
     });
 
-    res.status(200).json(rows);
-  } catch (error) {
-    next(error);
-  }
+    item.amount = item.credit ? item.credit : item.debit;
+    item.amount_equiv = item.credit_equiv ? item.credit_equiv : item.debit_equiv;
+  });
+
+  res.status(200).json(rows);
 
 }
 

--- a/server/controllers/finance/allocationCostCenter/getDistributionKey.js
+++ b/server/controllers/finance/allocationCostCenter/getDistributionKey.js
@@ -6,7 +6,7 @@
 */
 const db = require('../../../lib/db');
 
-function getDistributionKey(req, res, next) {
+async function getDistributionKey(req, res) {
   const sql = `
     SELECT k.auxiliary_cost_center_id, fca.label AS auxiliary_label, k.principal_cost_center_id,
     fcp.label AS principal_label, k.rate, k.user_id, u.display_name AS user_name
@@ -21,11 +21,8 @@ function getDistributionKey(req, res, next) {
     WHERE f.is_principal = 0 AND f.id NOT IN (SELECT k.auxiliary_cost_center_id FROM allocation_key AS k)
   `;
 
-  db.exec(sql)
-    .then((rows) => {
-      res.status(200).json(rows);
-    })
-    .catch(next);
+  const rows = await db.exec(sql);
+  res.status(200).json(rows);
 }
 
 function allDistributionKey() {

--- a/server/controllers/finance/allocationCostCenter/proceed.js
+++ b/server/controllers/finance/allocationCostCenter/proceed.js
@@ -7,7 +7,7 @@
 const db = require('../../../lib/db');
 const { BadRequest } = require('../../../lib/errors');
 
-function proceed(req, res, next) {
+async function proceed(req, res) {
   const { data } = req.body;
 
   const isDebtor = data.debit_equiv > 0;
@@ -64,12 +64,8 @@ function proceed(req, res, next) {
     throw new BadRequest('ERRORS.ER_EMPTY_QUERY');
   }
 
-  transaction.execute()
-    .then((results) => {
-      res.status(201).json({ id : results[1].insertId });
-    })
-    .catch(next);
-
+  const results = await transaction.execute();
+  res.status(201).json({ id : results[1].insertId });
 }
 
 exports.proceed = proceed;

--- a/server/controllers/finance/allocationCostCenter/setting.js
+++ b/server/controllers/finance/allocationCostCenter/setting.js
@@ -6,7 +6,7 @@
 
 const db = require('../../../lib/db');
 
-function setting(req, res, next) {
+async function setting(req, res) {
   const { data } = req.body;
 
   const dataValues = data.values;
@@ -44,23 +44,17 @@ function setting(req, res, next) {
       .addQuery(sql, [allocationKey]);
   }
 
-  transaction.execute()
-    .then((results) => {
-      res.status(201).json({ id : results[1].insertId });
-    })
-    .catch(next);
-
+  const results = await transaction.execute();
+  res.status(201).json({ id : results[1].insertId });
 }
 
-function resetKey(req, res, next) {
+async function resetKey(req, res) {
   const { data } = req.body;
 
   const delDistribution = `DELETE FROM allocation_key WHERE auxiliary_cost_center_id = ?`;
 
-  db.exec(delDistribution, [data])
-    .then(() => res.sendStatus(204))
-    .catch(next);
-
+  await db.exec(delDistribution, [data]);
+  res.sendStatus(204);
 }
 
 exports.setting = setting;

--- a/server/controllers/finance/budget/index.js
+++ b/server/controllers/finance/budget/index.js
@@ -1089,7 +1089,7 @@ async function fillBudget(req, res) {
   await Promise.all(budgetData.map(b => {
     const acct = b.id;
     const totalBudget = b.budget;
-    return rebalanceBudget(fiscalYearId, acct, totalBudget, false);
+    return rebalanceBudget(fiscalYearId, acct, totalBudget);
   }));
 
   res.sendStatus(200);

--- a/server/controllers/finance/configurationAnalysisTools.js
+++ b/server/controllers/finance/configurationAnalysisTools.js
@@ -18,7 +18,7 @@ function configurationAnalysisTools(id) {
 }
 
 // List
-function list(req, res, next) {
+async function list(req, res) {
   const sql = `
     SELECT at.id, at.label, at.account_reference_id,
     ar.abbr, at.analysis_tool_type_id, tp.label AS typeLabel
@@ -28,27 +28,19 @@ function list(req, res, next) {
     ORDER BY at.label ASC;
   `;
 
-  db.exec(sql)
-    .then((rows) => {
-      res.status(200).json(rows);
-    })
-    .catch(next);
-
+  const rows = await db.exec(sql);
+  res.status(200).json(rows);
 }
 
 // toolsType
-function toolsType(req, res, next) {
+async function toolsType(req, res) {
   const sql = `
     SELECT id, label
     FROM analysis_tool_type;
   `;
 
-  db.exec(sql)
-    .then((rows) => {
-      res.status(200).json(rows);
-    })
-    .catch(next);
-
+  const rows = await db.exec(sql);
+  res.status(200).json(rows);
 }
 
 /**
@@ -56,61 +48,43 @@ function toolsType(req, res, next) {
 *
 * Returns the detail of a single configuration_analysis_tools
 */
-function detail(req, res, next) {
+async function detail(req, res) {
   const { id } = req.params;
 
-  configurationAnalysisTools(id)
-    .then((record) => {
-      res.status(200).json(record);
-    })
-    .catch(next);
-
+  const record = await configurationAnalysisTools(id);
+  res.status(200).json(record);
 }
 
 // POST /configuration_analysis_tools
-function create(req, res, next) {
+async function create(req, res) {
   const sql = `INSERT INTO configuration_analysis_tools SET ?`;
   const data = req.body;
 
-  db.exec(sql, [data])
-    .then((row) => {
-      res.status(201).json({ id : row.insertId });
-    })
-    .catch(next);
-
+  const row = await db.exec(sql, [data]);
+  res.status(201).json({ id : row.insertId });
 }
 
 // PUT /configuration_analysis_tools /:id
-function update(req, res, next) {
+async function update(req, res) {
   const sql = `UPDATE configuration_analysis_tools SET ? WHERE id = ?;`;
 
-  db.exec(sql, [req.body, req.params.id])
-    .then(() => {
-      return configurationAnalysisTools(req.params.id);
-    })
-    .then((record) => {
-    // all updates completed successfull, return full object to client
-      res.status(200).json(record);
-    })
-    .catch(next);
-
+  await db.exec(sql, [req.body, req.params.id]);
+  const record = await configurationAnalysisTools(req.params.id);
+  // all updates completed successfull, return full object to client
+  res.status(200).json(record);
 }
 
 // DELETE /configuration_analysis_tools/:id
-function remove(req, res, next) {
+async function remove(req, res) {
   const sql = `DELETE FROM configuration_analysis_tools WHERE id = ?;`;
 
-  db.exec(sql, [req.params.id])
-    .then((row) => {
-    // if nothing happened, let the client know via a 404 error
-      if (row.affectedRows === 0) {
-        throw new NotFound(`Could not find a function with id ${req.params.id}`);
-      }
+  const row = await db.exec(sql, [req.params.id]);
+  // if nothing happened, let the client know via a 404 error
+  if (row.affectedRows === 0) {
+    throw new NotFound(`Could not find a function with id ${req.params.id}`);
+  }
 
-      res.status(204).json();
-    })
-    .catch(next);
-
+  res.status(204).json();
 }
 
 // get list of configurationAnalysisTools

--- a/server/controllers/finance/currencies.js
+++ b/server/controllers/finance/currencies.js
@@ -24,7 +24,7 @@ function lookupCurrencyById(id) {
 }
 
 /** list currencies in the database */
-exports.list = function list(req, res, next) {
+exports.list = async function list(req, res) {
   const sql = `
     SELECT currency.id, currency.name, currency.note, currency.format_key,
       currency.symbol, currency.min_monentary_unit, latest_rate.date
@@ -32,22 +32,14 @@ exports.list = function list(req, res, next) {
     ON currency.id = latest_rate.currency_id group by currency.id;
   `;
 
-  db.exec(sql)
-    .then(rows => {
-      res.status(200).json(rows);
-    })
-    .catch(next);
-
+  const rows = await db.exec(sql);
+  res.status(200).json(rows);
 };
 
 /** get the details of a single currency */
-exports.detail = function detail(req, res, next) {
-  lookupCurrencyById(req.params.id)
-    .then(row => {
-      res.status(200).json(row);
-    })
-    .catch(next);
-
+exports.detail = async function detail(req, res) {
+  const row = await lookupCurrencyById(req.params.id);
+  res.status(200).json(row);
 };
 
 /** get currencies information related to exchange rate */

--- a/server/controllers/finance/debtors/index.js
+++ b/server/controllers/finance/debtors/index.js
@@ -15,7 +15,6 @@
 * @requires lib/errors/NotFound
 */
 
-const _ = require('lodash');
 const db = require('../../../lib/db');
 const NotFound = require('../../../lib/errors/NotFound');
 const FilterParser = require('../../../lib/filter');
@@ -77,7 +76,7 @@ async function update(req, res, next) {
   const previousGroupSql = 'SELECT BUID(group_uuid) as group_uuid  FROM debtor WHERE uuid=?';
   const historicSQL = `INSERT INTO debtor_group_history SET ?`;
   const { user } = req.session;
-  const data = _.clone(req.body);
+  const data = structuredClone(req.body);
 
   // delete the uuid if it exists
   delete data.uuid;

--- a/server/controllers/finance/discounts.js
+++ b/server/controllers/finance/discounts.js
@@ -5,9 +5,9 @@
  * @module finance/discounts
  *
  * @requires lib/db
+ * @requires lib/errors/BadRequest
  */
 
-const NotFound = require('../../lib/errors/NotFound');
 const BadRequest = require('../../lib/errors/BadRequest');
 const db = require('../../lib/db');
 
@@ -25,16 +25,7 @@ function lookupDiscount(id) {
     JOIN account AS a ON d.account_id = a.id
     WHERE d.id = ?;`;
 
-  return db.exec(sql, [id])
-    .then((rows) => {
-    // if no matches in the database, throw a 404
-      if (rows.length === 0) {
-        throw new NotFound(`Could not find a discount with id ${id}`);
-      }
-
-      // return a single record
-      return rows[0];
-    });
+  return db.one(sql, [id]);
 }
 
 /**
@@ -43,13 +34,9 @@ function lookupDiscount(id) {
  * @desc Queries the database to a discount matching the param :id.  Expected
  * to respond with either HTTP status 404 or 200.
  */
-exports.detail = function detail(req, res, next) {
-  lookupDiscount(req.params.id)
-    .then((discount) => {
-      res.status(200).json(discount);
-    })
-    .catch(next);
-
+exports.detail = async function detail(req, res) {
+  const discount = await lookupDiscount(req.params.id);
+  res.status(200).json(discount);
 };
 
 /**
@@ -58,15 +45,10 @@ exports.detail = function detail(req, res, next) {
  * @desc Queries the database to list all discounts recorded in the database.
  * Returns HTTP status code 200 with an array containing zero or more records.
  */
-exports.list = function list(req, res, next) {
+exports.list = async function list(req, res) {
   const sql = 'SELECT d.id, d.label, d.value FROM discount AS d;';
-
-  db.exec(sql)
-    .then((rows) => {
-      res.status(200).json(rows);
-    })
-    .catch(next);
-
+  const rows = await db.exec(sql);
+  res.status(200).json(rows);
 };
 
 /**
@@ -75,24 +57,19 @@ exports.list = function list(req, res, next) {
  * @desc Inserts a single discount record into the database.  If the record
  * is properly inserted, it returns a 201 CREATED status and the generated id.
  */
-exports.create = function create(req, res, next) {
+exports.create = async function create(req, res) {
   // expects the proposed record to be namespaced by "discount"
   const data = db.convert(req.body.discount, ['inventory_uuid']);
 
   if (data.value < 0) {
-    next(new BadRequest(`${data.value} must to be positive, but received a negative value.`, `ERRORS.NEGATIVE_VALUE`));
-    return;
+    throw new BadRequest(`${data.value} must to be positive, but received a negative value.`, `ERRORS.NEGATIVE_VALUE`);
   }
 
   const sql = 'INSERT INTO discount SET ?;';
 
   // attempt to insert the record
-  db.exec(sql, [data])
-    .then((result) => {
-      res.status(201).json({ id : result.insertId });
-    })
-    .catch(next);
-
+  const result = await db.exec(sql, [data]);
+  res.status(201).json({ id : result.insertId });
 };
 
 /**
@@ -102,7 +79,7 @@ exports.create = function create(req, res, next) {
  * not exist, this endpoint returns a 404 error.  If the record does exist and
  * is sucessfully updated, we return the fully changed record (status 200).
  */
-exports.update = function update(req, res, next) {
+exports.update = async function update(req, res) {
   // no namespace necessary for updates -- allows middleware to catch empty
   // req.body's
   const data = db.convert(req.body, ['inventory_uuid']);
@@ -123,14 +100,10 @@ exports.update = function update(req, res, next) {
   const sql = 'UPDATE discount SET ? WHERE id = ?;';
 
   // ensure the record exists by looking it up first
-  lookupDiscount(id)
-    .then(() => db.exec(sql, [data, id]))
-    .then(() => lookupDiscount(id))
-    .then((discount) => {
-      res.status(200).json(discount);
-    })
-    .catch(next);
-
+  await lookupDiscount(id);
+  await db.exec(sql, [data, id]);
+  const discount = await lookupDiscount(id);
+  res.status(200).json(discount);
 };
 
 /**
@@ -140,15 +113,13 @@ exports.update = function update(req, res, next) {
  * the record does not exist, returns a 404 error.  Otherwise, it will return
  * a 204 NO CONTENT for a successfully deleted record.
  */
-exports.delete = function del(req, res, next) {
+exports.delete = async function del(req, res) {
   const { id } = req.params;
   const sql = 'DELETE FROM discount WHERE id = ?;';
 
   // make sure the record actually exists
   // TODO(@jniles): migrate to db.one()
-  lookupDiscount(id)
-    .then(() => db.exec(sql, [id]))
-    .then(() => res.sendStatus(204))
-    .catch(next);
-
+  await lookupDiscount(id);
+  await db.exec(sql, [id]);
+  res.sendStatus(204);
 };

--- a/server/controllers/finance/generalLedger/index.js
+++ b/server/controllers/finance/generalLedger/index.js
@@ -8,10 +8,8 @@
  * of a giant matrix of the balances of each account for each period in a fiscal
  * year.  The fiscal year must be provided by the client.
  *
- * @requires lodash
  * @requires lib/db
  * @requires FilterParser
- * @requires lib/util
  */
 
 // module dependencies
@@ -55,14 +53,11 @@ function findTransactions(options) {
  * @function getTransactions
  * @description returns general ledger transactions
  */
-function getTransactions(req, res, next) {
+async function getTransactions(req, res) {
   const options = req.query;
 
-  findTransactions(options)
-    .then(rows => {
-      res.status(200).json(rows);
-    })
-    .catch(next);
+  const rows = await findTransactions(options);
+  res.status(200).json(rows);
 }
 
 /**
@@ -73,15 +68,11 @@ function getTransactions(req, res, next) {
  *
  * GET /general_ledger/
  */
-function list(req, res, next) {
+async function list(req, res) {
   const fiscalYearId = req.query.fiscal_year_id;
 
-  getAccountTotalsMatrix(fiscalYearId)
-    .then((rows) => {
-      res.status(200).json(rows);
-    })
-    .catch(next);
-
+  const rows = await getAccountTotalsMatrix(fiscalYearId);
+  res.status(200).json(rows);
 }
 
 /**
@@ -92,15 +83,11 @@ function list(req, res, next) {
  *
  *
  */
-function getAggregates(req, res, next) {
+async function getAggregates(req, res) {
   const fiscalYearId = req.query.fiscal_year_id;
 
-  getAccountTotalsMatrixAggregates(fiscalYearId)
-    .then((rows) => {
-      res.status(200).json(rows);
-    })
-    .catch(next);
-
+  const rows = await getAccountTotalsMatrixAggregates(fiscalYearId);
+  res.status(200).json(rows);
 }
 
 /**

--- a/server/controllers/finance/indicator/dashboard/index.js
+++ b/server/controllers/finance/indicator/dashboard/index.js
@@ -5,13 +5,10 @@ const moment = require('moment');
 const process = require('./process');
 
 exports.getIndicators = getIndicators;
-function getIndicators(req, res, next) {
+async function getIndicators(req, res) {
   const options = req.query;
-  lookupIndicators(options)
-    .then(rows => {
-      res.status(200).json(rows);
-    })
-    .catch(next);
+  const rows = await lookupIndicators(options);
+  res.status(200).json(rows);
 }
 
 async function lookupIndicators(options) {

--- a/server/controllers/finance/indicator/dashboard/report.js
+++ b/server/controllers/finance/indicator/dashboard/report.js
@@ -28,7 +28,7 @@ exports.report = report;
 function report(req, res, next) {
   let reportInstance;
 
-  const query = _.clone(req.query);
+  const query = structuredClone(req.query);
   const options = req.query;
   const data = { display : {} };
 

--- a/server/controllers/finance/indicator/finances.js
+++ b/server/controllers/finance/indicator/finances.js
@@ -6,7 +6,7 @@ module.exports.update = update;
 module.exports.delete = remove;
 module.exports.detail = detail;
 
-function create(req, res, next) {
+async function create(req, res) {
   const { indicator, finances } = req.body;
   indicator.uuid = indicator.uuid ? db.bid(indicator.uuid) : db.bid(uuid());
   indicator.user_id = req.session.user.id;
@@ -21,12 +21,11 @@ function create(req, res, next) {
   transaction.addQuery(indicatorSql, indicator);
   transaction.addQuery(financesSql, finances);
 
-  transaction.execute().then(() => {
-    res.sendStatus(201);
-  }).catch(next);
+  await transaction.execute();
+  res.sendStatus(201);
 }
 
-function update(req, res, next) {
+async function update(req, res) {
   const { indicator, finances } = req.body;
   db.convert(finances, ['indicator_uuid']);
   const _uuid = db.bid(req.params.uuid);
@@ -40,12 +39,11 @@ function update(req, res, next) {
   transaction.addQuery(indicatorSql, [indicator, _uuid]);
   transaction.addQuery(financesSql, [finances, _uuid]);
 
-  transaction.execute().then(() => {
-    res.sendStatus(200);
-  }).catch(next);
+  await transaction.execute();
+  res.sendStatus(200);
 }
 
-function remove(req, res, next) {
+async function remove(req, res) {
   const _uuid = db.bid(req.params.uuid);
 
   const indicatorSql = `
@@ -58,12 +56,11 @@ function remove(req, res, next) {
   transaction.addQuery(financesSql, _uuid);
   transaction.addQuery(indicatorSql, _uuid);
 
-  transaction.execute().then(() => {
-    res.sendStatus(200);
-  }).catch(next);
+  await transaction.execute();
+  res.sendStatus(200);
 }
 
-async function detail(req, res, next) {
+async function detail(req, res) {
   const _uuid = db.bid(req.params.uuid);
 
   const query = `
@@ -80,11 +77,6 @@ async function detail(req, res, next) {
     WHERE i.uuid = ?
   `;
 
-  try {
-    const rows = await db.one(query, _uuid);
-    res.status(200).json(rows);
-
-  } catch (error) {
-    next(error);
-  }
+  const rows = await db.one(query, _uuid);
+  res.status(200).json(rows);
 }

--- a/server/controllers/finance/indicator/index.js
+++ b/server/controllers/finance/indicator/index.js
@@ -52,9 +52,7 @@ function find(options) {
 }
 
 // Indicator Variables Registry
-function read(req, res, next) {
-  find(req.query)
-    .then(indicators => {
-      res.status(200).json(indicators);
-    }).catch(next);
+async function read(req, res) {
+  const indicators = await find(req.query);
+  res.status(200).json(indicators);
 }

--- a/server/controllers/finance/indicator/personel.js
+++ b/server/controllers/finance/indicator/personel.js
@@ -6,7 +6,7 @@ module.exports.update = update;
 module.exports.delete = remove;
 module.exports.detail = detail;
 
-function create(req, res, next) {
+async function create(req, res) {
   const { indicator, personel } = req.body;
   indicator.uuid = indicator.uuid ? db.bid(indicator.uuid) : db.bid(uuid());
   indicator.user_id = req.session.user.id;
@@ -21,12 +21,11 @@ function create(req, res, next) {
   transaction.addQuery(indicatorSql, indicator);
   transaction.addQuery(personelSql, personel);
 
-  transaction.execute().then(() => {
-    res.sendStatus(201);
-  }).catch(next);
+  transaction.execute();
+  res.sendStatus(201);
 }
 
-function update(req, res, next) {
+async function update(req, res) {
   const { indicator, personel } = req.body;
   db.convert(personel, ['indicator_uuid']);
   const _uuid = db.bid(req.params.uuid);
@@ -40,12 +39,11 @@ function update(req, res, next) {
   transaction.addQuery(indicatorSql, [indicator, _uuid]);
   transaction.addQuery(personelSql, [personel, _uuid]);
 
-  transaction.execute().then(() => {
-    res.sendStatus(200);
-  }).catch(next);
+  transaction.execute();
+  res.sendStatus(200);
 }
 
-function remove(req, res, next) {
+async function remove(req, res) {
   const _uuid = db.bid(req.params.uuid);
 
   const indicatorSql = `
@@ -58,12 +56,11 @@ function remove(req, res, next) {
   transaction.addQuery(personelSql, _uuid);
   transaction.addQuery(indicatorSql, _uuid);
 
-  transaction.execute().then(() => {
-    res.sendStatus(200);
-  }).catch(next);
+  await transaction.execute();
+  res.sendStatus(200);
 }
 
-async function detail(req, res, next) {
+async function detail(req, res) {
   const _uuid = db.bid(req.params.uuid);
 
   const query = `
@@ -79,12 +76,6 @@ async function detail(req, res, next) {
     WHERE i.uuid = ?
   `;
 
-  try {
-    const rows = await db.one(query, _uuid);
-    res.status(200).json(rows);
-
-  } catch (error) {
-    next(error);
-  }
-
+  const rows = await db.one(query, _uuid);
+  res.status(200).json(rows);
 }

--- a/server/controllers/finance/indicator/status.js
+++ b/server/controllers/finance/indicator/status.js
@@ -2,9 +2,8 @@ const db = require('../../../lib/db');
 
 exports.list = list;
 
-function list(req, res, next) {
+async function list(req, res) {
   const sql = `SELECT id, text, translate_key FROM indicator_status`;
-  db.exec(sql).then((rows) => {
-    res.status(200).json(rows);
-  }).catch(next);
+  const rows = await db.exec(sql);
+  res.status(200).json(rows);
 }

--- a/server/controllers/finance/indicator/types.js
+++ b/server/controllers/finance/indicator/types.js
@@ -2,9 +2,8 @@ const db = require('../../../lib/db');
 
 exports.list = list;
 
-function list(req, res, next) {
+async function list(req, res) {
   const sql = `SELECT id, text, translate_key FROM indicator_type`;
-  db.exec(sql).then((rows) => {
-    res.status(200).json(rows);
-  }).catch(next);
+  const rows = await db.exec(sql);
+  res.status(200).json(rows);
 }

--- a/server/controllers/finance/period.js
+++ b/server/controllers/finance/period.js
@@ -6,7 +6,7 @@ exports.list = list;
 exports.details = details;
 exports.lookupPeriodById = lookupPeriodById;
 
-function list(req, res, next) {
+async function list(req, res) {
   const params = req.query;
   const filters = new FilterParser(params, { tableAlias : 'p' });
   const query = `
@@ -25,11 +25,8 @@ function list(req, res, next) {
     parameters : filters.parameters(),
   };
 
-  db.exec(sql.query, sql.parameters)
-    .then(periods => {
-      res.status(200).json(periods);
-    })
-    .catch(next);
+  const periods = await db.exec(sql.query, sql.parameters);
+  res.status(200).json(periods);
 }
 
 function lookupPeriodById(id) {
@@ -41,11 +38,8 @@ function lookupPeriodById(id) {
   return db.one(query, [id]);
 }
 
-function details(req, res, next) {
+async function details(req, res) {
   const { id } = req.params;
-  lookupPeriodById(id)
-    .then(period => {
-      res.status(200).json(period);
-    })
-    .catch(next);
+  const period = await lookupPeriodById(id);
+  res.status(200).json(period);
 }

--- a/server/controllers/finance/priceLists/index.js
+++ b/server/controllers/finance/priceLists/index.js
@@ -25,13 +25,9 @@ exports.lookup = lookup;
  *
  * GET /prices
  */
-exports.list = function list(req, res, next) {
-  lookup(req)
-    .then((rows) => {
-      res.status(200).json(rows);
-    })
-    .catch(next);
-
+exports.list = async function list(req, res) {
+  const rows = await lookup(req);
+  res.status(200).json(rows);
 };
 
 function lookup(req) {
@@ -101,15 +97,11 @@ function lookupPriceList(uid) {
  *
  * GET /prices/:uuid
  */
-exports.details = function details(req, res, next) {
+exports.details = async function details(req, res) {
   const uid = db.bid(req.params.uuid);
 
-  lookupPriceList(uid)
-    .then((priceList) => {
-      res.status(200).json(priceList);
-    })
-    .catch(next);
-
+  const priceList = await lookupPriceList(uid);
+  res.status(200).json(priceList);
 };
 
 /**
@@ -177,7 +169,7 @@ function formatPriceListItems(priceListUuid, items) {
  *
  * POST /prices
  */
-exports.create = function create(req, res, next) {
+exports.create = async function create(req, res) {
   let items;
   const data = req.body.list;
   const trans = db.transaction();
@@ -208,26 +200,20 @@ exports.create = function create(req, res, next) {
   // only enqueue the price list items if they exist
   if (items) { trans.addQuery(priceListItemSql, [items]); }
 
-  trans.execute()
-    .then(() => {
-      // respond to the client with a 201 CREATED
-      res.status(201).json({ uuid : priceListUuid });
-    })
-    .catch(next);
-
+  await trans.execute();
+  // respond to the client with a 201 CREATED
+  res.status(201).json({ uuid : priceListUuid });
 };
 
 // add a new price list item
-exports.createItem = function createItem(req, res, next) {
+exports.createItem = async function createItem(req, res) {
   const priceListCreateItemSql = `INSERT INTO price_list_item  SET ?`;
   const data = req.body;
   db.convert(data, ['inventory_uuid', 'price_list_uuid']);
   data.uuid = data.uuid ? db.bid(data.uuid) : db.uuid();
 
-  db.exec(priceListCreateItemSql, data).then(() => {
-    res.sendStatus(201);
-  }).catch(next);
-
+  await db.exec(priceListCreateItemSql, data);
+  res.sendStatus(201);
 };
 
 /**
@@ -237,35 +223,31 @@ exports.createItem = function createItem(req, res, next) {
  * Dumps the items that are for sale to a CSV file for the user to fill out and
  * later import via the import route.
  */
-exports.downloadFilledTemplate = async (req, res, next) => {
-  try {
-    const reportOptions = {
-      csvKey : 'rows',
-      suppressDefaultFormatting : true,
-      suppressDefaultFiltering : true,
-    };
+exports.downloadFilledTemplate = async (req, res) => {
+  const reportOptions = {
+    csvKey : 'rows',
+    suppressDefaultFormatting : true,
+    suppressDefaultFiltering : true,
+  };
 
-    // currency symbol is included in the import so the user knows
-    // the valuation of the currency
-    const { currencySymbol } = req.session.enterprise;
+  // currency symbol is included in the import so the user knows
+  // the valuation of the currency
+  const { currencySymbol } = req.session.enterprise;
 
-    const options = { ...req.query, ...reportOptions, filename : 'PRICE_LIST.NEW_PRICE_LIST' };
+  const options = { ...req.query, ...reportOptions, filename : 'PRICE_LIST.NEW_PRICE_LIST' };
 
-    const report = new ReportManager('', req.session, options);
-    const sql = 'SELECT BUID(uuid) as uuid, code, text, price FROM inventory WHERE sellable = 1 ORDER BY text, code';
-    const rows = await db.exec(sql);
-    const data = rows.map(row => {
-      row.previous_price = row.price;
-      row.price = '';
-      row.currency = currencySymbol;
-      return row;
-    });
+  const report = new ReportManager('', req.session, options);
+  const sql = 'SELECT BUID(uuid) as uuid, code, text, price FROM inventory WHERE sellable = 1 ORDER BY text, code';
+  const rows = await db.exec(sql);
+  const data = rows.map(row => {
+    row.previous_price = row.price;
+    row.price = '';
+    row.currency = currencySymbol;
+    return row;
+  });
 
-    const result = await report.render({ rows : data }, null, { csvKey : 'rows' });
-    res.set(csv.headers).send(result.report);
-  } catch (err) {
-    next(err);
-  }
+  const result = await report.render({ rows : data }, null, { csvKey : 'rows' });
+  res.set(csv.headers).send(result.report);
 };
 
 /**
@@ -276,46 +258,41 @@ exports.downloadFilledTemplate = async (req, res, next) => {
  * The CSV file must have uuids for each inventory item, the label of the item,
  * and the accompanying price in a column labeled "price".
  */
-exports.importItems = async (req, res, next) => {
-  try {
-    if (!req.files || req.files.length === 0) {
-      const errorDescription = 'Expected at least one file upload but did not receive any files.';
-      throw new BadRequest(errorDescription, 'ERRORS.MISSING_UPLOAD_FILES');
-    }
+exports.importItems = async (req, res) => {
+  if (!req.files || req.files.length === 0) {
+    const errorDescription = 'Expected at least one file upload but did not receive any files.';
+    throw new BadRequest(errorDescription, 'ERRORS.MISSING_UPLOAD_FILES');
+  }
 
-    db.convert(req.body, ['pricelist_uuid']);
+  db.convert(req.body, ['pricelist_uuid']);
 
-    const filePath = req.files[0].path;
+  const filePath = req.files[0].path;
 
-    const data = removeEmptyLines(await util.formatCsvToJson(filePath));
+  const data = removeEmptyLines(await util.formatCsvToJson(filePath));
 
-    if (!hasValidDataFormat(data)) {
-      throw new BadRequest('The given file has a bad data format for stock', 'ERRORS.BAD_DATA_FORMAT');
-    }
+  if (!hasValidDataFormat(data)) {
+    throw new BadRequest('The given file has a bad data format for stock', 'ERRORS.BAD_DATA_FORMAT');
+  }
 
-    const priceListUuid = db.bid(req.body.pricelist_uuid);
-    const transaction = db.transaction();
+  const priceListUuid = db.bid(req.body.pricelist_uuid);
+  const transaction = db.transaction();
 
-    transaction
+  transaction
 
     // first, clear all old values from the price list
-      .addQuery('DELETE FROM price_list_item WHERE price_list_uuid = ?', priceListUuid);
+    .addQuery('DELETE FROM price_list_item WHERE price_list_uuid = ?', priceListUuid);
 
-    const sql = `
+  const sql = `
       INSERT INTO price_list_item (uuid, inventory_uuid, price_list_uuid, label, value)
       VALUES (?, ?, ?, ?, ?)
     `;
 
-    data.forEach(row => {
-      transaction.addQuery(sql, [db.uuid(), db.bid(row.uuid), priceListUuid, row.text, row.price]);
-    });
+  data.forEach(row => {
+    transaction.addQuery(sql, [db.uuid(), db.bid(row.uuid), priceListUuid, row.text, row.price]);
+  });
 
-    await transaction.execute();
-    res.sendStatus(200);
-  } catch (ex) {
-    next(ex);
-  }
-
+  await transaction.execute();
+  res.sendStatus(200);
 };
 
 function removeEmptyLines(data) {
@@ -326,15 +303,11 @@ function hasValidDataFormat(data) {
   return data.every(row => (row.uuid && row.price > 0));
 }
 
-exports.deleteItem = async function deleteItem(req, res, next) {
+exports.deleteItem = async function deleteItem(req, res) {
   const priceListDeleteItemSql = `DELETE FROM price_list_item  WHERE uuid = ?`;
-  try {
-    const itemUuid = db.bid(req.params.uuid);
-    await db.exec(priceListDeleteItemSql, itemUuid);
-    res.sendStatus(200);
-  } catch (e) {
-    next(e);
-  }
+  const itemUuid = db.bid(req.params.uuid);
+  await db.exec(priceListDeleteItemSql, itemUuid);
+  res.sendStatus(200);
 };
 
 /**
@@ -342,7 +315,7 @@ exports.deleteItem = async function deleteItem(req, res, next) {
  *
  * PUT /prices/:uuid
  */
-exports.update = function update(req, res, next) {
+exports.update = async function update(req, res) {
   let items;
   const data = req.body.list;
   const priceListSql = 'UPDATE price_list SET ? WHERE uuid = ?;';
@@ -366,34 +339,26 @@ exports.update = function update(req, res, next) {
   delete data.items;
 
   // make sure the price list exists
-  lookupPriceList(uid)
-    .then(() => {
-      // if we get here, it means the price list exists and we can perform an
-      // update query on it. Since we are doing multiple operations at once,
-      // wrap the queries in a DB transaction.
-      if (!isEmptyObject(data)) {
-        trans.addQuery(priceListSql, [data, uid]);
-      }
+  await lookupPriceList(uid);
+  // if we get here, it means the price list exists and we can perform an
+  // update query on it. Since we are doing multiple operations at once,
+  // wrap the queries in a DB transaction.
+  if (!isEmptyObject(data)) {
+    trans.addQuery(priceListSql, [data, uid]);
+  }
 
-      // only trigger price list item updates if the items have been sent back to
-      // the server
+  // only trigger price list item updates if the items have been sent back to
+  // the server
 
-      if (items) {
-        trans.addQuery(priceListDeleteItemSql, [uid]);
-        trans.addQuery(priceListCreateItemSql, [items]);
-      }
+  if (items) {
+    trans.addQuery(priceListDeleteItemSql, [uid]);
+    trans.addQuery(priceListCreateItemSql, [items]);
+  }
 
-      return trans.execute();
-    })
-    .then(() => {
-      // send the full resource object back to the client via lookup function
-      return lookupPriceList(uid);
-    })
-    .then((priceList) => {
-      res.status(200).json(priceList);
-    })
-    .catch(next);
-
+  await trans.execute();
+  // send the full resource object back to the client via lookup function
+  const priceList = await lookupPriceList(uid);
+  res.status(200).json(priceList);
 };
 
 /**
@@ -401,22 +366,16 @@ exports.update = function update(req, res, next) {
  *
  * DELETE /prices/:uuid
  */
-exports.delete = function del(req, res, next) {
+exports.delete = async function del(req, res) {
   const uid = db.bid(req.params.uuid);
 
   const sql = 'DELETE FROM price_list WHERE uuid = ?;';
 
   // ensure that the price list exists
-  lookupPriceList(uid)
-    .then(() => {
-      return db.exec(sql, [uid]);
-    })
-    .then(() => {
-    // respond with 204 'NO CONTENT'
-      res.status(204).json();
-    })
-    .catch(next);
-
+  await lookupPriceList(uid);
+  await db.exec(sql, [uid]);
+  // respond with 204 'NO CONTENT'
+  res.status(204).json();
 };
 
 function isEmptyObject(object) {

--- a/server/controllers/finance/reports/account_reference/index.js
+++ b/server/controllers/finance/reports/account_reference/index.js
@@ -5,13 +5,11 @@
  *
  * @module finance/account_reference
  *
- * @requires lodash
  * @requires lib/db
  * @requires lib/ReportManager
  * @requires lib/errors/BadRequest
  */
 
-const _ = require('lodash');
 const AccountReference = require('../../accounts').references;
 const db = require('../../../../lib/db');
 const ReportManager = require('../../../../lib/ReportManager');
@@ -36,33 +34,27 @@ const DEFAULT_PARAMS = {
  * This function renders the balance of accounts references as report.  The account_reference report provides a view
  * of the balance of account_references for a given period of fiscal year.
  */
-async function report(req, res, next) {
-  const params = req.query;
+async function report(req, res) {
   const context = {};
-  _.defaults(params, DEFAULT_PARAMS);
+  const params = { ...DEFAULT_PARAMS, ...req.query };
 
-  try {
-    const reporting = new ReportManager(TEMPLATE, req.session, params);
+  const reporting = new ReportManager(TEMPLATE, req.session, params);
 
-    const getFiscalYearSQL = `
+  const getFiscalYearSQL = `
     SELECT p.id, p.start_date, p.end_date, p.fiscal_year_id, p.number,
       fy.start_date AS fiscalYearStart, fy.end_date AS fiscalYearEnd
     FROM period p JOIN fiscal_year fy ON p.fiscal_year_id = fy.id
     WHERE p.id = ?;
   `;
 
-    const dbPromises = [
-      db.one(getFiscalYearSQL, [params.period_id]),
-      AccountReference.computeAllAccountReference(params.period_id, params.reference_type_id),
-    ];
+  const [period, data] = await Promise.all([
+    db.one(getFiscalYearSQL, [params.period_id]),
+    AccountReference.computeAllAccountReference(params.period_id, params.reference_type_id),
+  ]);
 
-    const [period, data] = await Promise.all(dbPromises);
-    _.merge(context, { period, data });
-    context.referenceTypeLabel = params.reference_type_id ? params.reference_type_label : '';
+  Object.assign(context, { period, data });
+  context.referenceTypeLabel = params.reference_type_id ? params.reference_type_label : '';
 
-    const result = await reporting.render(context);
-    res.set(result.headers).send(result.report);
-  } catch (err) {
-    next(err);
-  }
+  const result = await reporting.render(context);
+  res.set(result.headers).send(result.report);
 }

--- a/server/controllers/finance/reports/budget/index.js
+++ b/server/controllers/finance/reports/budget/index.js
@@ -29,7 +29,7 @@ function typeName(id) {
   return name;
 }
 
-async function getReport(req, res, next) {
+async function getReport(req, res) {
   const params = req.query;
   const { renderer } = params;
   const fiscalYearId = params.fiscal_year_id;
@@ -40,90 +40,86 @@ async function getReport(req, res, next) {
     orientation : 'landscape',
   });
 
-  try {
-    let data;
+  let data;
 
-    const fiscalYear = await Fiscal.lookupFiscalYear(fiscalYearId);
+  const fiscalYear = await Fiscal.lookupFiscalYear(fiscalYearId);
 
-    const report = new ReportManager(BUDGET_REPORT_TEMPLATE, req.session, optionReport);
+  const report = new ReportManager(BUDGET_REPORT_TEMPLATE, req.session, optionReport);
 
-    const rows = await Budget.buildBudgetData(fiscalYearId);
+  const rows = await Budget.buildBudgetData(fiscalYearId);
 
-    if (renderer === 'pdf') {
-      rows.forEach(row => {
-        row.isTitle = row.type_id === TITLE;
-        row.isIncome = row.type_id === INCOME;
-        row.isExpense = row.type_id === EXPENSE;
-      });
+  if (renderer === 'pdf') {
+    rows.forEach(row => {
+      row.isTitle = row.type_id === TITLE;
+      row.isIncome = row.type_id === INCOME;
+      row.isExpense = row.type_id === EXPENSE;
+    });
 
-      // Split the income and expense related rows
-      const incomeRows = [];
-      const expenseRows = [];
-      let income = true;
-      rows.forEach(row => {
-        if (row.acctType === 'total-income') {
-          income = false;
-        }
-        if ((row.label === '')
+    // Split the income and expense related rows
+    const incomeRows = [];
+    const expenseRows = [];
+    let income = true;
+    rows.forEach(row => {
+      if (row.acctType === 'total-income') {
+        income = false;
+      }
+      if ((row.label === '')
           || (row.acctType === 'total-income')
           || (row.acctType === 'total-expenses')
           || (row.acctType === 'total-summary')) {
-          // skip blank row and summary rows
-        } else if (income) {
-          incomeRows.push(row);
-        } else {
-          expenseRows.push(row);
-        }
-      });
+        // skip blank row and summary rows
+      } else if (income) {
+        incomeRows.push(row);
+      } else {
+        expenseRows.push(row);
+      }
+    });
 
-      const incomeSummaryRow = rows.find(elt => elt.acctType === 'total-income');
-      const expensesSummaryRow = rows.find(elt => elt.acctType === 'total-expenses');
-      const totalSummaryRow = rows.find(acct => acct.acctType === 'total-summary');
+    const incomeSummaryRow = rows.find(elt => elt.acctType === 'total-income');
+    const expensesSummaryRow = rows.find(elt => elt.acctType === 'total-expenses');
+    const totalSummaryRow = rows.find(acct => acct.acctType === 'total-summary');
 
-      data = {
-        incomeRows,
-        expenseRows,
-        incomeSummaryRow,
-        expensesSummaryRow,
-        totalSummaryRow,
-        fiscalYear,
-        title : 'BUDGET.EXPORT.REPORT_TITLE',
-        dateTo : moment().format('YYYY-MM-DD'),
-        filters : formatFilters(params),
-        currencyId : Number(req.session.enterprise.currency_id),
-      };
+    data = {
+      incomeRows,
+      expenseRows,
+      incomeSummaryRow,
+      expensesSummaryRow,
+      totalSummaryRow,
+      fiscalYear,
+      title : 'BUDGET.EXPORT.REPORT_TITLE',
+      dateTo : moment().format('YYYY-MM-DD'),
+      filters : formatFilters(params),
+      currencyId : Number(req.session.enterprise.currency_id),
+    };
 
-    } else {
-      // For CSV and Excel, construct a simplied array of data with correct column header names
-      const csvData = [];
-      rows.forEach(row => {
-        if ((row.label === '')
+  } else {
+    // For CSV and Excel, construct a simplied array of data with correct column header names
+    const csvData = [];
+    rows.forEach(row => {
+      if ((row.label === '')
           || (row.acctType === 'total-income')
           || (row.acctType === 'total-expenses')
           || (row.acctType === 'total-summary')) {
-          // skip blank row and summary rows
-        } else {
-          csvData.push({
-            AcctNum : row.number,
-            Label : row.label,
-            Type : typeName(row.type_id),
-            Budget : row.budget || 0,
-            Actuals : row.actuals || 0,
-          });
-        }
+        // skip blank row and summary rows
+      } else {
+        csvData.push({
+          AcctNum : row.number,
+          Label : row.label,
+          Type : typeName(row.type_id),
+          Budget : row.budget || 0,
+          Actuals : row.actuals || 0,
+        });
+      }
 
-      });
+    });
 
-      data = {
-        rows : csvData,
-      };
-    }
-
-    const result = await report.render(data);
-    res.set(result.headers).send(result.report);
-  } catch (e) {
-    next(e);
+    data = {
+      rows : csvData,
+    };
   }
+
+  const result = await report.render(data);
+  res.set(result.headers).send(result.report);
 }
 
 exports.getReport = getReport;

--- a/server/controllers/finance/reports/budget_analytical/index.js
+++ b/server/controllers/finance/reports/budget_analytical/index.js
@@ -18,7 +18,7 @@ exports.report = report;
  * @description
  * Renders the analytical budget report.
  */
-async function report(req, res, next) {
+async function report(req, res) {
   const params = req.query;
 
   const fiscalYearId = parseInt(params.fiscal_id, 10);
@@ -56,54 +56,53 @@ async function report(req, res, next) {
     orientation : 'landscape',
   });
 
-  try {
-    const transaction = [];
-    const reportColumn = [];
-    const reportFootColumIncome = [];
-    const reportFootColumExpense = [];
-    let configurationReferences = [];
-    let configurationReferencesException = [];
+  const transaction = [];
+  const reportColumn = [];
+  const reportFootColumIncome = [];
+  const reportFootColumExpense = [];
+  let configurationReferences = [];
+  let configurationReferencesException = [];
 
-    const ACCOUNT_REFERENCE_NUMBERS = 2;
-    const ACCOUNT_REFERENCE_EXCLUSIONS = 3;
+  const ACCOUNT_REFERENCE_NUMBERS = 2;
+  const ACCOUNT_REFERENCE_EXCLUSIONS = 3;
 
-    const CONFIG_REF_OPERATING_REVENUE = 0;
-    const CONFIG_REF_OPERATING_FINANCIAL_REVENUE = 1;
-    const CONFIG_REF_OPERATING_SUBSIDIES = 2;
-    const CONFIG_REF_REVENUE_OTHER_SOURCES = 4;
-    const CONFIG_REF_LOCAL_REVENUES = 3;
+  const CONFIG_REF_OPERATING_REVENUE = 0;
+  const CONFIG_REF_OPERATING_FINANCIAL_REVENUE = 1;
+  const CONFIG_REF_OPERATING_SUBSIDIES = 2;
+  const CONFIG_REF_REVENUE_OTHER_SOURCES = 4;
+  const CONFIG_REF_LOCAL_REVENUES = 3;
 
-    const fiscalYear = await Fiscal.lookupFiscalYear(fiscalYearId);
+  const fiscalYear = await Fiscal.lookupFiscalYear(fiscalYearId);
 
-    if (includeSummarySection) {
-      let cashboxesIds = [];
-      let transactionTypes = [];
-      let transactionTypesSubsidies = [];
+  if (includeSummarySection) {
+    let cashboxesIds = [];
+    let transactionTypes = [];
+    let transactionTypesSubsidies = [];
 
-      if (params.cashboxesIds) {
-        // Selecting the cashbox to enable local revenue analysis
-        cashboxesIds = util.convertToNumericArray(params.cashboxesIds);
-      }
+    if (params.cashboxesIds) {
+      // Selecting the cashbox to enable local revenue analysis
+      cashboxesIds = util.convertToNumericArray(params.cashboxesIds);
+    }
 
-      if (params.transactionTypes) {
-        /**
+    if (params.transactionTypes) {
+      /**
          * Determination of transaction types to exclude for fund inflows
          * that are not considered as revenue
          */
-        transactionTypes = util.convertToNumericArray(params.transactionTypes);
+      transactionTypes = util.convertToNumericArray(params.transactionTypes);
 
-      }
+    }
 
-      if (params.transactionTypesSubsidies) {
-        /**
+    if (params.transactionTypesSubsidies) {
+      /**
          * Determination of transactions for operating subsidies,
          * subsidies are included in the calculation of overall revenue
          * but excluded when determining local revenue
          */
-        transactionTypesSubsidies = util.convertToNumericArray(params.transactionTypesSubsidies);
-      }
+      transactionTypesSubsidies = util.convertToNumericArray(params.transactionTypesSubsidies);
+    }
 
-      const query = `
+    const query = `
         SELECT
           cac.currency_id, cac.account_id, c.id, c.label, cur.symbol,
           a.number AS account_number, a.label AS account_label
@@ -114,18 +113,18 @@ async function report(req, res, next) {
         WHERE c.id IN ? ORDER BY c.id;
       `;
 
-      /**
+    /**
        * Retrieving accounts linked to the selected cashbox or cashboxes
        */
-      const cashboxes = await db.exec(query, [[cashboxesIds]]);
+    const cashboxes = await db.exec(query, [[cashboxesIds]]);
 
-      const cashAccountIds = cashboxes.map(cashbox => cashbox.account_id);
-      cashLabelDetails = cashboxes.map(
-        cashbox => `${cashbox.account_number} - ${cashbox.account_label}`);
+    const cashAccountIds = cashboxes.map(cashbox => cashbox.account_id);
+    cashLabelDetails = cashboxes.map(
+      cashbox => `${cashbox.account_number} - ${cashbox.account_label}`);
 
-      const BUDGET_ANALYSIS_REFERENCE_TYPE_ID = 8;
+    const BUDGET_ANALYSIS_REFERENCE_TYPE_ID = 8;
 
-      const sqlReferences = `
+    const sqlReferences = `
         SELECT ar.id, ar.abbr, ar.description, art.account_id, GROUP_CONCAT(a.number, ' ') AS accounts_number,
         GROUP_CONCAT(a.id, ' ') AS accounts_id, a.label
         FROM account_reference AS ar
@@ -135,56 +134,56 @@ async function report(req, res, next) {
         GROUP BY ar.id;
       `;
 
-      /**
+    /**
        * accountsReferenceType: A large array of objects containing
        * 0: Elements of the account reference type
        * 1: Account references corresponding to the budget analysis
        * 2: All account numbers by their account references
        * 3: All accounts to exclude, respectively by account reference
        */
-      const accountsReferenceType = await ReferencesCompute.getAccountsConfigurationReferences(
-        [BUDGET_ANALYSIS_REFERENCE_TYPE_ID],
-      );
+    const accountsReferenceType = await ReferencesCompute.getAccountsConfigurationReferences(
+      [BUDGET_ANALYSIS_REFERENCE_TYPE_ID],
+    );
 
-      const accountNumbersByReference = accountsReferenceType[ACCOUNT_REFERENCE_NUMBERS];
-      const excludedAccounts = accountsReferenceType[ACCOUNT_REFERENCE_EXCLUSIONS];
+    const accountNumbersByReference = accountsReferenceType[ACCOUNT_REFERENCE_NUMBERS];
+    const excludedAccounts = accountsReferenceType[ACCOUNT_REFERENCE_EXCLUSIONS];
 
-      configurationReferences = await db.exec(sqlReferences, [BUDGET_ANALYSIS_REFERENCE_TYPE_ID]);
+    configurationReferences = await db.exec(sqlReferences, [BUDGET_ANALYSIS_REFERENCE_TYPE_ID]);
 
-      /**
+    /**
        * Here, the account references corresponding to the budget analysis are formatted
        * and placed into the arrays accounts_number_formated and accounts_id_formated
        */
-      configurationReferences = configurationReferences.map(item => ({
-        ...item,
-        accounts_number_formated : item.accounts_number
-          .split(',')
-          .map(num => parseInt(num.trim(), 10))
-          .filter(num => Number.isInteger(num)),
-        accounts_id_formated : item.accounts_id
-          .split(',')
-          .map(num => parseInt(num.trim(), 10))
-          .filter(num => Number.isInteger(num)),
-      }));
+    configurationReferences = configurationReferences.map(item => ({
+      ...item,
+      accounts_number_formated : item.accounts_number
+        .split(',')
+        .map(num => parseInt(num.trim(), 10))
+        .filter(num => Number.isInteger(num)),
+      accounts_id_formated : item.accounts_id
+        .split(',')
+        .map(num => parseInt(num.trim(), 10))
+        .filter(num => Number.isInteger(num)),
+    }));
 
-      const localRevenues = configurationReferences[CONFIG_REF_LOCAL_REVENUES];
+    const localRevenues = configurationReferences[CONFIG_REF_LOCAL_REVENUES];
 
-      let referencesTypeAccounts = accountNumbersByReference.filter(
-        item => item.account_reference_id === localRevenues.id,
-      );
+    let referencesTypeAccounts = accountNumbersByReference.filter(
+      item => item.account_reference_id === localRevenues.id,
+    );
 
-      referencesTypeAccounts.forEach(item => {
-        item.exception = false;
-        excludedAccounts.forEach(elt => {
-          if (item.acc_id === elt.acc_id) {
-            item.exception = true;
-          }
-        });
+    referencesTypeAccounts.forEach(item => {
+      item.exception = false;
+      excludedAccounts.forEach(elt => {
+        if (item.acc_id === elt.acc_id) {
+          item.exception = true;
+        }
       });
+    });
 
-      referencesTypeAccounts = referencesTypeAccounts.filter(item => item.exception === false);
+    referencesTypeAccounts = referencesTypeAccounts.filter(item => item.exception === false);
 
-      const sqlReferencesException = `
+    const sqlReferencesException = `
         SELECT ar.id, ar.abbr, ar.description, art.account_id, GROUP_CONCAT(a.number, ' ') AS accounts_number,
         GROUP_CONCAT(a.id, ' ') AS accounts_id, a.label
         FROM account_reference AS ar
@@ -194,48 +193,48 @@ async function report(req, res, next) {
         GROUP BY ar.id;
       `;
 
-      /**
+    /**
        * Here, all accounts belonging to the excluded account references are listed.
        * The account numbers as well as the account IDs are placed into the arrays
        * accounts_number_formated and accounts_id_formated
        */
-      configurationReferencesException = await db.exec(sqlReferencesException, [BUDGET_ANALYSIS_REFERENCE_TYPE_ID]);
+    configurationReferencesException = await db.exec(sqlReferencesException, [BUDGET_ANALYSIS_REFERENCE_TYPE_ID]);
 
-      configurationReferencesException = configurationReferencesException.map(item => ({
-        ...item,
-        accounts_number_formated : item.accounts_number
-          .split(',')
-          .map(num => parseInt(num.trim(), 10))
-          .filter(num => Number.isInteger(num)),
-        accounts_id_formated : item.accounts_id
-          .split(',')
-          .map(num => parseInt(num.trim(), 10))
-          .filter(num => Number.isInteger(num)),
-      }));
+    configurationReferencesException = configurationReferencesException.map(item => ({
+      ...item,
+      accounts_number_formated : item.accounts_number
+        .split(',')
+        .map(num => parseInt(num.trim(), 10))
+        .filter(num => Number.isInteger(num)),
+      accounts_id_formated : item.accounts_id
+        .split(',')
+        .map(num => parseInt(num.trim(), 10))
+        .filter(num => Number.isInteger(num)),
+    }));
 
-      let filterTransactionType = ``;
-      let filterExcludeTransactionType = ``;
+    let filterTransactionType = ``;
+    let filterExcludeTransactionType = ``;
 
-      /**
+    /**
        * Here, clauses are formatted to be injected into SQL queries
        * in order to account for the transaction types to exclude
        */
-      if (transactionTypes.length) {
-        filterTransactionType = ` AND aggr.transaction_type_id NOT IN (${transactionTypes})`;
-        filterExcludeTransactionType = ` AND gl.transaction_type_id NOT IN (${transactionTypes})`;
-      }
+    if (transactionTypes.length) {
+      filterTransactionType = ` AND aggr.transaction_type_id NOT IN (${transactionTypes})`;
+      filterExcludeTransactionType = ` AND gl.transaction_type_id NOT IN (${transactionTypes})`;
+    }
 
-      let filterTransactionTypesSubsidies = ``;
+    let filterTransactionTypesSubsidies = ``;
 
-      /**
+    /**
        * Here, clauses are formatted to be injected into SQL queries
        * to exclude transaction types corresponding to operating subsidies
        */
-      if (transactionTypesSubsidies.length) {
-        filterTransactionTypesSubsidies = ` AND gl.transaction_type_id NOT IN (${transactionTypesSubsidies})`;
-      }
+    if (transactionTypesSubsidies.length) {
+      filterTransactionTypesSubsidies = ` AND gl.transaction_type_id NOT IN (${transactionTypesSubsidies})`;
+    }
 
-      const sqlCashflowIncome = `
+    const sqlCashflowIncome = `
         SELECT aggr.trans_id, a.number, a.label, aggr.account_id, SUM(aggr.debit_equiv) AS debit_equiv,
           SUM(aggr.credit_equiv) AS credit_equiv, SUM(aggr.credit_equiv - aggr.debit_equiv) AS balance,
           aggr.trans_date, aggr.record_uuid, aggr.transaction_type_id, tt.text
@@ -268,38 +267,38 @@ async function report(req, res, next) {
         ORDER BY a.number ASC;
       `;
 
-      const paramsLocalIncomeFilter = [
-        fiscalYearId,
-        [cashAccountIds],
-        fiscalYear.start_date,
-        fiscalYear.end_date,
-        fiscalYear.start_date,
-        fiscalYear.end_date,
-        fiscalYear.start_date,
-        fiscalYear.end_date,
-      ];
+    const paramsLocalIncomeFilter = [
+      fiscalYearId,
+      [cashAccountIds],
+      fiscalYear.start_date,
+      fiscalYear.end_date,
+      fiscalYear.start_date,
+      fiscalYear.end_date,
+      fiscalYear.start_date,
+      fiscalYear.end_date,
+    ];
 
-      /**
+    /**
        * Retrieving the revenue obtained with the selected cashbox
        */
-      const cashflowIncome = await db.exec(sqlCashflowIncome, paramsLocalIncomeFilter);
+    const cashflowIncome = await db.exec(sqlCashflowIncome, paramsLocalIncomeFilter);
 
-      cashflowIncome.forEach(income => {
-        referencesTypeAccounts.forEach(ref => {
-          if (income.account_id === ref.acc_id) {
-            localCashRevenues += income.balance;
-          }
-        });
+    cashflowIncome.forEach(income => {
+      referencesTypeAccounts.forEach(ref => {
+        if (income.account_id === ref.acc_id) {
+          localCashRevenues += income.balance;
+        }
       });
+    });
 
-      /**
+    /**
        * Configuration with index 4 corresponds to the fifth account reference configuration
        * to capture revenue from other sources such as bank accounts
        */
-      if (configurationReferences[CONFIG_REF_REVENUE_OTHER_SOURCES]) {
-        const otherIncome = configurationReferences[CONFIG_REF_REVENUE_OTHER_SOURCES];
+    if (configurationReferences[CONFIG_REF_REVENUE_OTHER_SOURCES]) {
+      const otherIncome = configurationReferences[CONFIG_REF_REVENUE_OTHER_SOURCES];
 
-        const sqlOtherIncome = `
+      const sqlOtherIncome = `
           SELECT map.text AS referenceVoucher, gl.trans_id, gl.trans_date, a.id AS account_id,
           a.number AS account_number, a.label AS account_label, gl.transaction_type_id,
           gl.description, SUM(gl.debit_equiv) AS debit_equiv,
@@ -317,284 +316,275 @@ async function report(req, res, next) {
           ORDER BY gl.trans_date ASC;
         `;
 
-        const referencesOtherIncome = await db.exec(sqlOtherIncome, [fiscalYearId, [otherIncome.accounts_id_formated]]);
+      const referencesOtherIncome = await db.exec(sqlOtherIncome, [fiscalYearId, [otherIncome.accounts_id_formated]]);
 
-        /**
+      /**
          * This is the value corresponding to the sum of other revenues. To obtain this value,
          * it is essential to exclude operating subsidies, corrections
          * of entries, and miscellaneous operations
          */
-        balanceOtherIncome = referencesOtherIncome[0].debit_equiv;
-      }
+      balanceOtherIncome = referencesOtherIncome[0].debit_equiv;
     }
+  }
 
-    const sqlGetPreviousFiscalYear = `
+  const sqlGetPreviousFiscalYear = `
       SELECT fy.id, fy.label, YEAR(fy.end_date) AS year
         FROM fiscal_year AS fy
         WHERE fy.id <= ? ORDER BY fy.id DESC
         LIMIT ?
     `;
 
-    const fiscalsYear = await db.exec(sqlGetPreviousFiscalYear, [fiscalYearId, setNumberYear]);
+  const fiscalsYear = await db.exec(sqlGetPreviousFiscalYear, [fiscalYearId, setNumberYear]);
 
-    const reporting = new ReportManager(BUDGET_REPORT_TEMPLATE, req.session, optionReport);
+  const reporting = new ReportManager(BUDGET_REPORT_TEMPLATE, req.session, optionReport);
 
-    fiscalsYear.forEach((fisc, index) => {
-      transaction.push(Budget.buildBudgetData(fisc.id));
+  fiscalsYear.forEach((fisc, index) => {
+    transaction.push(Budget.buildBudgetData(fisc.id));
 
-      if (index > 0) {
-        // Getting the fiscal years for the report header columns
-        reportColumn.push({ number : fisc.year });
-      }
+    if (index > 0) {
+      // Getting the fiscal years for the report header columns
+      reportColumn.push({ number : fisc.year });
+    }
+  });
+
+  const fiscalYearNumber = fiscalsYear[0].year || '';
+  const lastFiscalYearNumber = fiscalsYear[1].year || '';
+
+  const dataFiscalsYear = await Promise.all(transaction);
+  let tabFiscalReport = [];
+  const uniqueSet = new Set();
+
+  dataFiscalsYear.flat().forEach(item => {
+    const key = `${item.id}-${item.number}`;
+
+    if (uniqueSet.has(key)) {
+      return;
+    }
+
+    uniqueSet.add(key);
+    const isTitle = (item.type_id === 6);
+
+    tabFiscalReport.push({
+      id : item.id,
+      number : item.number,
+      label : item.label,
+      type_id : item.type_id,
+      isTitle,
     });
 
-    const fiscalYearNumber = fiscalsYear[0].year || '';
-    const lastFiscalYearNumber = fiscalsYear[1].year || '';
+  });
 
-    const dataFiscalsYear = await Promise.all(transaction);
-    let tabFiscalReport = [];
-    const uniqueSet = new Set();
+  dataFiscalsYear.forEach((fiscal, index) => {
+    if (index === 0) {
+      fiscal.forEach(fisc => {
+        tabFiscalReport.forEach(rep => {
+          if (fisc.number === rep.number) {
+            rep.budget = fisc.budget;
+            rep.realisation = fisc.actuals;
 
-    dataFiscalsYear.flat().forEach(item => {
-      const key = `${item.id}-${item.number}`;
+            rep.completion = fisc.budget ? fisc.deviationYTDPct / 100 : '';
 
-      if (uniqueSet.has(key)) {
-        return;
-      }
+            if (rep.type_id === 6 && fisc.budget) {
+              rep.completion = fisc.actuals / fisc.budget;
+            }
 
-      uniqueSet.add(key);
-      const isTitle = (item.type_id === 6);
+            rep.previousReport = [];
+            rep.variation = 0;
+            rep.isNull = (!fisc.budget && !fisc.actuals);
+            rep.isIncomeTitle = fisc.isIncomeTitle || '';
+            rep.isExpenseTitle = fisc.isExpenseTitle || '';
 
-      tabFiscalReport.push({
-        id : item.id,
-        number : item.number,
-        label : item.label,
-        type_id : item.type_id,
-        isTitle,
+            if (rep.type_id === 4) {
+              totalBudgetIncome += rep.budget;
+              totalRealisationIncome += rep.realisation;
+            }
+
+            if (rep.type_id === 5) {
+              totalBudgetExpense += rep.budget;
+              totalRealisationExpense += rep.realisation;
+            }
+          }
+        });
+      });
+    }
+
+    if (index > 0) {
+      let totalIncomeRealised = 0;
+      let totalExpenseRealised = 0;
+
+      fiscal.forEach(fisc => {
+        if (fisc.type_id === 4) {
+          totalIncomeRealised += fisc.actuals;
+        }
+
+        if (fisc.type_id === 5) {
+          totalExpenseRealised += fisc.actuals;
+        }
       });
 
-    });
+      reportFootColumIncome.push({ realisation : totalIncomeRealised });
+      reportFootColumExpense.push({ realisation : totalExpenseRealised });
+    }
+  });
 
+  tabFiscalReport.forEach(rep => {
     dataFiscalsYear.forEach((fiscal, index) => {
-      if (index === 0) {
+      if (index > 0) {
+        let realisationValue = 0;
         fiscal.forEach(fisc => {
-          tabFiscalReport.forEach(rep => {
-            if (fisc.number === rep.number) {
-              rep.budget = fisc.budget;
-              rep.realisation = fisc.actuals;
+          if (fisc.number === rep.number) {
+            realisationValue = fisc.actuals;
+            rep.isNull = (rep.isNull && !fisc.actuals);
 
-              rep.completion = fisc.budget ? fisc.deviationYTDPct / 100 : '';
-
-              if (rep.type_id === 6 && fisc.budget) {
-                rep.completion = fisc.actuals / fisc.budget;
-              }
-
-              rep.previousReport = [];
-              rep.variation = 0;
-              rep.isNull = (!fisc.budget && !fisc.actuals);
-              rep.isIncomeTitle = fisc.isIncomeTitle || '';
-              rep.isExpenseTitle = fisc.isExpenseTitle || '';
+            if (index === 1 && rep.realisation && fisc.actuals) {
+              rep.variation = rep.realisation - fisc.actuals;
 
               if (rep.type_id === 4) {
-                totalBudgetIncome += rep.budget;
-                totalRealisationIncome += rep.realisation;
+                totalVariationIncome += rep.variation;
               }
 
               if (rep.type_id === 5) {
-                totalBudgetExpense += rep.budget;
-                totalRealisationExpense += rep.realisation;
+                totalVariationExpense += rep.variation;
               }
             }
-          });
-        });
-      }
-
-      if (index > 0) {
-        let totalIncomeRealised = 0;
-        let totalExpenseRealised = 0;
-
-        fiscal.forEach(fisc => {
-          if (fisc.type_id === 4) {
-            totalIncomeRealised += fisc.actuals;
-          }
-
-          if (fisc.type_id === 5) {
-            totalExpenseRealised += fisc.actuals;
           }
         });
 
-        reportFootColumIncome.push({ realisation : totalIncomeRealised });
-        reportFootColumExpense.push({ realisation : totalExpenseRealised });
+        rep.previousReport.push({ realisation : realisationValue });
       }
     });
+  });
 
-    tabFiscalReport.forEach(rep => {
-      dataFiscalsYear.forEach((fiscal, index) => {
-        if (index > 0) {
-          let realisationValue = 0;
-          fiscal.forEach(fisc => {
-            if (fisc.number === rep.number) {
-              realisationValue = fisc.actuals;
-              rep.isNull = (rep.isNull && !fisc.actuals);
+  if (hideUnused) {
+    tabFiscalReport = tabFiscalReport.filter(id => !id.isNull);
+  }
 
-              if (index === 1 && rep.realisation && fisc.actuals) {
-                rep.variation = rep.realisation - fisc.actuals;
+  if (params.filter === 'hide_title') {
+    tabFiscalReport = tabFiscalReport.filter(id => !id.isTitle);
+  }
 
-                if (rep.type_id === 4) {
-                  totalVariationIncome += rep.variation;
-                }
+  if (params.filter === 'show_title') {
+    tabFiscalReport = tabFiscalReport.filter(id => id.isTitle);
+  }
 
-                if (rep.type_id === 5) {
-                  totalVariationExpense += rep.variation;
-                }
-              }
-            }
-          });
+  const tabFiscalIncomeData = tabFiscalReport.filter(id => {
+    return (id.type_id === ACCOUNT_TYPES_INCOME || id.isIncomeTitle);
+  });
 
-          rep.previousReport.push({ realisation : realisationValue });
-        }
-      });
-    });
+  const tabFiscalExpenseData = tabFiscalReport.filter(id => {
+    return (id.type_id === ACCOUNT_TYPES_EXPENSE || id.isExpenseTitle);
+  });
 
-    if (hideUnused) {
-      tabFiscalReport = tabFiscalReport.filter(id => {
-        return !id.isNull;
-      });
-    }
+  const totalCompletionIncome = totalRealisationIncome / totalBudgetIncome;
+  const totalCompletionExpense = totalRealisationExpense / totalBudgetExpense;
 
-    if (params.filter === 'hide_title') {
-      tabFiscalReport = tabFiscalReport.filter(id => {
-        return !id.isTitle;
-      });
-    }
+  // This is the difference between the profits made on expenses during the fiscal year
+  const realisationIncomeExpense = totalRealisationIncome - totalRealisationExpense;
 
-    if (params.filter === 'show_title') {
-      tabFiscalReport = tabFiscalReport.filter(id => {
-        return id.isTitle;
-      });
-    }
-
-    const tabFiscalIncomeData = tabFiscalReport.filter(id => {
-      return (id.type_id === ACCOUNT_TYPES_INCOME || id.isIncomeTitle);
-    });
-
-    const tabFiscalExpenseData = tabFiscalReport.filter(id => {
-      return (id.type_id === ACCOUNT_TYPES_EXPENSE || id.isExpenseTitle);
-    });
-
-    const totalCompletionIncome = totalRealisationIncome / totalBudgetIncome;
-    const totalCompletionExpense = totalRealisationExpense / totalBudgetExpense;
-
-    // This is the difference between the profits made on expenses during the fiscal year
-    const realisationIncomeExpense = totalRealisationIncome - totalRealisationExpense;
-
-    configurationReferences.forEach((item, index) => {
-      /**
+  configurationReferences.forEach((item, index) => {
+    /**
        * Here, we search for how to calculate the values corresponding to each of the account references.
        * These values are obtained from tabFiscalIncomeData and they only concern the first 4
        * configurations of the budget analysis, which is why we limit ourselves to index 4
        */
-      if (index < 4) {
-        item.value_account_number = item.accounts_number_formated.reduce((total, accountNumber) => {
-          const matchingIncome = tabFiscalIncomeData.find(income => income.number === accountNumber);
-          return total + (matchingIncome ? matchingIncome.realisation : 0);
-        }, 0);
-      }
-    });
+    if (index < 4) {
+      item.value_account_number = item.accounts_number_formated.reduce((total, accountNumber) => {
+        const matchingIncome = tabFiscalIncomeData.find(income => income.number === accountNumber);
+        return total + (matchingIncome ? matchingIncome.realisation : 0);
+      }, 0);
+    }
+  });
 
-    /** Here, we perform exactly the same operation but for the excluded accounts */
-    configurationReferencesException.forEach((item, index) => {
-      if (index < 4) {
-        item.value_account_number = item.accounts_number_formated.reduce((total, accountNumber) => {
-          const matchingIncome = tabFiscalIncomeData.find(income => income.number === accountNumber);
-          return total + (matchingIncome ? matchingIncome.realisation : 0);
-        }, 0);
-      }
-    });
+  /** Here, we perform exactly the same operation but for the excluded accounts */
+  configurationReferencesException.forEach((item, index) => {
+    if (index < 4) {
+      item.value_account_number = item.accounts_number_formated.reduce((total, accountNumber) => {
+        const matchingIncome = tabFiscalIncomeData.find(income => income.number === accountNumber);
+        return total + (matchingIncome ? matchingIncome.realisation : 0);
+      }, 0);
+    }
+  });
 
-    /**
+  /**
      * Here, we iterate through both arrays configurationReferences and configurationReferencesException
      * in order to subtract the corresponding value from the exceptions array:
      */
-    configurationReferences.forEach(item => {
-      const getException = configurationReferencesException.find(elt => elt.abbr === item.abbr);
-      if (getException) {
-        item.value_account_number -= getException.value_account_number;
-      }
-    });
+  configurationReferences.forEach(item => {
+    const getException = configurationReferencesException.find(elt => elt.abbr === item.abbr);
+    if (getException) {
+      item.value_account_number -= getException.value_account_number;
+    }
+  });
 
-    const operatingRevenue = configurationReferences[CONFIG_REF_OPERATING_REVENUE];
-    const operatingFinancialRevenue = configurationReferences[CONFIG_REF_OPERATING_FINANCIAL_REVENUE];
+  const operatingRevenue = configurationReferences[CONFIG_REF_OPERATING_REVENUE];
+  const operatingFinancialRevenue = configurationReferences[CONFIG_REF_OPERATING_FINANCIAL_REVENUE];
 
-    let operatingSubsidiesReferences = 0;
+  let operatingSubsidiesReferences = 0;
 
-    if (includeSummarySection) {
-      // Corresponds to operating revenue
-      operatingRevenueDescription = operatingRevenue.description;
+  if (includeSummarySection) {
+    // Corresponds to operating revenue
+    operatingRevenueDescription = operatingRevenue.description;
 
-      // Corresponds to actual revenue generated without operating subsidies
-      operatingFinancialRevenueDescription = operatingFinancialRevenue.description;
+    // Corresponds to actual revenue generated without operating subsidies
+    operatingFinancialRevenueDescription = operatingFinancialRevenue.description;
 
-      // Corresponds to the value of operating subsidies received
-      operatingSubsidiesReferences = configurationReferences[CONFIG_REF_OPERATING_SUBSIDIES].value_account_number;
+    // Corresponds to the value of operating subsidies received
+    operatingSubsidiesReferences = configurationReferences[CONFIG_REF_OPERATING_SUBSIDIES].value_account_number;
 
-      /**
+    /**
        * Here, we calculate the result without the accounts, which would represent the result
        * without subsidies and Financial revenues
        */
-      realisationOperatingRevenue = (operatingRevenue.value_account_number || 0) - totalRealisationExpense;
+    realisationOperatingRevenue = (operatingRevenue.value_account_number || 0) - totalRealisationExpense;
 
-      /** Here, we evaluate the result without operating subsidies */
-      realisationOperatingFinancialRevenue = (operatingFinancialRevenue.value_account_number || 0)
+    /** Here, we evaluate the result without operating subsidies */
+    realisationOperatingFinancialRevenue = (operatingFinancialRevenue.value_account_number || 0)
         - totalRealisationExpense;
-    }
+  }
 
-    /** localCash corresponds to the revenue generated without operating subsidies */
-    localCashRevenues += balanceOtherIncome;
+  /** localCash corresponds to the revenue generated without operating subsidies */
+  localCashRevenues += balanceOtherIncome;
 
-    /**
+  /**
      * Total Cash is the sum of local revenue + operating subsidies
      */
-    totalCash = localCashRevenues + operatingSubsidiesReferences;
-    const soldeTotalFinancement = totalCash - totalRealisationExpense;
+  totalCash = localCashRevenues + operatingSubsidiesReferences;
+  const soldeTotalFinancement = totalCash - totalRealisationExpense;
 
-    const data = {
-      colums : dataFiscalsYear,
-      enterprise,
-      rowsIncome : tabFiscalIncomeData,
-      rowsExpense : tabFiscalExpenseData,
-      fiscalYearLabel : fiscalYear.label,
-      fiscalYearNumber,
-      lastFiscalYearNumber,
-      reportColumn,
-      colspanValue,
-      totalBudgetIncome,
-      totalRealisationIncome,
-      totalBudgetExpense,
-      totalRealisationExpense,
-      totalVariationIncome,
-      totalVariationExpense,
-      totalCompletionIncome,
-      totalCompletionExpense,
-      reportFootColumIncome,
-      reportFootColumExpense,
-      currencyId : Number(req.session.enterprise.currency_id),
-      includeSummarySection,
-      totalCash,
-      realisationIncomeExpense,
-      realisationOperatingRevenue,
-      realisationOperatingFinancialRevenue,
-      operatingSubsidiesReferences,
-      localCashRevenues,
-      soldeTotalFinancement,
-      cashLabelDetails,
-      operatingRevenueDescription,
-      operatingFinancialRevenueDescription,
-    };
+  const data = {
+    colums : dataFiscalsYear,
+    enterprise,
+    rowsIncome : tabFiscalIncomeData,
+    rowsExpense : tabFiscalExpenseData,
+    fiscalYearLabel : fiscalYear.label,
+    fiscalYearNumber,
+    lastFiscalYearNumber,
+    reportColumn,
+    colspanValue,
+    totalBudgetIncome,
+    totalRealisationIncome,
+    totalBudgetExpense,
+    totalRealisationExpense,
+    totalVariationIncome,
+    totalVariationExpense,
+    totalCompletionIncome,
+    totalCompletionExpense,
+    reportFootColumIncome,
+    reportFootColumExpense,
+    currencyId : Number(req.session.enterprise.currency_id),
+    includeSummarySection,
+    totalCash,
+    realisationIncomeExpense,
+    realisationOperatingRevenue,
+    realisationOperatingFinancialRevenue,
+    operatingSubsidiesReferences,
+    localCashRevenues,
+    soldeTotalFinancement,
+    cashLabelDetails,
+    operatingRevenueDescription,
+    operatingFinancialRevenueDescription,
+  };
 
-    const result = await reporting.render(data);
-    res.set(result.headers).send(result.report);
-  } catch (e) {
-    next(e);
-  }
+  const result = await reporting.render(data);
+  res.set(result.headers).send(result.report);
 }

--- a/server/controllers/finance/reports/cash/index.js
+++ b/server/controllers/finance/reports/cash/index.js
@@ -38,11 +38,9 @@ const REPORT_TEMPLATE = './server/controllers/finance/reports/cash/report.handle
  *
  * GET /reports/cash/:uuid
  */
-function receipt(req, res, next) {
-  const options = req.query;
-  _.extend(options, { filename : 'CASH.TITLE' });
+async function receipt(req, res) {
+  const options = { ...req.query, filename : 'CASH.TITLE' };
 
-  let receiptReport;
   let template = RECEIPT_TEMPLATE;
 
   if (Number(options.posReceipt)) {
@@ -51,83 +49,68 @@ function receipt(req, res, next) {
   }
 
   // set up the report with report manager
-  try {
-    receiptReport = new ReportManager(template, req.session, options);
-  } catch (e) {
-    next(e);
-    return;
-  }
-
+  const receiptReport = new ReportManager(template, req.session, options);
   const data = {};
 
-  CashPayments.lookup(req.params.uuid)
-    .then((payment) => {
-      data.payment = payment;
+  const payment = await CashPayments.lookup(req.params.uuid);
+  data.payment = payment;
 
-      // create a description for the cash payment's receipt
-      const descriptionParts = payment.description.split(' -- ');
-      let renderedDescription;
+  // create a description for the cash payment's receipt
+  const descriptionParts = payment.description.split(' -- ');
+  let renderedDescription;
 
-      if (descriptionParts.length > 1) {
-        // render everything after the descriptor
-        renderedDescription = _.drop(descriptionParts, 1).join('');
-      } else {
-        // unable to parse ... use the whole description.
-        renderedDescription = payment.description;
-      }
+  if (descriptionParts.length > 1) {
+    // render everything after the descriptor
+    renderedDescription = _.drop(descriptionParts, 1).join('');
+  } else {
+    // unable to parse ... use the whole description.
+    renderedDescription = payment.description;
+  }
 
-      payment.renderedDescription = renderedDescription;
+  payment.renderedDescription = renderedDescription;
 
-      // lookup balances on all invoices
-      const invoicesItems = payment.items.map(invoices => invoices.invoice_uuid);
+  // lookup balances on all invoices
+  const invoicesItems = payment.items.map(invoices => invoices.invoice_uuid);
 
-      return Promise.all([
-        Users.lookup(payment.user_id),
-        Patients.lookupByDebtorUuid(payment.debtor_uuid),
-        Enterprises.lookupByProjectId(payment.project_id),
-        Debtors.invoiceBalances(payment.debtor_uuid, invoicesItems),
-        Debtors.balance(payment.debtor_uuid),
-      ]);
-    })
-    .then(([user, patient, enterprise, invoices, totalInvoices]) => {
-      _.assign(data, {
-        user,
-        patient,
-        enterprise,
-        invoices,
-        totalInvoices : totalInvoices[0] || {},
-      });
+  const [user, patient, enterprise, invoices, totalInvoices] = await Promise.all([
+    Users.lookup(payment.user_id),
+    Patients.lookupByDebtorUuid(payment.debtor_uuid),
+    Enterprises.lookupByProjectId(payment.project_id),
+    Debtors.invoiceBalances(payment.debtor_uuid, invoicesItems),
+    Debtors.balance(payment.debtor_uuid),
+  ]);
 
-      return Exchange.getExchangeRate(enterprise.id, data.payment.currency_id, data.payment.date);
-    })
-    .then((exchange) => {
-      data.rate = exchange.rate;
-      data.currentDateFormatted = (new Moment()).format('L');
-      data.hasRate = (data.rate && !data.payment.is_caution);
+  Object.assign(data, {
+    user,
+    patient,
+    enterprise,
+    invoices,
+    totalInvoices : totalInvoices[0] || {},
+  });
 
-      data.balances = data.invoices.reduce((aggregate, invoice) => {
-        aggregate[invoice.uuid] = invoice.balance;
-        return aggregate;
-      }, {});
+  const exchange = await Exchange.getExchangeRate(enterprise.id, data.payment.currency_id, data.payment.date);
+  data.rate = exchange.rate;
+  data.currentDateFormatted = (new Moment()).format('L');
+  data.hasRate = (data.rate && !data.payment.is_caution);
 
-      data.debtorTotalBalance = data.totalInvoices.balance;
+  data.balances = data.invoices.reduce((aggregate, invoice) => {
+    aggregate[invoice.uuid] = invoice.balance;
+    return aggregate;
+  }, {});
 
-      data.payment.items.forEach((invoiceItem) => {
-        invoiceItem.balance = data.balances[invoiceItem.invoice_uuid];
+  data.debtorTotalBalance = data.totalInvoices.balance;
 
-        // if the payment is anything other than the enterprise rate, exchange it
-        // @todo perform ALL exchanges in a standard library
-        invoiceItem.exchangedBalance = data.hasRate ? _.round(invoiceItem.balance * data.rate) : invoiceItem.balance;
-        invoiceItem.payment_complete = invoiceItem.balance === 0;
-      });
+  data.payment.items.forEach((invoiceItem) => {
+    invoiceItem.balance = data.balances[invoiceItem.invoice_uuid];
 
-      return receiptReport.render(data);
-    })
-    .then((result) => {
-      res.set(result.headers).send(result.report);
-    })
-    .catch(next);
+    // if the payment is anything other than the enterprise rate, exchange it
+    // @todo perform ALL exchanges in a standard library
+    invoiceItem.exchangedBalance = data.hasRate ? _.round(invoiceItem.balance * data.rate) : invoiceItem.balance;
+    invoiceItem.payment_complete = invoiceItem.balance === 0;
+  });
 
+  const result = await receiptReport.render(data);
+  res.set(result.headers).send(result.report);
 }
 
 /**
@@ -139,7 +122,7 @@ function receipt(req, res, next) {
  *
  * GET /reports/finance/cash
  */
-async function report(req, res, next) {
+async function report(req, res) {
   const query = _.clone(req.query);
   const filters = shared.formatFilters(req.query);
 
@@ -150,11 +133,10 @@ async function report(req, res, next) {
   });
 
   // set up the report with report manager
-  try {
-    const reportInstance = new ReportManager(REPORT_TEMPLATE, req.session, query);
+  const reportInstance = new ReportManager(REPORT_TEMPLATE, req.session, query);
 
-    // aggregates basic statistics about the selection
-    const aggregateSql = `
+  // aggregates basic statistics about the selection
+  const aggregateSql = `
       SELECT MIN(cash.date) AS minDate, MAX(cash.date) AS maxDate,
         COUNT(DISTINCT(cash.user_id)) AS numUsers,
         COUNT(DISTINCT(cash.project_id)) AS numProjects,
@@ -167,42 +149,36 @@ async function report(req, res, next) {
       WHERE cash.uuid IN (?);
     `;
 
-    // aggregates the cost by currency id.
-    const costSql = `
+  // aggregates the cost by currency id.
+  const costSql = `
       SELECT SUM(cash.amount) AS amount, cash.currency_id, currency.symbol
       FROM cash JOIN currency ON cash.currency_id = currency.id
       WHERE cash.uuid IN (?)
       GROUP BY currency_id;
     `;
 
-    const data = { filters };
+  const data = { filters };
 
-    data.rows = await CashPayments.find(query);
+  data.rows = await CashPayments.find(query);
 
-    // map the uuids for aggregate sql consumption
-    const uuids = data.rows.map(row => db.bid(row.uuid));
+  // map the uuids for aggregate sql consumption
+  const uuids = data.rows.map(row => db.bid(row.uuid));
 
-    if (uuids.length > 0) {
-      data.aggregates = await db.one(aggregateSql, [uuids]);
+  if (uuids.length > 0) {
+    data.aggregates = await db.one(aggregateSql, [uuids]);
 
-      // conditional switches
-      data.hasMultipleProjects = data.aggregates.numProjects > 1;
-      data.hasMultipleCashboxes = data.aggregates.numCashboxes > 1;
-
-      data.amounts = await db.exec(costSql, [uuids]);
-    }
-
-    let project = {};
-    if (query.project_id) {
-      project = await Projects.findDetails(query.project_id);
-    }
-
-    data.project = project;
-    const result = await reportInstance.render(data);
-    res.set(result.headers).send(result.report);
-  } catch (e) {
-    next(e);
+    // conditional switches
+    data.hasMultipleProjects = data.aggregates.numProjects > 1;
+    data.hasMultipleCashboxes = data.aggregates.numCashboxes > 1;
+    data.amounts = await db.exec(costSql, [uuids]);
   }
+
+  if (query.project_id) {
+    data.project = await Projects.findDetails(query.project_id);
+  }
+
+  const result = await reportInstance.render(data);
+  res.set(result.headers).send(result.report);
 }
 
 exports.receipt = receipt;

--- a/server/controllers/finance/reports/cash/index.js
+++ b/server/controllers/finance/reports/cash/index.js
@@ -61,7 +61,7 @@ async function receipt(req, res) {
 
   if (descriptionParts.length > 1) {
     // render everything after the descriptor
-    renderedDescription = _.drop(descriptionParts, 1).join('');
+    renderedDescription = descriptionParts.slice(1).join('');
   } else {
     // unable to parse ... use the whole description.
     renderedDescription = payment.description;
@@ -123,7 +123,7 @@ async function receipt(req, res) {
  * GET /reports/finance/cash
  */
 async function report(req, res) {
-  const query = _.clone(req.query);
+  const query = structuredClone(req.query);
   const filters = shared.formatFilters(req.query);
 
   _.extend(query, {

--- a/server/controllers/finance/reports/cashflow/index.js
+++ b/server/controllers/finance/reports/cashflow/index.js
@@ -46,7 +46,7 @@ async function reportByService(req, res) {
   const dateTo = new Date(req.query.dateTo);
   const cashboxAccountId = req.query.cashboxId;
 
-  const options = _.clone(req.query);
+  const options = structuredClone(req.query);
 
   _.extend(options, {
     filename : 'REPORT.CASHFLOW_BY_SERVICE.TITLE',
@@ -170,7 +170,7 @@ async function reportByService(req, res) {
 async function report(req, res) {
   const dateFrom = new Date(req.query.dateFrom);
   const dateTo = new Date(req.query.dateTo);
-  const options = _.clone(req.query);
+  const options = structuredClone(req.query);
   const reversalVoucherType = 10;
 
   let referenceAccountsRevenues = [];
@@ -221,8 +221,8 @@ async function report(req, res) {
   data.detailledReport = checkDetailledOption ? 1 : 0;
 
   // convert cashboxesIds parameters in array format ['', '', ...]
+  const cashboxesIds = Object.values(req.query.cashboxesIds);
   // this parameter can be sent as a string or an array we force the conversion into an array
-  const cashboxesIds = _.values(req.query.cashboxesIds);
 
   Object.assign(options, {
     filename : 'REPORT.CASHFLOW.TITLE',
@@ -452,9 +452,9 @@ async function report(req, res) {
     const expenses = _.chain(rows).filter({ transaction_type : 'expense' }).groupBy('transaction_text').value();
     const others = _.chain(rows).filter({ transaction_type : 'other' }).groupBy('transaction_text').value();
 
-    const incomeTextKeys = _.keys(incomes);
-    const expenseTextKeys = _.keys(expenses);
-    const otherTextKeys = _.keys(others);
+    const incomeTextKeys = Object.keys(incomes);
+    const expenseTextKeys = Object.keys(expenses);
+    const otherTextKeys = Object.keys(others);
 
     const incomeTotalByTextKeys = cashflowFunction.aggregateTotalByTextKeys(data, incomes);
     const expenseTotalByTextKeys = cashflowFunction.aggregateTotalByTextKeys(data, expenses);
@@ -549,9 +549,9 @@ async function report(req, res) {
       .groupBy('description_reference').value();
 
     /** In this section, we get the display key for each section of the report */
-    const incomeGlobalsTextKeys = _.keys(incomesGlobals);
-    const expenseGlobalsTextKeys = _.keys(expensesGlobals);
-    const otherGlobalsTextKeys = _.keys(othersGlobals);
+    const incomeGlobalsTextKeys = Object.keys(incomesGlobals);
+    const expenseGlobalsTextKeys = Object.keys(expensesGlobals);
+    const otherGlobalsTextKeys = Object.keys(othersGlobals);
 
     /** Here, we obtain the details of each account reference with the sum of values for each period */
     const incomeGlobalsTotalByTextKeys = cashflowFunction.aggregateTotalByTextKeys(data, incomesGlobals);
@@ -843,7 +843,7 @@ async function reporting(options, session) {
 
   // convert cashboxesIds parameters in array format ['', '', ...]
   // this parameter can be sent as a string or an array we force the conversion into an array
-  const cashboxesIds = _.values(options.cashboxesIds);
+  const cashboxesIds = Object.values(options.cashboxesIds);
 
   _.extend(options, { orientation : 'landscape' });
 
@@ -934,9 +934,9 @@ async function reporting(options, session) {
   const expenses = _.chain(rows).filter({ transaction_type : 'expense' }).groupBy('transaction_text').value();
   const others = _.chain(rows).filter({ transaction_type : 'other' }).groupBy('transaction_text').value();
 
-  const incomeTextKeys = _.keys(incomes);
-  const expenseTextKeys = _.keys(expenses);
-  const otherTextKeys = _.keys(others);
+  const incomeTextKeys = Object.keys(incomes);
+  const expenseTextKeys = Object.keys(expenses);
+  const otherTextKeys = Object.keys(others);
 
   const incomeTotalByTextKeys = cashflowFunction.aggregateTotalByTextKeys(data, incomes);
   const expenseTotalByTextKeys = cashflowFunction.aggregateTotalByTextKeys(data, expenses);

--- a/server/controllers/finance/reports/client_debts/index.js
+++ b/server/controllers/finance/reports/client_debts/index.js
@@ -22,12 +22,12 @@ const SUPPORT_TRANSACTION_TYPE = 4;
  */
 async function report(req, res, next) {
   try {
-    const qs = _.clone(req.query);
+    const qs = structuredClone(req.query);
     _.extend(qs, { filename : 'REPORT.CLIENT_SUMMARY.TITLE' });
 
     const groupUuid = db.bid(req.query.group_uuid);
     const showDetails = parseInt(req.query.shouldShowDebtsDetails, 10);
-    const metadata = _.clone(req.session);
+    const metadata = structuredClone(req.session);
 
     const rpt = new ReportManager(TEMPLATE, metadata, qs);
 

--- a/server/controllers/finance/reports/client_support/index.js
+++ b/server/controllers/finance/reports/client_support/index.js
@@ -27,7 +27,7 @@ async function report(req, res, next) {
     const showEmployeeSupport = parseInt(req.query.shouldShowEmployeeSupport, 10);
     const showOtherSupport = parseInt(req.query.shouldShowOtherSupport, 10);
     const showDetails = parseInt(req.query.shouldShowDetails, 10);
-    const metadata = _.clone(req.session);
+    const metadata = structuredClone(req.session);
 
     const rpt = new ReportManager(TEMPLATE, metadata, qs);
 

--- a/server/controllers/finance/reports/configurable_analysis_report/index.js
+++ b/server/controllers/finance/reports/configurable_analysis_report/index.js
@@ -270,7 +270,7 @@ async function report(req, res) {
     db.exec(sqlBalanceAccounts, paramFilter),
     db.exec(sqlOpeningBalanceSheet, paramFilterOpening)];
 
-  const [balance, openingBalance] = Promise.all(gettingBalanceAccount);
+  const [balance, openingBalance] = await Promise.all(gettingBalanceAccount);
 
   data.config.forEach(config => {
     config.displayLabel = 'FORM.LABELS.BALANCE';
@@ -341,7 +341,7 @@ async function report(req, res) {
 
     t.report = [];
     data.config.forEach(cfg => {
-      if (t.id === cfg.analysis_tool_t_id) {
+      if (t.id === cfg.analysis_tool_type_id) {
         t.totalDebit += cfg.sumDebit;
         t.totalCredit += cfg.sumCredit;
         t.totalBalance += cfg.sumBalance;

--- a/server/controllers/finance/reports/configurable_analysis_report/index.js
+++ b/server/controllers/finance/reports/configurable_analysis_report/index.js
@@ -1,4 +1,3 @@
-const _ = require('lodash');
 const db = require('../../../../lib/db');
 const ReportManager = require('../../../../lib/ReportManager');
 const NotFound = require('../../../../lib/errors/NotFound');
@@ -22,10 +21,9 @@ const DEFAULT_PARAMS = {
  * @description
  *
  */
-function report(req, res, next) {
-  const params = req.query;
+async function report(req, res) {
+  const params = { ...DEFAULT_PARAMS, ...req.query };
   const data = {};
-  let reporting;
 
   data.period = {
     start_date : new Date(params.start_date),
@@ -41,7 +39,9 @@ function report(req, res, next) {
 
   // convert cashboxesIds parameters in array format ['', '', ...]
   // this parameter can be sent as a string or an array we force the conversion into an array
-  const cashboxesIds = _.values(req.query.cashboxesIds);
+  const cashboxesIds = typeof req.query.cashboxesIds === 'string'
+    ? req.query.cashboxesIds.split(',')
+    : req.query.cashboxesIds;
 
   data.options = {
     display_account_details : parseInt(params.hide_account_details, 10),
@@ -51,67 +51,57 @@ function report(req, res, next) {
   params.start_date = new Date(params.start_date);
   data.currencyId = params.currency_id;
 
-  _.defaults(params, DEFAULT_PARAMS);
+  const reporting = new ReportManager(TEMPLATE, req.session, params);
 
-  try {
-    reporting = new ReportManager(TEMPLATE, req.session, params);
-  } catch (e) {
-    next(e);
-    return;
-  }
+  const rows = await cashboxes.getCashboxesDetails(cashboxesIds);
+  const getOpening = [];
+  data.cashboxes = rows;
+  data.cashboxes.forEach(cash => {
+    getOpening.push(AccountExtras.getOpeningBalanceForDate(cash.account_id, data.period.end_date));
+  });
 
-  cashboxes.getCashboxesDetails(cashboxesIds)
-    .then(rows => {
-      const getOpening = [];
-      data.cashboxes = rows;
-      data.cashboxes.forEach(cash => {
-        getOpening.push(AccountExtras.getOpeningBalanceForDate(cash.account_id, data.period.end_date));
-      });
+  const cashBoxOpeningBalances = await Promise.all(getOpening);
+  data.cashboxesAggregate = {
+    debit : 0,
+    credit : 0,
+    balance : 0,
+  };
 
-      return Promise.all(getOpening);
-    })
-    .then(cashBoxOpeningBalances => {
-      data.cashboxesAggregate = {
-        debit : 0,
-        credit : 0,
-        balance : 0,
-      };
+  data.cashboxes.forEach(cash => {
+    cash.debit = 0;
+    cash.credit = 0;
+    cash.balance = 0;
 
-      data.cashboxes.forEach(cash => {
-        cash.debit = 0;
-        cash.credit = 0;
-        cash.balance = 0;
+    cashBoxOpeningBalances.forEach(opening => {
+      if (cash.account_id === opening.accountId) {
+        cash.debit = opening.debit;
+        cash.credit = opening.credit;
+        cash.balance = opening.balance;
+      }
+    });
+  });
 
-        cashBoxOpeningBalances.forEach(opening => {
-          if (cash.account_id === opening.accountId) {
-            cash.debit = opening.debit;
-            cash.credit = opening.credit;
-            cash.balance = opening.balance;
-          }
-        });
-      });
+  data.cashboxes.forEach(cash => {
+    data.cashboxesAggregate.debit += parseFloat(cash.debit);
+    data.cashboxesAggregate.credit += parseFloat(cash.credit);
+    data.cashboxesAggregate.balance += parseFloat(cash.balance);
+  });
 
-      data.cashboxes.forEach(cash => {
-        data.cashboxesAggregate.debit += parseFloat(cash.debit);
-        data.cashboxesAggregate.credit += parseFloat(cash.credit);
-        data.cashboxesAggregate.balance += parseFloat(cash.balance);
-      });
-
-      const sqlType = `
+  const sqlType = `
         SELECT tt.id, tt.label, tt.is_balance_sheet, tt.rank,
         NOT(tt.is_balance_sheet) is_income_expense
         FROM analysis_tool_type tt
         ORDER BY tt.rank ASC
       `;
 
-      const sqlConfig = `
+  const sqlConfig = `
         SELECT id, account_reference_id, label,
         analysis_tool_type_id
         FROM configuration_analysis_tools
         ORDER BY label ASC
       `;
 
-      const sqlReferences = `
+  const sqlReferences = `
         SELECT at.id, at.account_reference_id,
         a.number, a.label, ari.is_exception,
         at.analysis_tool_type_id
@@ -122,96 +112,120 @@ function report(req, res, next) {
         ORDER BY a.label ASC
       `;
 
-      const promises = [
-        db.exec(sqlType),
-        db.exec(sqlConfig),
-        db.exec(sqlReferences)];
+  const promises = [
+    db.exec(sqlType),
+    db.exec(sqlConfig),
+    db.exec(sqlReferences)];
 
-      return Promise.all(promises);
-    })
-    .then(([type, config, dataConfig]) => {
-      data.type = type;
-      data.config = config;
-      data.dataConfig = dataConfig;
-      data.provisionary = params.includeUnpostedValues;
+  const [ptype, pconfig, pdataConfig] = await Promise.all(promises);
 
-      const checkConfiguration = (data.type.length && data.config.length && data.dataConfig.length);
+  data.type = ptype;
+  data.config = pconfig;
+  data.dataConfig = pdataConfig;
+  data.provisionary = params.includeUnpostedValues;
 
-      if (!checkConfiguration) {
-        throw new NotFound(`The necessary configurations are missing`);
-      }
+  const checkConfiguration = (data.type.length && data.config.length && data.dataConfig.length);
 
-      const dbPromises = [];
-      const accountsNumber = dataConfig.map(row => row.number);
+  if (!checkConfiguration) {
+    throw new NotFound(`The necessary configurations are missing`);
+  }
 
-      accountsNumber.forEach(item => {
-        const sqlGetAccounts = `
+  const dbPromises = [];
+  const accountsNumber = pdataConfig.map(row => row.number);
+
+  accountsNumber.forEach(item => {
+    const sqlGetAccounts = `
           SELECT a.id, a.number
           FROM account AS a
           WHERE a.number LIKE '${item}%' AND a.type_id <> 6;
         `;
-        dbPromises.push(db.exec(sqlGetAccounts));
-      });
+    dbPromises.push(db.exec(sqlGetAccounts));
+  });
 
-      return Promise.all(dbPromises);
-    })
-    .then(accountsFound => {
-      const accountReferences = [];
-      accountsFound.forEach(account => {
-        account.forEach(item => {
-          accountReferences.push(item.id);
-        });
-      });
+  const accountsFound = await Promise.all(dbPromises);
+  const accountReferences = [];
+  accountsFound.forEach(account => {
+    account.forEach(item => {
+      accountReferences.push(item.id);
+    });
+  });
 
-      const paramsGeneralLedger = [
-        data.period.start_date,
-        data.period.end_date,
-        data.period.start_date,
-        data.period.start_date,
-        data.period.start_date,
-      ];
+  const paramsGeneralLedger = [
+    data.period.start_date,
+    data.period.end_date,
+    data.period.start_date,
+    data.period.start_date,
+    data.period.start_date,
+  ];
 
-      const paramsCombinedLedger = [
-        data.period.start_date,
-        data.period.end_date,
-        accountReferences,
-        data.period.start_date,
-        data.period.start_date,
-        data.period.start_date,
-        data.period.start_date,
-        data.period.end_date,
-        accountReferences,
-        data.period.start_date,
-        data.period.start_date,
-        data.period.start_date,
-      ];
+  const paramsCombinedLedger = [
+    data.period.start_date,
+    data.period.end_date,
+    accountReferences,
+    data.period.start_date,
+    data.period.start_date,
+    data.period.start_date,
+    data.period.start_date,
+    data.period.end_date,
+    accountReferences,
+    data.period.start_date,
+    data.period.start_date,
+    data.period.start_date,
+  ];
 
-      const paramFilterOpening = [
-        data.period.start_date,
-        data.period.fiscal_year_id,
-        accountReferences,
-      ];
+  const paramFilterOpening = [
+    data.period.start_date,
+    data.period.fiscal_year_id,
+    accountReferences,
+  ];
 
-      const sqlOpeningBalanceSheet = `
-        SELECT (a.id) AS account_id, a.number, p.translate_key, a.label, SUM(pt.debit) AS debit,
-        SUM(pt.credit) AS credit, SUM(pt.debit - pt.credit) AS balance
-        FROM period_total AS pt
-        JOIN period AS p ON p.id = pt.period_id
-        JOIN account AS a ON a.id = pt.account_id
-        WHERE (DATE(p.end_date) < DATE(?) OR p.number = 0) AND pt.fiscal_year_id = ?
-        AND a.type_id <= 3 AND a.id IN (?)
-        GROUP BY a.number;
-      `;
+  const sqlOpeningBalanceSheet = `
+    SELECT (a.id) AS account_id, a.number, p.translate_key, a.label, SUM(pt.debit) AS debit,
+    SUM(pt.credit) AS credit, SUM(pt.debit - pt.credit) AS balance
+    FROM period_total AS pt
+    JOIN period AS p ON p.id = pt.period_id
+    JOIN account AS a ON a.id = pt.account_id
+    WHERE (DATE(p.end_date) < DATE(?) OR p.number = 0) AND pt.fiscal_year_id = ?
+    AND a.type_id <= 3 AND a.id IN (?)
+    GROUP BY a.number;
+  `;
 
-      const sqlGeneralLedger = `
-        SELECT a.number, a.label, gl.account_id, SUM(gl.debit_equiv) AS debit, SUM(gl.credit_equiv) AS credit,
-        SUM(gl.debit_equiv - gl.credit_equiv) AS balance,
-        gl.record_uuid, gl.trans_date
-        FROM general_ledger AS gl
-        JOIN account AS a ON a.id = gl.account_id
-        WHERE DATE(gl.trans_date) >= DATE(?) AND DATE(gl.trans_date) <= DATE(?)
-        AND gl.transaction_type_id <> 10
-        AND gl.record_uuid NOT IN (
+  const sqlGeneralLedger = `
+    SELECT a.number, a.label, gl.account_id, SUM(gl.debit_equiv) AS debit, SUM(gl.credit_equiv) AS credit,
+    SUM(gl.debit_equiv - gl.credit_equiv) AS balance,
+    gl.record_uuid, gl.trans_date
+    FROM general_ledger AS gl
+    JOIN account AS a ON a.id = gl.account_id
+    WHERE DATE(gl.trans_date) >= DATE(?) AND DATE(gl.trans_date) <= DATE(?)
+    AND gl.transaction_type_id <> 10
+    AND gl.record_uuid NOT IN (
+      SELECT rev.uuid
+      FROM (
+          SELECT v.uuid FROM voucher v WHERE v.reversed = 1
+          AND DATE(v.date) >= DATE(?)
+        UNION
+          SELECT c.uuid FROM cash c WHERE c.reversed = 1
+          AND DATE(c.date) >= DATE(?)
+        UNION
+          SELECT i.uuid FROM invoice i WHERE i.reversed = 1
+          AND DATE(i.date) >= DATE(?)
+      ) AS rev
+    )
+    GROUP BY gl.account_id
+    ORDER BY a.number ASC, a.label
+  `;
+
+  const sqlCombinedLedger = `
+    SELECT a.number, a.label, cl.account_id, SUM(cl.debit) AS debit, SUM(cl.credit) AS credit,
+    SUM(cl.debit - cl.credit) AS balance, cl.record_uuid, cl.trans_date
+    FROM
+    (
+      SELECT gl.account_id, gl.debit_equiv AS debit, gl.credit_equiv AS credit, gl.record_uuid, gl.trans_date
+      FROM general_ledger AS gl
+      WHERE DATE(gl.trans_date) >= DATE(?) AND DATE(gl.trans_date) <= DATE(?)
+      AND gl.account_id iN (?)
+      AND gl.transaction_type_id <> 10
+      AND gl.record_uuid NOT IN (
           SELECT rev.uuid
           FROM (
               SELECT v.uuid FROM voucher v WHERE v.reversed = 1
@@ -224,154 +238,120 @@ function report(req, res, next) {
               AND DATE(i.date) >= DATE(?)
           ) AS rev
         )
-        GROUP BY gl.account_id
-        ORDER BY a.number ASC, a.label
-      `;
+        UNION
+        SELECT ps.account_id, ps.debit_equiv AS debit, ps.credit_equiv AS credit, ps.record_uuid, ps.trans_date
+        FROM posting_journal AS ps
+        WHERE DATE(ps.trans_date) >= DATE(?) AND DATE(ps.trans_date) <= DATE(?)
+        AND ps.account_id iN (?)
+        AND ps.transaction_type_id <> 10
+        AND ps.record_uuid NOT IN (
+            SELECT rev.uuid
+            FROM (
+                SELECT v.uuid FROM voucher v WHERE v.reversed = 1
+                AND DATE(v.date) >= DATE(?)
+              UNION
+                SELECT c.uuid FROM cash c WHERE c.reversed = 1
+                AND DATE(c.date) >= DATE(?)
+              UNION
+                SELECT i.uuid FROM invoice i WHERE i.reversed = 1
+                AND DATE(i.date) >= DATE(?)
+            ) AS rev
+          )
+    ) AS cl
+    JOIN account AS a ON a.id = cl.account_id
+      GROUP BY cl.account_id
+      ORDER BY a.number ASC, a.label
+  `;
 
-      const sqlCombinedLedger = `
-        SELECT a.number, a.label, cl.account_id, SUM(cl.debit) AS debit, SUM(cl.credit) AS credit,
-        SUM(cl.debit - cl.credit) AS balance, cl.record_uuid, cl.trans_date
-        FROM
-        (
-          SELECT gl.account_id, gl.debit_equiv AS debit, gl.credit_equiv AS credit, gl.record_uuid, gl.trans_date
-          FROM general_ledger AS gl
-          WHERE DATE(gl.trans_date) >= DATE(?) AND DATE(gl.trans_date) <= DATE(?)
-          AND gl.account_id iN (?)
-          AND gl.transaction_type_id <> 10
-          AND gl.record_uuid NOT IN (
-              SELECT rev.uuid
-              FROM (
-                  SELECT v.uuid FROM voucher v WHERE v.reversed = 1
-                  AND DATE(v.date) >= DATE(?)
-                UNION
-                  SELECT c.uuid FROM cash c WHERE c.reversed = 1
-                  AND DATE(c.date) >= DATE(?)
-                UNION
-                  SELECT i.uuid FROM invoice i WHERE i.reversed = 1
-                  AND DATE(i.date) >= DATE(?)
-              ) AS rev
-            )
-            UNION
-            SELECT ps.account_id, ps.debit_equiv AS debit, ps.credit_equiv AS credit, ps.record_uuid, ps.trans_date
-            FROM posting_journal AS ps
-            WHERE DATE(ps.trans_date) >= DATE(?) AND DATE(ps.trans_date) <= DATE(?)
-            AND ps.account_id iN (?)
-            AND ps.transaction_type_id <> 10
-            AND ps.record_uuid NOT IN (
-                SELECT rev.uuid
-                FROM (
-                    SELECT v.uuid FROM voucher v WHERE v.reversed = 1
-                    AND DATE(v.date) >= DATE(?)
-                  UNION
-                    SELECT c.uuid FROM cash c WHERE c.reversed = 1
-                    AND DATE(c.date) >= DATE(?)
-                  UNION
-                    SELECT i.uuid FROM invoice i WHERE i.reversed = 1
-                    AND DATE(i.date) >= DATE(?)
-                ) AS rev
-              )
-        ) AS cl
-        JOIN account AS a ON a.id = cl.account_id
-          GROUP BY cl.account_id
-          ORDER BY a.number ASC, a.label
-      `;
+  const sqlBalanceAccounts = params.includeUnpostedValues ? sqlCombinedLedger : sqlGeneralLedger;
+  const paramFilter = params.includeUnpostedValues ? paramsCombinedLedger : paramsGeneralLedger;
 
-      const sqlBalanceAccounts = params.includeUnpostedValues ? sqlCombinedLedger : sqlGeneralLedger;
-      const paramFilter = params.includeUnpostedValues ? paramsCombinedLedger : paramsGeneralLedger;
+  const gettingBalanceAccount = [
+    db.exec(sqlBalanceAccounts, paramFilter),
+    db.exec(sqlOpeningBalanceSheet, paramFilterOpening)];
 
-      const gettingBalanceAccount = [
-        db.exec(sqlBalanceAccounts, paramFilter),
-        db.exec(sqlOpeningBalanceSheet, paramFilterOpening)];
+  const [balance, openingBalance] = Promise.all(gettingBalanceAccount);
 
-      return Promise.all(gettingBalanceAccount);
-    })
-    .then(([balance, openingBalance]) => {
+  data.config.forEach(config => {
+    config.displayLabel = 'FORM.LABELS.BALANCE';
 
-      data.config.forEach(config => {
-        config.displayLabel = 'FORM.LABELS.BALANCE';
+    config.balance = [];
+    config.sumDebit = 0;
+    config.sumCredit = 0;
+    config.sumBalance = 0;
+    config.sumOpenBalance = 0;
+    config.sumFinalBalance = 0;
 
-        config.balance = [];
-        config.sumDebit = 0;
-        config.sumCredit = 0;
-        config.sumBalance = 0;
-        config.sumOpenBalance = 0;
-        config.sumFinalBalance = 0;
+    balance.forEach(item => {
+      item.openingDebit = 0;
+      item.openingCredit = 0;
+      item.openingBalance = 0;
+      openingBalance.forEach(opening => {
+        if (item.account_id === opening.account_id) {
+          item.openingDebit = opening.debit;
+          item.openingCredit = opening.credit;
+          item.openingBalance = opening.balance;
+        }
+      });
+    });
 
-        balance.forEach(item => {
-          item.openingDebit = 0;
-          item.openingCredit = 0;
-          item.openingBalance = 0;
-          openingBalance.forEach(opening => {
-            if (item.account_id === opening.account_id) {
-              item.openingDebit = opening.debit;
-              item.openingCredit = opening.credit;
-              item.openingBalance = opening.balance;
-            }
-          });
-        });
+    balance.forEach(item => {
+      const accountNumber = item.number.toString();
+      let checkIncluded = true;
+      let checkValidy = false;
 
-        balance.forEach(item => {
-          const accountNumber = item.number.toString();
-          let checkIncluded = true;
-          let checkValidy = false;
+      data.dataConfig.forEach(dataCfg => {
+        const checkAccountStartsWith = accountNumber.startsWith(dataCfg.number);
+        if (config.id === dataCfg.id && dataCfg.is_exception && checkAccountStartsWith) {
+          checkIncluded = false;
+        }
 
-          data.dataConfig.forEach(dataConfig => {
-            const checkAccountStartsWith = accountNumber.startsWith(dataConfig.number);
-            if (config.id === dataConfig.id && dataConfig.is_exception && checkAccountStartsWith) {
-              checkIncluded = false;
-            }
-
-            if (config.id === dataConfig.id && !dataConfig.is_exception && checkAccountStartsWith) {
-              checkValidy = true;
-            }
-          });
-
-          if (checkIncluded && checkValidy) {
-            if (item.openingBalance) {
-              item.openingBalanceDebCred = item.openingBalance;
-              item.finalBalanceDebCred = item.openingBalanceDebCred + item.balance;
-
-              config.sumOpenBalance += item.openingBalanceDebCred;
-              config.sumFinalBalance += item.finalBalanceDebCred;
-            } else {
-              item.finalBalanceDebCred = item.balance;
-              config.sumFinalBalance += item.balance;
-            }
-
-            config.sumDebit += item.debit;
-            config.sumCredit += item.credit;
-            config.sumBalance += item.balance;
-
-            config.balance.push(item);
-          }
-        });
+        if (config.id === dataCfg.id && !dataCfg.is_exception && checkAccountStartsWith) {
+          checkValidy = true;
+        }
       });
 
-      data.type.forEach(type => {
-        type.totalDebit = 0;
-        type.totalCredit = 0;
-        type.totalBalance = 0;
-        type.totalOpenBalance = 0;
-        type.totalFinalBalance = 0;
+      if (checkIncluded && checkValidy) {
+        if (item.openingBalance) {
+          item.openingBalanceDebCred = item.openingBalance;
+          item.finalBalanceDebCred = item.openingBalanceDebCred + item.balance;
 
-        type.report = [];
-        data.config.forEach(config => {
-          if (type.id === config.analysis_tool_type_id) {
-            type.totalDebit += config.sumDebit;
-            type.totalCredit += config.sumCredit;
-            type.totalBalance += config.sumBalance;
-            type.totalOpenBalance += config.sumOpenBalance;
-            type.totalFinalBalance += config.sumFinalBalance;
-            type.report.push(config);
-          }
-        });
-      });
+          config.sumOpenBalance += item.openingBalanceDebCred;
+          config.sumFinalBalance += item.finalBalanceDebCred;
+        } else {
+          item.finalBalanceDebCred = item.balance;
+          config.sumFinalBalance += item.balance;
+        }
 
-      return reporting.render(data);
-    })
-    .then(result => {
-      res.set(result.headers).send(result.report);
-    })
-    .catch(next);
+        config.sumDebit += item.debit;
+        config.sumCredit += item.credit;
+        config.sumBalance += item.balance;
 
+        config.balance.push(item);
+      }
+    });
+  });
+
+  data.type.forEach(t => {
+    t.totalDebit = 0;
+    t.totalCredit = 0;
+    t.totalBalance = 0;
+    t.totalOpenBalance = 0;
+    t.totalFinalBalance = 0;
+
+    t.report = [];
+    data.config.forEach(cfg => {
+      if (t.id === cfg.analysis_tool_t_id) {
+        t.totalDebit += cfg.sumDebit;
+        t.totalCredit += cfg.sumCredit;
+        t.totalBalance += cfg.sumBalance;
+        t.totalOpenBalance += cfg.sumOpenBalance;
+        t.totalFinalBalance += cfg.sumFinalBalance;
+        t.report.push(cfg);
+      }
+    });
+  });
+
+  const result = await reporting.render(data);
+  res.set(result.headers).send(result.report);
 }

--- a/server/controllers/finance/reports/cost_center_step_down/accounts_report.js
+++ b/server/controllers/finance/reports/cost_center_step_down/accounts_report.js
@@ -97,10 +97,7 @@ async function buildAccountsReport(params, session) {
   return report.render(context);
 }
 
-function costCenterByAccountsReport(req, res, next) {
-  buildAccountsReport(req.query, req.session)
-    .then((result) => {
-      res.set(result.headers).send(result.report);
-    })
-    .catch(next);
+async function costCenterByAccountsReport(req, res) {
+  const result = await buildAccountsReport(req.query, req.session);
+  res.set(result.headers).send(result.report);
 }

--- a/server/controllers/finance/reports/cost_center_step_down/income_and_expense.js
+++ b/server/controllers/finance/reports/cost_center_step_down/income_and_expense.js
@@ -91,10 +91,7 @@ async function buildAccountsReport(params, session) {
   return report.render(context);
 }
 
-function incomeAndExpenseReport(req, res, next) {
-  buildAccountsReport(req.query, req.session)
-    .then((result) => {
-      res.set(result.headers).send(result.report);
-    })
-    .catch(next);
+async function incomeAndExpenseReport(req, res) {
+  const result = await buildAccountsReport(req.query, req.session);
+  res.set(result.headers).send(result.report);
 }

--- a/server/controllers/finance/reports/cost_center_step_down/index.js
+++ b/server/controllers/finance/reports/cost_center_step_down/index.js
@@ -34,10 +34,7 @@ async function buildReport(params, session) {
   return report.render(context);
 }
 
-function document(req, res, next) {
-  buildReport(req.query, req.session)
-    .then((result) => {
-      res.set(result.headers).send(result.report);
-    })
-    .catch(next);
+async function document(req, res) {
+  const result = await buildReport(req.query, req.session);
+  res.set(result.headers).send(result.report);
 }

--- a/server/controllers/finance/reports/creditors/index.js
+++ b/server/controllers/finance/reports/creditors/index.js
@@ -28,38 +28,19 @@ const DEFAULT_OPTIONS = {
  * @description
  * The HTTP interface which actually creates the report.
  */
-function agedCreditorReport(req, res, next) {
-  const qs = _.extend(req.query, DEFAULT_OPTIONS);
-  const metadata = _.clone(req.session);
+async function agedCreditorReport(req, res) {
+  const qs = { ...DEFAULT_OPTIONS, ...req.query };
+  const metadata = { ...req.session };
 
-  let report;
-
-  try {
-    report = new ReportManager(TEMPLATE, metadata, qs);
-  } catch (e) {
-    next(e);
-    return;
-  }
-
-  const sql = `
-    SELECT end_date FROM period WHERE id = ?;
-  `;
-
-  db.one(sql, [qs.period_id])
-    .then(period => {
-      qs.date = period.end_date;
-      qs.enterprise_id = metadata.enterprise.id;
-      // fire the SQL for the report
-      return queryContext(qs);
-    })
-    .then(data => {
-      return report.render(data);
-    })
-    .then(result => {
-      res.set(result.headers).send(result.report);
-    })
-    .catch(next);
-
+  const report = new ReportManager(TEMPLATE, metadata, qs);
+  const sql = `SELECT end_date FROM period WHERE id = ?;`;
+  const period = await db.one(sql, [qs.period_id]);
+  qs.date = period.end_date;
+  qs.enterprise_id = metadata.enterprise.id;
+  // fire the SQL for the report
+  const data = await queryContext(qs);
+  const result = await report.render(data);
+  res.set(result.headers).send(result.report);
 }
 
 /**

--- a/server/controllers/finance/reports/debtors/annual_clients_report.js
+++ b/server/controllers/finance/reports/debtors/annual_clients_report.js
@@ -1,5 +1,3 @@
-const _ = require('lodash');
-
 const ReportManager = require('../../../../lib/ReportManager');
 const db = require('../../../../lib/db');
 const Fiscal = require('../../fiscal');
@@ -157,21 +155,17 @@ async function setupAnnualClientsReport(options, enterprise) {
  * @description
  * The HTTP interface which actually creates the report.
  */
-async function annualClientsReport(req, res, next) {
-  const options = _.extend(req.query, {
+async function annualClientsReport(req, res) {
+  const options = Object.assign(req.query, {
     filename : 'REPORT.CLIENTS.TITLE',
     orientation : 'portrait',
     csvKey   : 'rows',
   });
 
-  try {
-    const reportManager = new ReportManager(TEMPLATE, req.session, options);
-    const data = await setupAnnualClientsReport(req.query, req.session.enterprise);
-    const { headers, report } = await reportManager.render(data);
-    res.set(headers).send(report);
-  } catch (e) {
-    next(e);
-  }
+  const reportManager = new ReportManager(TEMPLATE, req.session, options);
+  const data = await setupAnnualClientsReport(req.query, req.session.enterprise);
+  const { headers, report } = await reportManager.render(data);
+  res.set(headers).send(report);
 }
 
 /**
@@ -181,11 +175,12 @@ async function annualClientsReport(req, res, next) {
  * @param {*} session the session
  */
 async function reporting(options, session) {
-  const params = _.extend({}, options, {
+  const params = {
+    ...options,
     filename : 'REPORT.CLIENTS.TITLE',
     orientation : 'portrait',
     csvKey   : 'rows',
-  });
+  };
 
   const report = new ReportManager(TEMPLATE, session, params);
   const data = await setupAnnualClientsReport(params, session.enterprise.currency_id);

--- a/server/controllers/finance/reports/debtors/index.js
+++ b/server/controllers/finance/reports/debtors/index.js
@@ -38,7 +38,7 @@ const DEFAULT_OPTIONS = {
 function agedDebtorReport(req, res, next) {
   const qs = _.extend(req.query, DEFAULT_OPTIONS);
 
-  const metadata = _.clone(req.session);
+  const metadata = structuredClone(req.session);
 
   let report;
 
@@ -82,7 +82,7 @@ async function queryContext(params = {}) {
   const useMonthGrouping = Boolean(Number(params.useMonthGrouping));
 
   // format the dates for MySQL escape
-  const dates = _.fill(Array(5), params.date);
+  const dates = Array(5).fill(params.date);
   const data = {};
   const currencyId = db.escape(params.currency_id);
   const enterpriseId = db.escape(params.enterprise_id);

--- a/server/controllers/finance/reports/debtors/openDebtors.js
+++ b/server/controllers/finance/reports/debtors/openDebtors.js
@@ -30,7 +30,6 @@
  * in the HTTP query string.
  */
 
-const _ = require('lodash');
 const ReportManager = require('../../../../lib/ReportManager');
 const db = require('../../../../lib/db');
 const Exchange = require('../../exchange');
@@ -57,7 +56,7 @@ async function build(req, res) {
     filename : 'REPORT.OPEN_DEBTORS.TREE',
     csvKey : 'debtors',
   };
-  const metadata = _.clone(req.session);
+  const metadata = structuredClone(req.session);
 
   qs.enterpriseId = metadata.enterprise.id;
   qs.enterpriseCurrencySymbol = metadata.enterprise.currencySymbol;

--- a/server/controllers/finance/reports/debtors/summaryReport.handlebars
+++ b/server/controllers/finance/reports/debtors/summaryReport.handlebars
@@ -55,7 +55,7 @@
              {{#each inventoryGroups as | s |}}
                 <td class="text-right">{{ currency s.total ../metadata.enterprise.currency_id}}</td>
             {{/each}}
-            <td>{{currency gobalSum ../metadata.enterprise.currency_id}}</td>
+            <td>{{currency globalSum ../metadata.enterprise.currency_id}}</td>
         </tfoot>
       </table>
     </section>

--- a/server/controllers/finance/reports/debtors/summaryReport.js
+++ b/server/controllers/finance/reports/debtors/summaryReport.js
@@ -30,7 +30,7 @@ async function summaryReport(req, res, next) {
     const qs = _.extend(req.query, DEFAULT_OPTIONS);
     const { dateFrom, dateTo } = req.query;
     const groupUuid = req.query.group_uuid;
-    const metadata = _.clone(req.session);
+    const metadata = structuredClone(req.session);
 
     const report = new ReportManager(TEMPLATE, metadata, qs);
 
@@ -82,7 +82,7 @@ async function summaryReport(req, res, next) {
     // let loop each invoice  attribute each invoice item to it inventoryGroup
     Object.keys(invoicesList).forEach(invKey => {
       const invItems = invoicesList[invKey];
-      const record = { inventoryGroups : _.clone(emptyArray) };
+      const record = { inventoryGroups : structuredClone(emptyArray) };
       invItems.forEach(item => {
         record.date = item.date;
         record.invRef = item.invRef;

--- a/server/controllers/finance/reports/invoices/index.js
+++ b/server/controllers/finance/reports/invoices/index.js
@@ -151,9 +151,9 @@ async function receipt(req, res) {
     invoiceResponse.exchangedTotal = _.round(invoiceResponse.cost * invoiceResponse.exchange);
   }
 
-  const invoiceBalance = await (balanceOnInvoiceReceipt
-    ? Debtors.invoiceBalances(invoiceResponse.debtor_uuid, [invoiceUuid])
-    : []);
+  const invoiceBalance = balanceOnInvoiceReceipt
+    ? await Debtors.invoiceBalances(invoiceResponse.debtor_uuid, [invoiceUuid])
+    : [];
 
   if (invoiceBalance.length > 0) {
     [invoiceResponse.invoiceBalance] = invoiceBalance;

--- a/server/controllers/finance/reports/invoices/index.js
+++ b/server/controllers/finance/reports/invoices/index.js
@@ -43,7 +43,7 @@ exports.reporting = reporting;
  */
 async function report(req, res, next) {
   try {
-    const query = _.clone(req.query);
+    const query = structuredClone(req.query);
 
     const result = await reporting(query, req.session);
     res.set(result.headers).send(result.report);

--- a/server/controllers/finance/reports/monthly_balance/index.js
+++ b/server/controllers/finance/reports/monthly_balance/index.js
@@ -126,12 +126,9 @@ async function reporting(opts, session) {
   return report.render(context);
 }
 
-function document(req, res, next) {
-  reporting(req.query, req.session)
-    .then((result) => {
-      res.set(result.headers).send(result.report);
-    })
-    .catch(next);
+async function document(req, res) {
+  const result = await reporting(req.query, req.session);
+  res.set(result.headers).send(result.report);
 }
 
 function selectAccountParent(account) {

--- a/server/controllers/finance/reports/ohada_balance_sheet/index.js
+++ b/server/controllers/finance/reports/ohada_balance_sheet/index.js
@@ -59,7 +59,7 @@ async function reporting(options, session) {
   const previousConditionalReferences = fiscalYear.previous.period_id
     ? conditionalReferences.compute(fiscalYear.previous.period_id) : [];
 
-  const [currentData, previousData, currentConditional, previousConditional] = Promise.all([
+  const [currentData, previousData, currentConditional, previousConditional] = await Promise.all([
     currentPeriodReferences,
     previousPeriodReferences,
     currentConditionalReferences,

--- a/server/controllers/finance/reports/operating/index.js
+++ b/server/controllers/finance/reports/operating/index.js
@@ -148,10 +148,7 @@ function formatData(result, total, decimalPrecision) {
   });
 }
 
-function document(req, res, next) {
-  reporting(req.query, req.session)
-    .then((result) => {
-      res.set(result.headers).send(result.report);
-    })
-    .catch(next);
+async function document(req, res) {
+  const result = await reporting(req.query, req.session);
+  res.set(result.headers).send(result.report);
 }

--- a/server/controllers/finance/reports/purchases/index.js
+++ b/server/controllers/finance/reports/purchases/index.js
@@ -26,8 +26,8 @@ exports.reportDetailed = reportDetailed;
  * Build a report for Purchase Registry report of metadata
  *
  */
-async function report(req, res, next) {
-  const query = _.clone(req.query);
+async function report(req, res) {
+  const query = { ...req.query };
   const filters = shared.formatFilters(req.query);
 
   _.extend(query, {
@@ -36,14 +36,10 @@ async function report(req, res, next) {
     orientation : 'landscape',
   });
 
-  try {
-    const reportInstance = new ReportManager(REPORT_TEMPLATE, req.session, query);
-    const rows = await Purchases.find(query);
-    const result = await reportInstance.render({ filters, rows });
-    res.set(result.headers).send(result.report);
-  } catch (e) {
-    next(e);
-  }
+  const reportInstance = new ReportManager(REPORT_TEMPLATE, req.session, query);
+  const rows = await Purchases.find(query);
+  const result = await reportInstance.render({ filters, rows });
+  res.set(result.headers).send(result.report);
 }
 
 /**
@@ -53,8 +49,8 @@ async function report(req, res, next) {
  * Build a report detailed for Purchase Registry report of metadata
  *
  */
-async function reportDetailed(req, res, next) {
-  const query = _.clone(req.query);
+async function reportDetailed(req, res) {
+  const query = { ...req.query };
   const filters = shared.formatFilters(req.query);
 
   _.extend(query, {
@@ -63,12 +59,8 @@ async function reportDetailed(req, res, next) {
     orientation : 'landscape',
   });
 
-  try {
-    const reportInstance = new ReportManager(REPORT_TEMPLATE_DETAILED, req.session, query);
-    const rows = await Purchases.findDetailed(query);
-    const result = await reportInstance.render({ filters, rows });
-    res.set(result.headers).send(result.report);
-  } catch (e) {
-    next(e);
-  }
+  const reportInstance = new ReportManager(REPORT_TEMPLATE_DETAILED, req.session, query);
+  const rows = await Purchases.findDetailed(query);
+  const result = await reportInstance.render({ filters, rows });
+  res.set(result.headers).send(result.report);
 }

--- a/server/controllers/finance/reports/realized_profit/index.js
+++ b/server/controllers/finance/reports/realized_profit/index.js
@@ -24,40 +24,39 @@ const DEFAULT_OPTIONS = {
  * @description
  * The HTTP interface which actually creates the report.
  */
-async function report(req, res, next) {
-  try {
-    const qs = _.extend(req.query, DEFAULT_OPTIONS);
-    const { dateFrom, dateTo } = req.query;
-    const showRemainDetails = parseInt(req.query.shouldShowRemainDetails, 10);
-    const showPaidDetails = parseInt(req.query.shouldShowPaidDetails, 10);
-    const showInvoicedDetails = parseInt(req.query.shouldShowInvoicedDetails, 10);
-    const metadata = structuredClone(req.session);
+async function report(req, res) {
+  const qs = _.extend(req.query, DEFAULT_OPTIONS);
+  const { dateFrom, dateTo } = req.query;
+  const showRemainDetails = parseInt(req.query.shouldShowRemainDetails, 10);
+  const showPaidDetails = parseInt(req.query.shouldShowPaidDetails, 10);
+  const showInvoicedDetails = parseInt(req.query.shouldShowInvoicedDetails, 10);
+  const metadata = structuredClone(req.session);
 
-    const rpt = new ReportManager(TEMPLATE, metadata, qs);
+  const rpt = new ReportManager(TEMPLATE, metadata, qs);
 
-    const CASH_PAYMENT_TRANSACTION_TYPE = 2;
-    const CAUTION_TRANSACTION_TYPE = 19;
-    const CONVENTION_TRANSACTION_TYPE = 3;
+  const CASH_PAYMENT_TRANSACTION_TYPE = 2;
+  const CAUTION_TRANSACTION_TYPE = 19;
+  const CONVENTION_TRANSACTION_TYPE = 3;
 
-    const normalPayment = `
+  const normalPayment = `
       SELECT reference_uuid, SUM(IFNULL(credit_equiv - debit_equiv, 0)) AS paid FROM general_ledger
       WHERE transaction_type_id = ${CASH_PAYMENT_TRANSACTION_TYPE}
       GROUP BY reference_uuid
     `;
 
-    const cautionPayment = `
+  const cautionPayment = `
       SELECT reference_uuid, SUM(IFNULL(credit_equiv - debit_equiv, 0)) AS paid FROM general_ledger
       WHERE transaction_type_id = ${CAUTION_TRANSACTION_TYPE}
       GROUP BY reference_uuid
     `;
 
-    const conventionPayment = `
+  const conventionPayment = `
       SELECT reference_uuid, SUM(IFNULL(credit_equiv - debit_equiv, 0)) AS paid FROM general_ledger
       WHERE transaction_type_id = ${CONVENTION_TRANSACTION_TYPE}
       GROUP BY reference_uuid
     `;
 
-    const globalQuery = `
+  const globalQuery = `
       SELECT
         c.invoiced, (c.normal_paid + c.caution_paid + c.convention_paid) AS paid,
         c.debtorGroupName, c.serviceName, c.invoice_uuid, BUID(c.service_uuid) AS service_uuid, c.debtor_group_uuid
@@ -80,64 +79,61 @@ async function report(req, res, next) {
       )c
     `;
 
-    const groupByServiceAndDebtorGroup = `
+  const groupByServiceAndDebtorGroup = `
       GROUP BY w.service_uuid, w.debtor_group_uuid
     `;
 
-    const tableQuery = `
+  const tableQuery = `
       SELECT
         SUM(w.paid) paid, SUM(w.invoiced) invoiced, SUM(w.invoiced - w.paid) remaining,
         w.debtorGroupName, w.serviceName, w.service_uuid, w.debtor_group_uuid
       FROM (${globalQuery})w
     `;
 
-    const parameters = [
-      moment(dateFrom).format('YYYY-MM-DD'), moment(dateTo).format('YYYY-MM-DD'),
-    ];
+  const parameters = [
+    moment(dateFrom).format('YYYY-MM-DD'), moment(dateTo).format('YYYY-MM-DD'),
+  ];
 
-    const transaction = db.transaction();
-    const tempTable = 'invoicePaymentsPivotTable';
-    const createTempTable = `
+  const transaction = db.transaction();
+  const tempTable = 'invoicePaymentsPivotTable';
+  const createTempTable = `
       CREATE TEMPORARY TABLE ${tempTable} AS (${tableQuery.concat(groupByServiceAndDebtorGroup)});
     `;
 
-    transaction.addQuery(`DROP TEMPORARY TABLE IF EXISTS ${tempTable};`);
-    transaction.addQuery(createTempTable, parameters);
-    transaction.addQuery(`CALL Pivot('${tempTable}', 'debtorGroupName', 'serviceName', 'remaining', '', '')`);
-    transaction.addQuery(`CALL Pivot('${tempTable}', 'debtorGroupName', 'serviceName', 'paid', '', '')`);
-    transaction.addQuery(`CALL Pivot('${tempTable}', 'debtorGroupName', 'serviceName', 'invoiced', '', '')`);
-    transaction.addQuery(`${tableQuery}`, parameters);
+  transaction.addQuery(`DROP TEMPORARY TABLE IF EXISTS ${tempTable};`);
+  transaction.addQuery(createTempTable, parameters);
+  transaction.addQuery(`CALL Pivot('${tempTable}', 'debtorGroupName', 'serviceName', 'remaining', '', '')`);
+  transaction.addQuery(`CALL Pivot('${tempTable}', 'debtorGroupName', 'serviceName', 'paid', '', '')`);
+  transaction.addQuery(`CALL Pivot('${tempTable}', 'debtorGroupName', 'serviceName', 'invoiced', '', '')`);
+  transaction.addQuery(`${tableQuery}`, parameters);
 
-    const rows = await transaction.execute();
-    const remainingTable = rows[2][0];
-    const remainingMatrix = matrix(remainingTable);
+  const rows = await transaction.execute();
+  const remainingTable = rows[2][0];
+  const remainingMatrix = matrix(remainingTable);
 
-    const paidTable = rows[3][0];
-    const paidMatrix = matrix(paidTable);
+  const paidTable = rows[3][0];
+  const paidMatrix = matrix(paidTable);
 
-    const invoicedTable = rows[4][0];
-    const invoicedMatrix = matrix(invoicedTable);
+  const invoicedTable = rows[4][0];
+  const invoicedMatrix = matrix(invoicedTable);
 
-    const [totals] = rows[5];
-    totals.paidRatio = totals.invoiced ? (totals.paid / totals.invoiced) : 0;
-    totals.remainingRatio = totals.invoiced ? (totals.remaining / totals.invoiced) : 0;
+  const [totals] = rows[5];
+  totals.paidRatio = totals.invoiced ? (totals.paid / totals.invoiced) : 0;
+  totals.remainingRatio = totals.invoiced ? (totals.remaining / totals.invoiced) : 0;
 
-    const result = await rpt.render({
-      dateFrom,
-      dateTo,
-      totals,
-      remainingMatrix,
-      paidMatrix,
-      invoicedMatrix,
-      showRemainDetails,
-      showPaidDetails,
-      showInvoicedDetails,
-    });
+  const result = await rpt.render({
+    dateFrom,
+    dateTo,
+    totals,
+    remainingMatrix,
+    paidMatrix,
+    invoicedMatrix,
+    showRemainDetails,
+    showPaidDetails,
+    showInvoicedDetails,
+  });
 
-    res.set(result.headers).send(result.report);
-  } catch (e) {
-    next(e);
-  }
+  res.set(result.headers).send(result.report);
 }
 
 function matrix(dataset) {

--- a/server/controllers/finance/reports/realized_profit/index.js
+++ b/server/controllers/finance/reports/realized_profit/index.js
@@ -31,7 +31,7 @@ async function report(req, res, next) {
     const showRemainDetails = parseInt(req.query.shouldShowRemainDetails, 10);
     const showPaidDetails = parseInt(req.query.shouldShowPaidDetails, 10);
     const showInvoicedDetails = parseInt(req.query.shouldShowInvoicedDetails, 10);
-    const metadata = _.clone(req.session);
+    const metadata = structuredClone(req.session);
 
     const rpt = new ReportManager(TEMPLATE, metadata, qs);
 

--- a/server/controllers/finance/reports/reportAccounts/index.js
+++ b/server/controllers/finance/reports/reportAccounts/index.js
@@ -1,3 +1,4 @@
+const debug = require('debug')('bhima:finance:reports:reportAccounts');
 const ReportManager = require('../../../../lib/ReportManager');
 
 const AccountsExtra = require('../../accounts/extra');
@@ -21,6 +22,7 @@ const TEMPLATE = './server/controllers/finance/reports/reportAccounts/report.han
  */
 async function document(req, res) {
   const bundle = {};
+  debug('Rendering the accouunt report.');
 
   const params = req.query;
   params.user = req.session.user;
@@ -33,15 +35,25 @@ async function document(req, res) {
 
   params.dateFrom = (params.dateFrom) ? new Date(params.dateFrom) : new Date();
 
+  debug(`Date range from ${params.dateFrom} to present.`);
+
   // first, we look up the currency to have all the parameters we need
   const currency = await Currency.lookupCurrencyById(params.currency_id);
   Object.assign(bundle, { currency });
 
+  debug(`Using currency ${currency.id}.`);
+
   // get the exchange rate for the opening balance
   const rate = await Exchange.getExchangeRate(params.enterprise_id, params.currency_id, params.dateFrom);
+  debug(`Got rate: ${JSON.stringify(rate)}.`);
+
   bundle.rate = rate.rate || 1;
   bundle.invertedRate = Exchange.formatExchangeRateForDisplay(bundle.rate);
+  debug(`invertedRate: ${bundle.invertedRate}.`);
+
   const balance = await AccountsExtra.getOpeningBalanceForDate(params.account_id, params.dateFrom, false);
+  debug(`balance: ${JSON.stringify(balance)}.`);
+
   const { invertedRate } = bundle;
 
   const header = {
@@ -49,18 +61,20 @@ async function document(req, res) {
     balance         : Number(balance.balance),
     credit          : Number(balance.credit),
     debit           : Number(balance.debit),
-    exchangedCredit : Number(balance.credit) * rate,
-    exchangedDebit : Number(balance.debit) * rate,
-    exchangedBalance : Number(balance.balance) * rate,
+    exchangedCredit : Number(balance.credit) * bundle.rate,
+    exchangedDebit : Number(balance.debit) * bundle.rate,
+    exchangedBalance : Number(balance.balance) * bundle.rate,
     isCreditBalance : Number(balance.balance) < 0,
     rate,
     invertedRate,
   };
 
   Object.assign(bundle, { header });
-  const tranxs = await AccountTransactions.getAccountTransactions(params, bundle.header.exchangedBalance);
-  Object.assign(bundle, tranxs, { params });
+  const result = await AccountTransactions.getAccountTransactions(params, bundle.header.exchangedBalance);
+
+  Object.assign(bundle, result, { params });
   const fiscal = await Fiscal.getNumberOfFiscalYears(params.dateFrom, params.dateTo);
+
   // check to see if this statement spans multiple fiscal years AND concerns
   // an income/ expense account
   // @TODO these constants should be system shared variables
@@ -83,8 +97,8 @@ async function document(req, res) {
     provisionary : params.includeUnpostedValues,
   });
 
-  const result = await report.render(bundle);
-  res.set(result.headers).send(result.report);
+  const r = await report.render(bundle);
+  res.set(r.headers).send(r.report);
 }
 
 exports.document = document;

--- a/server/controllers/finance/shared.js
+++ b/server/controllers/finance/shared.js
@@ -5,12 +5,10 @@
  * This module contains helper functions for operating on transactions.  These
  * helper functions do things like like
  *
- * @requires lodash
  * @requires lib/db
  * @requires lib/errors/BadRequest
  */
 
-const _ = require('lodash');
 const db = require('../../lib/db');
 const FilterParser = require('../../lib/filter');
 const BadRequest = require('../../lib/errors/BadRequest');
@@ -65,7 +63,7 @@ exports.lookupFinancialRecordByUuid = (req, res, next) => {
     db.exec(cash.query, cash.parameters),
   ])
     .then(records => {
-      const [record] = _.flatten(records);
+      const [record] = records.reduce((a, b) => a.concat(b), []);
       res.status(200).json(record);
     })
     .catch(next);
@@ -140,7 +138,7 @@ function getQueryForTable(table, options) {
  * An HTTP interface to lookup financial records (cash/voucher/invoices) in the database.
  */
 exports.lookupFinancialRecord = (req, res, next) => {
-  const options = _.clone(req.query);
+  const options = structuredClone(req.query);
 
   const vouchers = getQueryForTable('voucher', options);
   const invoices = getQueryForTable('invoice', options);
@@ -152,7 +150,8 @@ exports.lookupFinancialRecord = (req, res, next) => {
     db.exec(cash.query, cash.parameters),
   ])
     .then(records => {
-      res.status(200).json(_.flatten(records));
+      const r = records.reduce((a, b) => a.concat(b), []);
+      res.status(200).json(r);
     })
     .catch(next);
 };

--- a/server/controllers/finance/shared.js
+++ b/server/controllers/finance/shared.js
@@ -61,7 +61,7 @@ exports.lookupFinancialRecordByUuid = async (req, res) => {
     db.exec(invoices.query, invoices.parameters),
     db.exec(cash.query, cash.parameters),
   ]);
-  const [record] = records.reduce((a, b) => a.concat(b), []);
+  const [record] = records.flat();
   res.status(200).json(record);
 
 };

--- a/server/controllers/finance/stepDownCostAllocationBasis.js
+++ b/server/controllers/finance/stepDownCostAllocationBasis.js
@@ -12,40 +12,31 @@ module.exports = {
 //
 // POST /cost_center_allocation_basis
 //
-function create(req, res, next) {
+async function create(req, res) {
   const sql = `INSERT INTO cost_center_allocation_basis SET ?`;
   const data = req.body;
-  db.exec(sql, data)
-    .then(() => {
-      res.sendStatus(201);
-    })
-    .catch(next);
-
+  await db.exec(sql, data);
+  res.sendStatus(201);
 }
 
 // get details of specific allocation basis
 //
 // GET /cost_center_allocation_basis/:id
 //
-function read(req, res, next) {
+async function read(req, res) {
   const sql = 'SELECT * FROM `cost_center_allocation_basis` WHERE id = ?';
-  return db.one(sql, [req.params.id])
-    .then(result => res.status(200).json(result))
-    .catch(next);
-
+  const result = await db.one(sql, [req.params.id]);
+  res.status(200).json(result);
 }
 
 // get details of all allocation bases
 //
 // GET /cost_center_allocation_basis
 //
-function list(req, res, next) {
+async function list(req, res) {
   const sql = 'SELECT * FROM cost_center_allocation_basis ORDER BY name ASC;';
-  return db.exec(sql, [])
-    .then((rows) => {
-      res.status(200).json(rows);
-    })
-    .catch(next);
+  const rows = await db.exec(sql, []);
+  res.status(200).json(rows);
 
 }
 
@@ -53,14 +44,11 @@ function list(req, res, next) {
 //
 // PUT /cost_center_allocation_basis/:id
 //
-function update(req, res, next) {
+async function update(req, res) {
   const sql = 'UPDATE cost_center_allocation_basis SET ?  WHERE id = ?';
   const data = req.body;
-  db.exec(sql, [data, req.params.id])
-    .then(() => {
-      res.sendStatus(200);
-    })
-    .catch(next);
+  await db.exec(sql, [data, req.params.id]);
+  res.sendStatus(200);
 
 }
 
@@ -68,11 +56,8 @@ function update(req, res, next) {
 //
 // DELETE /cost_center_allocation_basis/:id
 //
-function remove(req, res, next) {
+async function remove(req, res) {
   const sql = 'DELETE FROM cost_center_allocation_basis WHERE id = ?';
-  db.exec(sql, req.params.id)
-    .then(() => {
-      res.sendStatus(204);
-    })
-    .catch(next);
+  await db.exec(sql, req.params.id);
+  res.sendStatus(204);
 }

--- a/server/controllers/finance/stepDownCostAllocationQuantity.js
+++ b/server/controllers/finance/stepDownCostAllocationQuantity.js
@@ -18,7 +18,7 @@ module.exports = {
 //
 // GET /cost_center_allocation_basis_quantity/bulk/:id
 //
-async function bulkDetails(req, res, next) {
+async function bulkDetails(req, res) {
   const sql = `
     SELECT
       abv.id, abv.quantity, abv.cost_center_id, abv.basis_id,
@@ -28,19 +28,15 @@ async function bulkDetails(req, res, next) {
     JOIN cost_center_allocation_basis ab ON ab.id = abv.basis_id
     WHERE cc.id = ?
   `;
-  try {
-    const data = await db.exec(sql, [+req.params.id]);
-    res.status(200).json(data);
-  } catch (error) {
-    next(error);
-  }
+  const data = await db.exec(sql, [+req.params.id]);
+  res.status(200).json(data);
 }
 
 // add multiple new allocation basis quantity
 //
 // POST /cost_center_allocation_basis_quantity/bulk
 //
-function bulkCreate(req, res, next) {
+async function bulkCreate(req, res) {
   const data = req.body.params;
   const sql = `INSERT INTO cost_center_allocation_basis_value SET ?`;
   const tx = db.transaction();
@@ -49,11 +45,8 @@ function bulkCreate(req, res, next) {
     tx.addQuery(sql, item);
   });
 
-  tx.execute()
-    .then(() => {
-      res.sendStatus(201);
-    })
-    .catch(next);
+  await tx.execute();
+  res.sendStatus(201);
 
 }
 
@@ -61,7 +54,7 @@ function bulkCreate(req, res, next) {
 //
 // PUT /cost_center_allocation_basis_quantity/bulk
 //
-function bulkUpdate(req, res, next) {
+async function bulkUpdate(req, res) {
   const ccId = req.params.id;
   const data = req.body.params;
   const sql = `INSERT INTO cost_center_allocation_basis_value SET ?`;
@@ -73,11 +66,8 @@ function bulkUpdate(req, res, next) {
     tx.addQuery(sql, { cost_center_id : ccId, ...item });
   });
 
-  tx.execute()
-    .then(() => {
-      res.sendStatus(201);
-    })
-    .catch(next);
+  await tx.execute();
+  res.sendStatus(201);
 
 }
 
@@ -85,16 +75,12 @@ function bulkUpdate(req, res, next) {
 //
 // DELETE /cost_center_allocation_basis_quantity/bulk
 //
-function bulkDelete(req, res, next) {
+async function bulkDelete(req, res) {
   const ccId = req.params.id;
   const sql = `DELETE FROM cost_center_allocation_basis_value WHERE cost_center_id = ?`;
 
-  db.exec(sql, [ccId])
-    .then(() => {
-      res.sendStatus(203);
-    })
-    .catch(next);
-
+  await db.exec(sql, [ccId]);
+  res.sendStatus(203);
 }
 
 // get details of all allocation base quantities
@@ -102,7 +88,7 @@ function bulkDelete(req, res, next) {
 // GET /cost_center_allocation_basis_quantity
 //   Uses two optional parameters:  basis_id, cost_center_id
 //
-function list(req, res, next) {
+async function list(req, res) {
   const sql = `
     SELECT
       abv.id, abv.quantity, abv.cost_center_id, abv.basis_id,
@@ -118,105 +104,85 @@ function list(req, res, next) {
   const query = filters.applyQuery(sql);
   const params = filters.parameters();
 
-  return db.exec(query, params)
-    .then((rows) => {
-      res.status(200).json(rows);
-    })
-    .catch(next);
-
+  const rows = await db.exec(query, params);
+  res.status(200).json(rows);
 }
 
 // add a new allocation basis quantity
 //
 // POST /cost_center_allocation_basis_quantity
 //
-function create(req, res, next) {
+async function create(req, res) {
   const sql = `INSERT INTO cost_center_allocation_basis_value SET ?`;
   const data = req.body;
-  db.exec(sql, data)
-    .then(() => {
-      res.sendStatus(201);
-    })
-    .catch(next);
-
+  await db.exec(sql, data);
+  res.sendStatus(201);
 }
 
 // update allocation basis quantity details
 //
 // PUT /cost_center_allocation_basis_quantity/:id
 //
-function update(req, res, next) {
+async function update(req, res) {
   const sql = 'UPDATE cost_center_allocation_basis_value SET ?  WHERE id = ?';
   const data = req.body;
-  db.exec(sql, [data, req.params.id])
-    .then(() => {
-      res.sendStatus(200);
-    })
-    .catch(next);
-
+  await db.exec(sql, [data, req.params.id]);
+  res.sendStatus(200);
 }
 
 // Delete a allocation basis quantity
 //
 // DELETE /cost_center_allocation_basis_quantity/:id
 //
-function remove(req, res, next) {
+async function remove(req, res) {
   const sql = 'DELETE FROM cost_center_allocation_basis_value WHERE id = ?';
-  db.exec(sql, req.params.id)
-    .then(() => {
-      res.sendStatus(204);
-    })
-    .catch(next);
+  await db.exec(sql, req.params.id);
+  res.sendStatus(204);
 }
 
 // Update computable allocation basis quantities
 //
 // UPDATE /cost_center_allocation_basis_quantities_update
 //
-async function updateQuantities(req, res, next) {
-  try {
-    // Get the full list of cost center IDs
-    const costCentersQuery = 'SELECT id, label AS name from cost_center';
-    const costCenters = await db.exec(costCentersQuery);
+async function updateQuantities(req, res) {
+  // Get the full list of cost center IDs
+  const costCentersQuery = 'SELECT id, label AS name from cost_center';
+  const costCenters = await db.exec(costCentersQuery);
 
-    // Get the allocation bases that are computable
-    const cabQuery = 'SELECT id, name FROM cost_center_allocation_basis WHERE is_computed = 1';
-    const computables = await db.exec(cabQuery);
+  // Get the allocation bases that are computable
+  const cabQuery = 'SELECT id, name FROM cost_center_allocation_basis WHERE is_computed = 1';
+  const computables = await db.exec(cabQuery);
 
-    // Queries to update the quantity records
-    const delQRec = 'DELETE FROM `cost_center_allocation_basis_value` '
+  // Queries to update the quantity records
+  const delQRec = 'DELETE FROM `cost_center_allocation_basis_value` '
       + 'WHERE `cost_center_id` = ? AND `basis_id` = ?';
-    const insertQRec = 'INSERT INTO `cost_center_allocation_basis_value` '
+  const insertQRec = 'INSERT INTO `cost_center_allocation_basis_value` '
       + '(`cost_center_id`, `basis_id`, `quantity`) VALUES (?, ?, ?)';
 
-    /* eslint-disable no-await-in-loop */
-    for (let i = 0; i < computables.length; i++) {
-      const transaction = db.transaction();
-      const basis = computables[i];
-      const data = await computedAllocationQuantities(basis.id);
+  /* eslint-disable no-await-in-loop */
+  for (let i = 0; i < computables.length; i++) {
+    const transaction = db.transaction();
+    const basis = computables[i];
+    const data = await computedAllocationQuantities(basis.id);
 
-      // Update quantities for each cost center
-      for (let k = 0; k < costCenters.length; k++) {
-        const cc = costCenters[k];
-        // Get the data for this cost center (if any)
-        const ccData = data.find(item => item.cost_center_id === cc.id);
-        const newQuantity = ccData ? ccData[basis.name] : 0;
+    // Update quantities for each cost center
+    for (let k = 0; k < costCenters.length; k++) {
+      const cc = costCenters[k];
+      // Get the data for this cost center (if any)
+      const ccData = data.find(item => item.cost_center_id === cc.id);
+      const newQuantity = ccData ? ccData[basis.name] : 0;
 
-        // First delete the old record first
-        transaction.addQuery(delQRec, [cc.id, basis.id]);
-        // The add a new entry for the updated quantity
-        transaction.addQuery(insertQRec, [cc.id, basis.id, newQuantity]);
-      }
-
-      await transaction.execute();
+      // First delete the old record first
+      transaction.addQuery(delQRec, [cc.id, basis.id]);
+      // The add a new entry for the updated quantity
+      transaction.addQuery(insertQRec, [cc.id, basis.id, newQuantity]);
     }
 
-    // Success!
-    res.sendStatus(200);
-
-  } catch (e) {
-    next(e);
+    await transaction.execute();
   }
+
+  // Success!
+  res.sendStatus(200);
 }
 
 /**

--- a/server/controllers/finance/taxPayment.js
+++ b/server/controllers/finance/taxPayment.js
@@ -1,7 +1,7 @@
 const db = require('../../lib/db');
 
 // HTTP Controller
-exports.availablePaymentPeriod = function availablePaymentPeriod(req, res, next) {
+exports.availablePaymentPeriod = async function availablePaymentPeriod(req, res) {
   const sql = `
     SELECT
       p.id, p.config_tax_id, p.config_rubric_id, p.config_accounting_id, p.config_cotisation_id,
@@ -17,25 +17,17 @@ exports.availablePaymentPeriod = function availablePaymentPeriod(req, res, next)
       ORDER BY p.id DESC
   `;
 
-  db.exec(sql)
-    .then((result) => {
-      res.send(result);
-    })
-    .catch((err) => { next(err); });
-
+  const result = await db.exec(sql);
+  res.send(result);
 };
 
-exports.setTaxPayment = function setTaxPayment(req, res, next) {
+exports.setTaxPayment = async function setTaxPayment(req, res) {
   const sql = `
     UPDATE tax_payment SET posted = 1 ' +
     WHERE tax_payment.payment_uuid=${db.escape(req.body.payment_uuid)}
       AND tax_payment.tax_id = ${db.escape(req.body.tax_id)};
   `;
 
-  db.exec(sql)
-    .then((result) => {
-      res.send(result);
-    })
-    .catch((err) => { next(err); });
-
+  const result = await db.exec(sql);
+  res.send(result);
 };

--- a/server/controllers/finance/transactions.js
+++ b/server/controllers/finance/transactions.js
@@ -87,17 +87,14 @@ function isUserAuthorized(text, actions) {
  *
  * DELETE /transactions/:uuid
  */
-function deleteRoute(req, res, next) {
+async function deleteRoute(req, res) {
   const { uuid } = req.params;
 
   debug(`#delete() attempting to remove transaction ${uuid}.`);
 
-  deleteTransaction(uuid, req.session.actions, req.session.user.id)
-    .then(() => {
-      debug(`#delete() successfully removed transaction ${uuid}.`);
-      res.sendStatus(201);
-    })
-    .catch(next);
+  await deleteTransaction(uuid, req.session.actions, req.session.user.id);
+  debug(`#delete() successfully removed transaction ${uuid}.`);
+  res.sendStatus(201);
 }
 
 function formatTransactionRecord(txnRecord) {
@@ -167,19 +164,17 @@ async function deleteTransaction(uuid, actions, userId) {
  *
  * @param {object} params - { uuids: [...], comment: '' }
  */
-function commentTransactions(req, res, next) {
+async function commentTransactions(req, res) {
   const { uuids, comment } = req.body.params;
   const uids = uuids.map(db.bid);
 
   const journalUpdate = 'UPDATE posting_journal SET comment = ? WHERE uuid IN ?';
   const ledgerUpdate = 'UPDATE general_ledger SET comment = ? WHERE uuid IN ?';
 
-  Promise.all([
+  await Promise.all([
     db.exec(journalUpdate, [comment, [uids]]),
     db.exec(ledgerUpdate, [comment, [uids]]),
-  ])
-    .then(() => {
-      res.sendStatus(200);
-    })
-    .catch(next);
+  ]);
+
+  res.sendStatus(200);
 }

--- a/server/controllers/finance/voucherTools/index.js
+++ b/server/controllers/finance/voucherTools/index.js
@@ -35,7 +35,7 @@ exports.correct = correct;
  *
  * Returns voucher ids for the reversal and correction vouchers.
  */
-function correct(req, res, next) {
+async function correct(req, res) {
   // transactionDetails - details for the transaction that should be corrected (this is what will be
   // reversed)
   // correction - rows that should replace the transaction that is being reversed (these are
@@ -45,16 +45,11 @@ function correct(req, res, next) {
 
   const response = {};
 
-  correctTransaction(transactionDetails, correction, userId)
-    .then((correctionActionResults) => {
-      response.actions = correctionActionResults;
-      return _fetchCorrectionVoucherDetails(correctionActionResults);
-    })
-    .then((details) => {
-      response.details = details;
-      res.status(201).json(response);
-    })
-    .catch(next);
+  const correctionActionResults = await correctTransaction(transactionDetails, correction, userId);
+  response.actions = correctionActionResults;
+  const details = await _fetchCorrectionVoucherDetails(correctionActionResults);
+  response.details = details;
+  res.status(201).json(response);
 }
 
 // transactionDetails

--- a/server/controllers/inventory/inventory/core.js
+++ b/server/controllers/inventory/inventory/core.js
@@ -76,7 +76,7 @@ exports.inventoryColsMap = inventoryColsMap;
 async function createItemsMetadata(record, session) {
   let tags;
 
-  const recordCopy = _.clone(record);
+  const recordCopy = structuredClone(record);
   const recordUuid = record.uuid || uuid();
 
   record.enterprise_id = session.enterprise.id;
@@ -90,7 +90,7 @@ async function createItemsMetadata(record, session) {
   const transaction = db.transaction();
 
   if (record.tags) {
-    tags = _.clone(record.tags);
+    tags = structuredClone(record.tags);
     delete record.tags;
   }
 
@@ -146,7 +146,7 @@ async function updateItemsMetadata(record, identifier, session) {
   // remove the uuid if it exists
   delete record.uuid;
   record.updated_by = session.user.id;
-  const recordCopy = _.clone(record);
+  const recordCopy = structuredClone(record);
   if (record.group_uuid) {
     record.group_uuid = db.bid(record.group_uuid);
   }
@@ -159,7 +159,7 @@ async function updateItemsMetadata(record, identifier, session) {
   }
 
   if (record.tags) {
-    tags = _.clone(record.tags);
+    tags = structuredClone(record.tags);
     delete record.tags;
   }
 

--- a/server/controllers/inventory/inventory/core.js
+++ b/server/controllers/inventory/inventory/core.js
@@ -403,13 +403,12 @@ async function getItemsMetadataById(uid, query = {}) {
 * @param error An error object
 * @param req ExpressJS req object
 * @param res ExpressJS res object
-* @param next ExpressJS's next function
 */
-function errorHandler(error, req, res, next) {
+async function errorHandler(error, req, res) {
   if (error.httpStatus !== undefined) {
     res.status(error.httpStatus).json(error);
   } else {
-    next(error);
+    throw error;
   }
 }
 

--- a/server/controllers/inventory/inventory/units.js
+++ b/server/controllers/inventory/inventory/units.js
@@ -3,6 +3,7 @@
  * This controller is responsible for handling CRUD operations with inventory units
  */
 
+const debug = require('debug')('bhima:inventory:units');
 const db = require('../../../lib/db');
 const Forbidden = require('../../../lib/errors/Forbidden');
 
@@ -38,10 +39,10 @@ function create(record) {
 function update(record, id) {
   // Make sure we cannot update a pre-defined inventory unit
   return getUnits(id)
-    .then((result) => {
-      const [dbRecord] = result;
+    .then(([dbRecord]) => {
 
       if (dbRecord.token) {
+        debug(`Error: Attempt to modify a predefined inventory_unit definition id:${id}`);
         throw new Forbidden('Cannot modify a predefined inventory_unit definition');
       }
 
@@ -49,17 +50,14 @@ function update(record, id) {
       const sql = 'UPDATE inventory_unit SET ? WHERE id = ?;';
       return db.exec(sql, [record, id]);
     })
-    .then(() => {
-      return getUnits(id);
-    });
+    .then(() => getUnits(id));
 }
 
 /** remove inventory unit */
 function remove(id) {
   // Make sure we cannot delete a pre-defined inventory unit
   return getUnits(id)
-    .then(result => {
-      const [dbRecord] = result;
+    .then(([dbRecord]) => {
       if (dbRecord.token) {
         throw new Forbidden('Cannot delete a predefined inventory_unit definition');
       }

--- a/server/controllers/inventory/reports/prices.js
+++ b/server/controllers/inventory/reports/prices.js
@@ -20,7 +20,7 @@ module.exports = prices;
 
 const TEMPLATE = './server/controllers/inventory/reports/prices.handlebars';
 
-async function prices(req, res, next) {
+async function prices(req, res) {
   const params = structuredClone(req.query);
   const filters = shared.formatFilters(params);
 
@@ -32,21 +32,17 @@ async function prices(req, res, next) {
 
   const metadata = structuredClone(req.session);
 
-  try {
-    const report = new ReportManager(TEMPLATE, metadata, qs);
+  const report = new ReportManager(TEMPLATE, metadata, qs);
 
-    const items = await inventorycore.getItemsMetadata(params);
-    let groups = _.groupBy(items, i => i.groupName);
+  const items = await inventorycore.getItemsMetadata(params);
+  let groups = _.groupBy(items, i => i.groupName);
 
-    // make sure that they keys are sorted in alphabetical order
-    groups = _.mapValues(groups, lines => {
-      _.sortBy(lines, 'label');
-      return lines;
-    });
+  // make sure that they keys are sorted in alphabetical order
+  groups = _.mapValues(groups, lines => {
+    _.sortBy(lines, 'label');
+    return lines;
+  });
 
-    const result = await report.render({ groups, filters });
-    res.set(result.headers).send(result.report);
-  } catch (e) {
-    next(e);
-  }
+  const result = await report.render({ groups, filters });
+  res.set(result.headers).send(result.report);
 }

--- a/server/controllers/inventory/reports/prices.js
+++ b/server/controllers/inventory/reports/prices.js
@@ -21,7 +21,7 @@ module.exports = prices;
 const TEMPLATE = './server/controllers/inventory/reports/prices.handlebars';
 
 async function prices(req, res, next) {
-  const params = _.clone(req.query);
+  const params = structuredClone(req.query);
   const filters = shared.formatFilters(params);
 
   const qs = _.extend(req.query, {
@@ -30,7 +30,7 @@ async function prices(req, res, next) {
     filename : 'INVENTORY.PRICE_LIST_REPORT',
   });
 
-  const metadata = _.clone(req.session);
+  const metadata = structuredClone(req.session);
 
   try {
     const report = new ReportManager(TEMPLATE, metadata, qs);

--- a/server/controllers/inventory/reports/purchases.receipt.js
+++ b/server/controllers/inventory/reports/purchases.receipt.js
@@ -9,7 +9,6 @@
  * @requires inventory/purchases
  */
 
-const _ = require('lodash');
 const ReportManager = require('../../../lib/ReportManager');
 const Purchases = require('../../finance/purchases');
 
@@ -25,35 +24,30 @@ const template = './server/controllers/inventory/reports/purchases.receipt.handl
  *
  * GET /reports/inventory/purchases/:uuid
  */
-async function build(req, res, next) {
-  const options = req.query;
-  _.extend(options, { filename : 'PURCHASES.RECEIPT.TITLE' });
+async function build(req, res) {
+  const options = { ...req.query, filename : 'PURCHASES.RECEIPT.TITLE' };
 
-  try {
-    const report = new ReportManager(template, req.session, options);
+  const report = new ReportManager(template, req.session, options);
 
-    // format the receipt and ship it off to the client
-    const purchase = await Purchases.lookup(req.params.uuid);
+  // format the receipt and ship it off to the client
+  const purchase = await Purchases.lookup(req.params.uuid);
 
-    // For products with packaging, the quantity that will be displayed on
-    // the order form will be that of the box as well as the unit cost as well as the unit
-    purchase.items.forEach(item => {
-      if (item.is_count_per_container && (item.package_size > 1)) {
-        item.quantity /= item.package_size;
-        item.unit_price *= item.package_size;
-        item.unit_type = 'INVENTORY.UNITS.BOX.TEXT';
-        item.size = `( ${item.package_size} )`;
-      }
-    });
+  // For products with packaging, the quantity that will be displayed on
+  // the order form will be that of the box as well as the unit cost as well as the unit
+  purchase.items.forEach(item => {
+    if (item.is_count_per_container && (item.package_size > 1)) {
+      item.quantity /= item.package_size;
+      item.unit_price *= item.package_size;
+      item.unit_type = 'INVENTORY.UNITS.BOX.TEXT';
+      item.size = `( ${item.package_size} )`;
+    }
+  });
 
-    purchase.total_cost = purchase.cost + purchase.shipping_handling;
-    report.currency_id = purchase.currency_id;
-    const result = await report.render({ purchase });
+  purchase.total_cost = purchase.cost + purchase.shipping_handling;
+  report.currency_id = purchase.currency_id;
+  const result = await report.render({ purchase });
 
-    res.set(result.headers).send(result.report);
-  } catch (e) {
-    next(e);
-  }
+  res.set(result.headers).send(result.report);
 }
 
 module.exports = build;

--- a/server/controllers/medical/diagnoses.js
+++ b/server/controllers/medical/diagnoses.js
@@ -15,11 +15,9 @@ exports.list = list;
  * @description
  * Lists all the ICD10 codes from the database.
  */
-function list(req, res, next) {
+async function list(req, res) {
   const sql = 'SELECT id, code, label FROM icd10 ORDER BY code;';
 
-  db.exec(sql)
-    .then(codes => res.status(200).json(codes))
-    .catch(next);
-
+  const codes = await db.exec(sql);
+  res.status(200).json(codes);
 }

--- a/server/controllers/medical/dischargeTypes.js
+++ b/server/controllers/medical/dischargeTypes.js
@@ -2,12 +2,10 @@ const db = require('../../lib/db');
 
 exports.list = list;
 
-function list(req, res, next) {
+async function list(req, res) {
   const query = `
     SELECT id, label FROM discharge_type ORDER BY id;
   `;
-  db.exec(query)
-    .then(rows => res.status(200).json(rows))
-    .catch(next);
-
+  const rows = await db.exec(query);
+  res.status(200).json(rows);
 }

--- a/server/controllers/medical/patientGroups.js
+++ b/server/controllers/medical/patientGroups.js
@@ -234,7 +234,7 @@ async function lookupPatientGroup(uid) {
 
   const patientGroupUuid = db.bid(uid);
 
-  const [patientGroup, subsidies, invoicingFees] = Promise.all([
+  const [patientGroup, subsidies, invoicingFees] = await Promise.all([
     db.one(sql, patientGroupUuid, uid, 'patient group'),
     db.exec(subsidiesSql, patientGroupUuid),
     db.exec(invoicingFeeSql, patientGroupUuid),

--- a/server/controllers/medical/patients/pictures.js
+++ b/server/controllers/medical/patients/pictures.js
@@ -30,24 +30,15 @@ exports.set = set;
  * POST /patients/:uuid/pictures
  */
 
-function set(req, res, next) {
+async function set(req, res) {
   if (req.files.length === 0) {
-    next(BadRequest('Expected at least one file upload but did not receive any files.'));
-    return;
+    throw new BadRequest('Expected at least one file upload but did not receive any files.');
   }
 
-  const data = {};
-
-  data.avatar = req.files[0].link;
-
+  const data = { avatar : req.files[0].link };
   const buid = db.bid(req.params.uuid);
-
   const sql = 'UPDATE patient SET ? WHERE uuid = ?';
 
-  db.exec(sql, [data, buid])
-    .then(() => {
-      res.status(200).json({ link : data.avatar });
-    })
-    .catch(next);
-
+  await db.exec(sql, [data, buid]);
+  res.status(200).json({ link : data.avatar });
 }

--- a/server/controllers/medical/patients/visits.js
+++ b/server/controllers/medical/patients/visits.js
@@ -362,7 +362,7 @@ async function transfer(req, res) {
   const previousBed = await db.one(lookupLastLocation, [patientVisitUuid, patientUuid]);
   glb.previousBed = previousBed;
 
-  const selectedBed = await (params.id ? { id : params.id } : lookupNextAvailableBed(params));
+  const selectedBed = params.id ? { id : params.id } : await lookupNextAvailableBed(params);
 
   glb.newHospitalizationUuid = uuid();
 

--- a/server/controllers/medical/reports/visits.report.js
+++ b/server/controllers/medical/reports/visits.report.js
@@ -1,7 +1,6 @@
 /**
  * Visits Report
  */
-const _ = require('lodash');
 const moment = require('moment');
 const ReportManager = require('../../../lib/ReportManager');
 const db = require('../../../lib/db');
@@ -11,26 +10,18 @@ const TEMPLATE = './server/controllers/medical/reports/visits.report.handlebars'
 
 exports.document = document;
 
-function document(req, res, next) {
-  let report;
-
+async function document(req, res) {
   const params = req.query;
 
-  const optionReport = _.extend(params, {
+  const optionReport = Object.assign(params, {
     filename : 'PATIENT_RECORDS.REPORT.VISITS',
   });
 
-  try {
-    report = new ReportManager(TEMPLATE, req.session, optionReport);
-  } catch (e) {
-    next(e);
-    return;
-  }
+  const report = new ReportManager(TEMPLATE, req.session, optionReport);
 
-  getData(params)
-    .then(visits => report.render({ visits, params }))
-    .then(result => res.set(result.headers).send(result.report))
-    .catch(next);
+  const visits = await getData(params);
+  const result = await report.render({ visits, params });
+  res.set(result.headers).send(result.report);
 }
 
 async function getData(options) {

--- a/server/controllers/medical/snis.js
+++ b/server/controllers/medical/snis.js
@@ -1,14 +1,10 @@
 const db = require('../../lib/db');
 
-function healthZones(req, res, next) {
+async function healthZones(req, res) {
   const sql = 'SELECT id, zone, territoire, province FROM mod_snis_zs';
 
-  db.exec(sql)
-    .then(rows => {
-      res.status(200).json(rows);
-    })
-    .catch(next);
-
+  const rows = await db.exec(sql);
+  res.status(200).json(rows);
 }
 
 // Expose

--- a/server/controllers/medical/ward/room.js
+++ b/server/controllers/medical/ward/room.js
@@ -8,61 +8,47 @@ module.exports.read = read;
 module.exports.detail = detail;
 
 // register a new room
-function create(req, res, next) {
+async function create(req, res) {
   const data = req.body;
   data.uuid = db.bid(data.uuid || db.uuid());
   db.convert(data, ['ward_uuid']);
   const sql = 'INSERT INTO room SET ?';
 
-  db.exec(sql, data).then(() => {
-    res.sendStatus(201);
-  })
-    .catch(next);
+  await db.exec(sql, data);
+  res.sendStatus(201);
 }
 
 // modify a room informations
-function update(req, res, next) {
+async function update(req, res) {
   const data = req.body;
   delete data.uuid;
   const uuid = db.bid(req.params.uuid);
   db.convert(data, ['ward_uuid']);
   const sql = `UPDATE room SET ? WHERE uuid =?`;
 
-  db.exec(sql, [data, uuid])
-    .then(() => {
-      res.sendStatus(200);
-    })
-    .catch(next);
+  await db.exec(sql, [data, uuid]);
+  res.sendStatus(200);
 }
 
 // delete a room
-function remove(req, res, next) {
+async function remove(req, res) {
   const uuid = db.bid(req.params.uuid);
   const sql = `DELETE FROM room WHERE uuid=?`;
 
-  db.exec(sql, uuid)
-    .then(() => {
-      res.sendStatus(204);
-    })
-    .catch(next);
+  await db.exec(sql, uuid);
+  res.sendStatus(204);
 }
 
 // get all rooms
-function read(req, res, next) {
-  lookupRooms(req.query)
-    .then(rooms => {
-      res.status(200).json(rooms);
-    })
-    .catch(next);
+async function read(req, res) {
+  const rooms = await lookupRooms(req.query);
+  res.status(200).json(rooms);
 }
 
 // get a specific room
-function detail(req, res, next) {
-  lookupRoom(req.params.uuid)
-    .then(room => {
-      res.status(200).json(room);
-    })
-    .catch(next);
+async function detail(req, res) {
+  const room = await lookupRoom(req.params.uuid);
+  res.status(200).json(room);
 }
 
 // lookup a room

--- a/server/controllers/medical/ward/ward.js
+++ b/server/controllers/medical/ward/ward.js
@@ -7,20 +7,18 @@ module.exports.read = read;
 module.exports.detail = detail;
 
 // register a new ward
-function create(req, res, next) {
+async function create(req, res) {
   const data = req.body;
   data.uuid = db.bid(data.uuid || db.uuid());
   db.convert(data, ['service_uuid']);
   const sql = 'INSERT INTO ward SET ?';
 
-  db.exec(sql, data).then(() => {
-    res.sendStatus(201);
-  })
-    .catch(next);
+  await db.exec(sql, data);
+  res.sendStatus(201);
 }
 
 // modify a ward informations
-function update(req, res, next) {
+async function update(req, res) {
   const data = req.body;
 
   delete data.uuid;
@@ -33,24 +31,21 @@ function update(req, res, next) {
 
   const sql = 'UPDATE ward SET ? WHERE uuid = ?';
 
-  db.exec(sql, [data, uuid])
-    .then(() => { res.sendStatus(200); })
-    .catch(next);
+  await db.exec(sql, [data, uuid]);
+  res.sendStatus(200);
 }
 
 // delete a patient
-function remove(req, res, next) {
+async function remove(req, res) {
   const uuid = db.bid(req.params.uuid);
   const sql = `DELETE FROM ward WHERE uuid=?`;
 
-  db.exec(sql, uuid).then(() => {
-    res.sendStatus(204);
-  })
-    .catch(next);
+  await db.exec(sql, uuid);
+  res.sendStatus(204);
 }
 
 // get all wards
-function read(req, res, next) {
+async function read(req, res) {
   const sql = `
     SELECT BUID(w.uuid) as uuid, w.name,
       w.description, BUID(w.service_uuid) as service_uuid,
@@ -61,22 +56,18 @@ function read(req, res, next) {
     LEFT JOIN service s ON s.uuid = w.service_uuid
   `;
 
-  db.exec(sql).then(wards => {
-    res.status(200).json(wards);
-  })
-    .catch(next);
+  const wards = await db.exec(sql);
+  res.status(200).json(wards);
 }
 
 // get a specific ward
-function detail(req, res, next) {
+async function detail(req, res) {
   const sql = `
     SELECT BUID(uuid) as uuid, name, description, BUID(service_uuid) as service_uuid
     FROM ward
     WHERE uuid=?
   `;
   const uuid = db.bid(req.params.uuid);
-  db.one(sql, uuid).then(ward => {
-    res.status(200).json(ward);
-  })
-    .catch(next);
+  const ward = await db.one(sql, uuid);
+  res.status(200).json(ward);
 }

--- a/server/controllers/payroll/accounts/index.js
+++ b/server/controllers/payroll/accounts/index.js
@@ -67,9 +67,9 @@ async function update(req, res) {
 }
 
 // delete /payroll/account_configuration/:id
-function del(req, res, next) {
-  db.delete(
-    'config_accounting', 'id', req.params.id, res, next,
+async function del(req, res) {
+  await db.delete(
+    'config_accounting', 'id', req.params.id, res,
     `Could not find a Account Configuration with id ${req.params.id}`,
   );
 }

--- a/server/controllers/payroll/configuration/index.js
+++ b/server/controllers/payroll/configuration/index.js
@@ -66,10 +66,10 @@ async function update(req, res) {
 
 }
 
-// DELETE /PAYROLL_CONFIG /:ID
-function del(req, res, next) {
-  db.delete(
-    'payroll_configuration', 'id', req.params.id, res, next,
+// DELETE /payroll_config/:id
+async function del(req, res) {
+  await db.delete(
+    'payroll_configuration', 'id', req.params.id, res,
     `Could not find a Payroll configuration with id ${req.params.id}`,
   );
 }

--- a/server/controllers/payroll/multiplePayroll/setConfiguration.js
+++ b/server/controllers/payroll/multiplePayroll/setConfiguration.js
@@ -22,7 +22,7 @@ const DECIMAL_PRECISION = 2;
  * This controller allows to initialize the payment configuration for an employee,
  * the data of this configuration comes from the manual configuration,
  */
-async function config(req, res, next) {
+async function config(req, res) {
   const { data } = req.body;
 
   const transaction = db.transaction();
@@ -45,71 +45,70 @@ async function config(req, res, next) {
   // FIXME(@jniles) - in our test data, "code" is the employee name.
   debug('Working on employee: %s', employee.code);
 
-  try {
-    debug('Looking up exchange rates.');
+  debug('Looking up exchange rates.');
 
-    const [exchange, exchangeIpr] = await Promise.all([
-      Exchange.getExchangeRate(enterpriseId, data.currency_id, new Date()),
-      Exchange.getExchangeRate(enterpriseId, iprCurrencyId, new Date()),
-    ]);
+  const [exchange, exchangeIpr] = await Promise.all([
+    Exchange.getExchangeRate(enterpriseId, data.currency_id, new Date()),
+    Exchange.getExchangeRate(enterpriseId, iprCurrencyId, new Date()),
+  ]);
 
-    const enterpriseExchangeRate = currencyId === data.currency_id ? 1 : exchange.rate;
+  const enterpriseExchangeRate = currencyId === data.currency_id ? 1 : exchange.rate;
 
-    const iprExchangeRate = exchangeIpr.rate;
+  const iprExchangeRate = exchangeIpr.rate;
 
-    debug(`Using the rates: IPR: ${iprExchangeRate}; enterprise: ${enterpriseExchangeRate}.`);
+  debug(`Using the rates: IPR: ${iprExchangeRate}; enterprise: ${enterpriseExchangeRate}.`);
 
-    // calculate the daily wage of the employee
-    const totalDayPeriod = data.daysPeriod.working_day;
-    const dailySalary = employee.individual_salary
-      ? (employee.individual_salary / totalDayPeriod)
-      : (employee.basic_salary / totalDayPeriod);
+  // calculate the daily wage of the employee
+  const totalDayPeriod = data.daysPeriod.working_day;
+  const dailySalary = employee.individual_salary
+    ? (employee.individual_salary / totalDayPeriod)
+    : (employee.basic_salary / totalDayPeriod);
 
-    const workingDayCost = dailySalary * data.working_day;
-    const nbChildren = employee.nb_enfant;
+  const workingDayCost = dailySalary * data.working_day;
+  const nbChildren = employee.nb_enfant;
 
-    // Calcul of Seniority date Between hiring_date and the end date of Period
-    const yearsOfSeniority = moment(periodDateTo).diff(moment(employee.hiring_date), 'years');
+  // Calcul of Seniority date Between hiring_date and the end date of Period
+  const yearsOfSeniority = moment(periodDateTo).diff(moment(employee.hiring_date), 'years');
 
-    debug(`[${employee.code}] Seniority: ${yearsOfSeniority} years.`);
-    debug(`[${employee.code}] Children: ${nbChildren}`);
-    debug(`[${employee.code}] Daily Salary: ${dailySalary}`);
+  debug(`[${employee.code}] Seniority: ${yearsOfSeniority} years.`);
+  debug(`[${employee.code}] Children: ${nbChildren}`);
+  debug(`[${employee.code}] Daily Salary: ${dailySalary}`);
 
-    /**
+  /**
      * Some institution allocates a percentage for the offday and holiday payment.
      * the calculation of this rate is found by calculating the equivalence of the daily wage with
      * the percentage of the offday or holiday.
     */
-    let offDaysCost = 0;
-    const offDaysElements = data.offDays.map(offDay => {
-      const offDayValue = ((dailySalary * offDay.percent_pay) / 100);
-      offDaysCost += offDayValue;
-      return [offDay.id, offDay.percent_pay, paymentUuid, offDay.label, offDayValue];
-    });
+  let offDaysCost = 0;
+  const offDaysElements = data.offDays.map(offDay => {
+    const offDayValue = ((dailySalary * offDay.percent_pay) / 100);
+    offDaysCost += offDayValue;
+    return [offDay.id, offDay.percent_pay, paymentUuid, offDay.label, offDayValue];
+  });
 
-    let holidaysCost = 0;
-    const holidaysElements = data.holidays.map(holiday => {
-      const holidayValue = ((dailySalary * holiday.percentage * holiday.numberOfDays) / 100);
-      holidaysCost += holidayValue;
-      return [
-        holiday.id,
-        holiday.numberOfDays,
-        holiday.percentage,
-        paymentUuid,
-        holiday.label,
-        holidayValue,
-      ];
-    });
+  let holidaysCost = 0;
+  const holidaysElements = data.holidays.map(holiday => {
+    const holidayValue = ((dailySalary * holiday.percentage * holiday.numberOfDays) / 100);
+    holidaysCost += holidayValue;
+    return [
+      holiday.id,
+      holiday.numberOfDays,
+      holiday.percentage,
+      paymentUuid,
+      holiday.label,
+      holidayValue,
+    ];
+  });
 
-    /*
+  /*
      * Recalculation of base salary on the basis of any holiday or vacation period,
      * where the percentages are respectively equal to 100% of the basic salary will
      * remain equal to that defined at the level of the Holiday table
      */
 
-    const basicSalary = (workingDayCost + offDaysCost + holidaysCost) * enterpriseExchangeRate;
+  const basicSalary = (workingDayCost + offDaysCost + holidaysCost) * enterpriseExchangeRate;
 
-    const sql = `
+  const sql = `
       SELECT config_rubric_item.id, config_rubric_item.config_rubric_id, config_rubric_item.rubric_payroll_id,
         payroll_configuration.label AS PayrollConfig, rubric_payroll.*
       FROM config_rubric_item
@@ -119,199 +118,196 @@ async function config(req, res, next) {
       AND (rubric_payroll.expense_account_id IS NOT NULL);
     `;
 
-    const rubrics = await db.exec(sql, [payrollConfigurationId]);
+  const rubrics = await db.exec(sql, [payrollConfigurationId]);
 
-    let sumNonTaxable = 0;
-    let sumTaxable = 0;
-    let sumTaxContributionEmp = 0;
-    let membershipFeeEmployee = 0;
+  let sumNonTaxable = 0;
+  let sumTaxable = 0;
+  let sumTaxContributionEmp = 0;
+  let membershipFeeEmployee = 0;
 
-    let nonTaxables = [];
-    let taxables = [];
-    let taxesContributions = [];
+  let nonTaxables = [];
+  let taxables = [];
+  let taxesContributions = [];
 
-    if (rubrics.length) {
-      rubrics.forEach(rubric => {
-        // Conversion of non-percentage currency values to the currency used for payment
-        if (rubric.value && !rubric.is_percent && !rubric.is_seniority_bonus) {
-          rubric.value *= enterpriseExchangeRate;
-        }
+  if (rubrics.length) {
+    rubrics.forEach(rubric => {
+      // Conversion of non-percentage currency values to the currency used for payment
+      if (rubric.value && !rubric.is_percent && !rubric.is_seniority_bonus) {
+        rubric.value *= enterpriseExchangeRate;
+      }
 
-        // Initialize values for rubrics that are not automatically calculated
-        rubric.result = util.roundDecimal(data.value[rubric.abbr], DECIMAL_PRECISION);
+      // Initialize values for rubrics that are not automatically calculated
+      rubric.result = util.roundDecimal(data.value[rubric.abbr], DECIMAL_PRECISION);
 
-        // Automatic calcul of Seniority_Bonus & Family_Allowances
-        if (rubric.is_seniority_bonus === 1) {
-          const seniorityElements = [yearsOfSeniority, rubric.value];
+      // Automatic calcul of Seniority_Bonus & Family_Allowances
+      if (rubric.is_seniority_bonus === 1) {
+        const seniorityElements = [yearsOfSeniority, rubric.value];
 
-          rubric.result = automaticRubric(basicSalary, seniorityElements);
-        }
+        rubric.result = automaticRubric(basicSalary, seniorityElements);
+      }
 
-        if (rubric.is_family_allowances === 1) {
-          const allowanceElements = [nbChildren];
-          rubric.result = automaticRubric(rubric.value, allowanceElements);
-        }
-      });
+      if (rubric.is_family_allowances === 1) {
+        const allowanceElements = [nbChildren];
+        rubric.result = automaticRubric(rubric.value, allowanceElements);
+      }
+    });
 
-      // Filtering nontaxable Rubrics
-      nonTaxables = rubrics.filter(item => item.is_social_care);
+    // Filtering nontaxable Rubrics
+    nonTaxables = rubrics.filter(item => item.is_social_care);
 
-      // Filtering taxable Rubrics
-      taxables = rubrics.filter(item => (item.is_tax !== 1
+    // Filtering taxable Rubrics
+    taxables = rubrics.filter(item => (item.is_tax !== 1
               && item.is_discount !== 1
               && item.is_social_care !== 1
               && item.is_membership_fee !== 1));
 
-      // Filtering all taxes and contributions that is calculated from the taxable base
-      taxesContributions = rubrics.filter(
-        item => (item.is_tax || item.is_membership_fee || item.is_discount === 1),
-      );
+    // Filtering all taxes and contributions that is calculated from the taxable base
+    taxesContributions = rubrics.filter(
+      item => (item.is_tax || item.is_membership_fee || item.is_discount === 1),
+    );
+  }
+
+  // Calcul value for nontaxable and automatically calculated Expected Seniority_bonus & Family_allowances
+  if (nonTaxables.length) {
+    nonTaxables.forEach(nonTaxable => {
+      if (!nonTaxable.is_seniority_bonus && !nonTaxable.is_family_allowances) {
+        nonTaxable.result = nonTaxable.is_percent
+          ? util.roundDecimal((basicSalary * nonTaxable.value) / 100, DECIMAL_PRECISION)
+          : (nonTaxable.result || nonTaxable.value);
+      }
+
+      sumNonTaxable += nonTaxable.result;
+      allRubrics.push([paymentUuid, nonTaxable.rubric_payroll_id, nonTaxable.result]);
+    });
+  }
+
+  // Calcul value for taxable and automatically calculated Expected Seniority_bonus & Family_allowances
+  if (taxables.length) {
+    taxables.forEach(taxable => {
+      if (!taxable.is_seniority_bonus && !taxable.is_family_allowances) {
+        taxable.result = taxable.is_percent
+          ? util.roundDecimal((basicSalary * taxable.value) / 100, DECIMAL_PRECISION)
+          : (taxable.result || taxable.value);
+      }
+
+      sumTaxable += taxable.result;
+      allRubrics.push([paymentUuid, taxable.rubric_payroll_id, taxable.result]);
+    });
+  }
+
+  const baseTaxable = basicSalary + sumTaxable;
+
+  const grossSalary = basicSalary + sumTaxable + sumNonTaxable;
+
+  if (taxesContributions.length) {
+    taxesContributions.forEach(taxContribution => {
+      taxContribution.result = taxContribution.is_percent
+        ? util.roundDecimal((baseTaxable * taxContribution.value) / 100, DECIMAL_PRECISION)
+        : (taxContribution.result || taxContribution.value);
+
+      // Recovery of the value of the Membership Fee worker share
+      if (taxContribution.is_membership_fee && taxContribution.is_employee) {
+        membershipFeeEmployee = taxContribution.result;
+      }
+    });
+  }
+
+  const baseIpr = ((baseTaxable - membershipFeeEmployee) * (iprExchangeRate / enterpriseExchangeRate));
+
+  // Annual cumulation of Base IPR
+  const annualCumulation = baseIpr * 12;
+
+  debug(`[${employee.code}] Base IPR Rate: ${baseIpr}`);
+
+  let iprValue = 0;
+
+  if (iprScales.length) {
+    iprValue = calculateIPRTaxRate(annualCumulation, iprScales);
+
+    // decrease the tax rate for each child.
+    if (nbChildren > 0) {
+      iprValue -= (iprValue * (nbChildren * 2)) / 100;
     }
 
-    // Calcul value for nontaxable and automatically calculated Expected Seniority_bonus & Family_allowances
-    if (nonTaxables.length) {
-      nonTaxables.forEach(nonTaxable => {
-        if (!nonTaxable.is_seniority_bonus && !nonTaxable.is_family_allowances) {
-          nonTaxable.result = nonTaxable.is_percent
-            ? util.roundDecimal((basicSalary * nonTaxable.value) / 100, DECIMAL_PRECISION)
-            : (nonTaxable.result || nonTaxable.value);
-        }
+    debug(`[${employee.code}] Raw IPR value: ${iprValue}`);
 
-        sumNonTaxable += nonTaxable.result;
-        allRubrics.push([paymentUuid, nonTaxable.rubric_payroll_id, nonTaxable.result]);
-      });
-    }
+    // Convert IPR value in selected Currency
+    iprValue = util.roundDecimal(iprValue * (enterpriseExchangeRate / iprExchangeRate), DECIMAL_PRECISION);
 
-    // Calcul value for taxable and automatically calculated Expected Seniority_bonus & Family_allowances
-    if (taxables.length) {
-      taxables.forEach(taxable => {
-        if (!taxable.is_seniority_bonus && !taxable.is_family_allowances) {
-          taxable.result = taxable.is_percent
-            ? util.roundDecimal((basicSalary * taxable.value) / 100, DECIMAL_PRECISION)
-            : (taxable.result || taxable.value);
-        }
-
-        sumTaxable += taxable.result;
-        allRubrics.push([paymentUuid, taxable.rubric_payroll_id, taxable.result]);
-      });
-    }
-
-    const baseTaxable = basicSalary + sumTaxable;
-
-    const grossSalary = basicSalary + sumTaxable + sumNonTaxable;
+    debug(`[${employee.code}] Final IPR value: ${iprValue}`);
 
     if (taxesContributions.length) {
       taxesContributions.forEach(taxContribution => {
-        taxContribution.result = taxContribution.is_percent
-          ? util.roundDecimal((baseTaxable * taxContribution.value) / 100, DECIMAL_PRECISION)
-          : (taxContribution.result || taxContribution.value);
-
-        // Recovery of the value of the Membership Fee worker share
-        if (taxContribution.is_membership_fee && taxContribution.is_employee) {
-          membershipFeeEmployee = taxContribution.result;
+        // Set the result of IPR calculation
+        if (taxContribution.is_ipr) {
+          taxContribution.result = iprValue;
         }
-      });
-    }
 
-    const baseIpr = ((baseTaxable - membershipFeeEmployee) * (iprExchangeRate / enterpriseExchangeRate));
-
-    // Annual cumulation of Base IPR
-    const annualCumulation = baseIpr * 12;
-
-    debug(`[${employee.code}] Base IPR Rate: ${baseIpr}`);
-
-    let iprValue = 0;
-
-    if (iprScales.length) {
-      iprValue = calculateIPRTaxRate(annualCumulation, iprScales);
-
-      // decrease the tax rate for each child.
-      if (nbChildren > 0) {
-        iprValue -= (iprValue * (nbChildren * 2)) / 100;
-      }
-
-      debug(`[${employee.code}] Raw IPR value: ${iprValue}`);
-
-      // Convert IPR value in selected Currency
-      iprValue = util.roundDecimal(iprValue * (enterpriseExchangeRate / iprExchangeRate), DECIMAL_PRECISION);
-
-      debug(`[${employee.code}] Final IPR value: ${iprValue}`);
-
-      if (taxesContributions.length) {
-        taxesContributions.forEach(taxContribution => {
-          // Set the result of IPR calculation
-          if (taxContribution.is_ipr) {
-            taxContribution.result = iprValue;
-          }
-
-          // Calculation of the sum of taxes and membership fee borne by the employee
-          if (taxContribution.is_employee) { sumTaxContributionEmp += taxContribution.result; }
-
-          allRubrics.push([paymentUuid, taxContribution.rubric_payroll_id, taxContribution.result]);
-        });
-      }
-    } else if (taxesContributions.length) {
-      taxesContributions.forEach(taxContribution => {
         // Calculation of the sum of taxes and membership fee borne by the employee
-        if (taxContribution.is_employee) {
-          sumTaxContributionEmp += taxContribution.result;
-        }
+        if (taxContribution.is_employee) { sumTaxContributionEmp += taxContribution.result; }
 
         allRubrics.push([paymentUuid, taxContribution.rubric_payroll_id, taxContribution.result]);
       });
-
     }
+  } else if (taxesContributions.length) {
+    taxesContributions.forEach(taxContribution => {
+      // Calculation of the sum of taxes and membership fee borne by the employee
+      if (taxContribution.is_employee) {
+        sumTaxContributionEmp += taxContribution.result;
+      }
 
-    const netSalary = grossSalary - sumTaxContributionEmp;
+      allRubrics.push([paymentUuid, taxContribution.rubric_payroll_id, taxContribution.result]);
+    });
 
-    debug(`[${employee.code}] : Net Salary: ${netSalary}, Gross Salary: ${grossSalary}, Base Taxable: ${baseTaxable}`);
+  }
 
-    const paymentData = {
-      uuid : paymentUuid,
-      employee_uuid : db.bid(employee.uuid),
-      payroll_configuration_id : payrollConfigurationId,
-      currency_id : data.currency_id,
-      basic_salary : basicSalary,
-      base_taxable : baseTaxable,
-      daily_salary : dailySalary,
-      total_day : totalDayPeriod,
-      working_day : data.working_day,
-      gross_salary : grossSalary,
-      net_salary : netSalary,
-      amount_paid : 0,
-      status_id : 2,
-    };
+  const netSalary = grossSalary - sumTaxContributionEmp;
 
-    const deletePaymentData = 'DELETE FROM payment WHERE employee_uuid = ? AND payroll_configuration_id = ?';
-    const setPaymentData = 'INSERT INTO payment SET ?';
-    const setRubricPaymentData = `INSERT INTO rubric_payment (payment_uuid, rubric_payroll_id, value)
+  debug(`[${employee.code}] : Net Salary: ${netSalary}, Gross Salary: ${grossSalary}, Base Taxable: ${baseTaxable}`);
+
+  const paymentData = {
+    uuid : paymentUuid,
+    employee_uuid : db.bid(employee.uuid),
+    payroll_configuration_id : payrollConfigurationId,
+    currency_id : data.currency_id,
+    basic_salary : basicSalary,
+    base_taxable : baseTaxable,
+    daily_salary : dailySalary,
+    total_day : totalDayPeriod,
+    working_day : data.working_day,
+    gross_salary : grossSalary,
+    net_salary : netSalary,
+    amount_paid : 0,
+    status_id : 2,
+  };
+
+  const deletePaymentData = 'DELETE FROM payment WHERE employee_uuid = ? AND payroll_configuration_id = ?';
+  const setPaymentData = 'INSERT INTO payment SET ?';
+  const setRubricPaymentData = `INSERT INTO rubric_payment (payment_uuid, rubric_payroll_id, value)
             VALUES ?`;
-    const setHolidayPayment = `INSERT INTO holiday_payment
+  const setHolidayPayment = `INSERT INTO holiday_payment
             (holiday_id, holiday_nbdays, holiday_percentage, payment_uuid, label, value) VALUES ?`;
-    const setOffDayPayment = `INSERT INTO offday_payment
+  const setOffDayPayment = `INSERT INTO offday_payment
             (offday_id, offday_percentage, payment_uuid, label, value) VALUES ?`;
 
-    transaction
-      .addQuery(deletePaymentData, [db.bid(employee.uuid), payrollConfigurationId])
-      .addQuery(setPaymentData, [paymentData]);
+  transaction
+    .addQuery(deletePaymentData, [db.bid(employee.uuid), payrollConfigurationId])
+    .addQuery(setPaymentData, [paymentData]);
 
-    if (allRubrics.length) {
-      transaction.addQuery(setRubricPaymentData, [allRubrics]);
-    }
-
-    if (holidaysElements.length) {
-      transaction.addQuery(setHolidayPayment, [holidaysElements]);
-    }
-
-    if (offDaysElements.length) {
-      transaction.addQuery(setOffDayPayment, [offDaysElements]);
-    }
-
-    await transaction.execute();
-    res.sendStatus(201);
-  } catch (err) {
-    next(err);
+  if (allRubrics.length) {
+    transaction.addQuery(setRubricPaymentData, [allRubrics]);
   }
+
+  if (holidaysElements.length) {
+    transaction.addQuery(setHolidayPayment, [holidaysElements]);
+  }
+
+  if (offDaysElements.length) {
+    transaction.addQuery(setOffDayPayment, [offDaysElements]);
+  }
+
+  await transaction.execute();
+  res.sendStatus(201);
 }
 
 // Configure Payment for Employee

--- a/server/controllers/payroll/multiplePayrollIndice/parameters.config.js
+++ b/server/controllers/payroll/multiplePayrollIndice/parameters.config.js
@@ -342,9 +342,7 @@ async function create(req, res) {
       if (!emp.dayIndex) {
         const messageError = translate(lang)('ERRORS.ER_EMPLOYEE_IS_NOT_CONFIGURED_CORRECTLY');
         const messageErrorFormated = messageError.replace('%EMPLOYEE%', emp.display_name);
-        throw new BadRequest('The employee: is not configured correctly',
-          messageErrorFormated,
-        );
+        throw new BadRequest('The employee: is not configured correctly', messageErrorFormated);
       }
 
       transaction.addQuery(

--- a/server/controllers/payroll/reports/multipayroll.js
+++ b/server/controllers/payroll/reports/multipayroll.js
@@ -29,7 +29,7 @@ const TEMPLATE = './server/controllers/payroll/reports/multipayroll.handlebars';
  * GET /reports/payroll/multipayroll
  */
 async function build(req, res) {
-  const options = _.clone(req.query);
+  const options = structuredClone(req.query);
 
   // delete options.payroll_configuration_id;
   delete options.currency_id;

--- a/server/controllers/payroll/rubricConfig/index.js
+++ b/server/controllers/payroll/rubricConfig/index.js
@@ -22,15 +22,11 @@ async function lookupRubricConfig(id) {
 }
 
 // Lists the Payroll RubricConfigs
-async function list(req, res, next) {
+async function list(req, res) {
   const sql = `SELECT id, label FROM config_rubric;`;
 
-  try {
-    const rows = await db.exec(sql);
-    res.status(200).json(rows);
-  } catch (e) {
-    next(e);
-  }
+  const rows = await db.exec(sql);
+  res.status(200).json(rows);
 }
 
 /**
@@ -38,47 +34,38 @@ async function list(req, res, next) {
 *
 * Returns the detail of a single RubricConfig
 */
-async function detail(req, res, next) {
+async function detail(req, res) {
   const { id } = req.params;
 
-  try {
-    const record = await lookupRubricConfig(id);
-    res.status(200).json(record);
-  } catch (e) {
-    next(e);
-  }
+  const record = await lookupRubricConfig(id);
+  res.status(200).json(record);
 }
 
 // POST /payroll/rubric_config
-async function create(req, res, next) {
+async function create(req, res) {
   const { label, items } = req.body;
 
   debug(`Creating rubric configuration ${label} with ${items.length} items.`);
 
-  try {
+  // first create the config_rubric item so we have the id
+  const row = await db.exec('INSERT INTO config_rubric SET ?', [{ label }]);
 
-    // first create the config_rubric item so we have the id
-    const row = await db.exec('INSERT INTO config_rubric SET ?', [{ label }]);
+  // NOTE(@jniles): you are allowed to make a rubric with just a label, and no items
+  // attached.
+  if (items && items.length > 0) {
+    const configItems = items.map(id => ([id, row.insertId]));
 
-    // NOTE(@jniles): you are allowed to make a rubric with just a label, and no items
-    // attached.
-    if (items && items.length > 0) {
-      const configItems = items.map(id => ([id, row.insertId]));
-
-      // next, create the config_rubric_item records
-      await db.exec('INSERT INTO config_rubric_item (rubric_payroll_id, config_rubric_id) VALUES ?', [configItems]);
-    }
-
-    // if all goes well, return to the client
-    // TODO(@jniles): use a db.transcation here so that we are able to roll this back as needed.
-    res.status(201).json({ id : row.insertId });
-  } catch (e) {
-    next(e);
+    // next, create the config_rubric_item records
+    await db.exec('INSERT INTO config_rubric_item (rubric_payroll_id, config_rubric_id) VALUES ?', [configItems]);
   }
+
+  // if all goes well, return to the client
+  // TODO(@jniles): use a db.transcation here so that we are able to roll this back as needed.
+  res.status(201).json({ id : row.insertId });
 }
 
 // PUT /payroll/rubric_config/:id
-async function update(req, res, next) {
+async function update(req, res) {
   const sql = `UPDATE config_rubric SET ? WHERE id = ?;`;
 
   debug(`Updating rubric configuration with id ${req.params.id}.`);
@@ -86,47 +73,39 @@ async function update(req, res, next) {
   const items = req.body.items.map(id => ([id, req.params.id]));
   delete req.body.items;
 
-  try {
-    await db.exec(sql, [req.body, req.params.id]);
+  await db.exec(sql, [req.body, req.params.id]);
 
-    const transaction = db.transaction()
-      .addQuery(sql, [req.body, req.params.id])
-      .addQuery('DELETE FROM config_rubric_item WHERE config_rubric_id = ?;', [req.params.id]);
+  const transaction = db.transaction()
+    .addQuery(sql, [req.body, req.params.id])
+    .addQuery('DELETE FROM config_rubric_item WHERE config_rubric_id = ?;', [req.params.id]);
 
-    if (items.length > 0) {
-      transaction
-        .addQuery('INSERT INTO config_rubric_item (rubric_payroll_id, config_rubric_id) VALUES ?', [items]);
-    }
-
-    await transaction.execute();
-
-    // all updates completed successfull, return full object to client
-    const record = await lookupRubricConfig(req.params.id);
-
-    res.status(200).json(record);
-  } catch (e) {
-    next(e);
+  if (items.length > 0) {
+    transaction
+      .addQuery('INSERT INTO config_rubric_item (rubric_payroll_id, config_rubric_id) VALUES ?', [items]);
   }
+
+  await transaction.execute();
+
+  // all updates completed successfull, return full object to client
+  const record = await lookupRubricConfig(req.params.id);
+
+  res.status(200).json(record);
 }
 
 // DELETE /payroll/rubric_config/:id
-async function del(req, res, next) {
+async function del(req, res) {
 
-  try {
-    // check to see if the rubric configuration exists
-    await lookupRubricConfig(req.params.id);
+  // check to see if the rubric configuration exists
+  await lookupRubricConfig(req.params.id);
 
-    // if so, delete it.
-    await db.transaction()
-      .addQuery('DELETE FROM config_rubric_item WHERE config_rubric_id = ?;', [req.params.id])
-      .addQuery('DELETE FROM config_rubric WHERE id = ?;', [req.params.id])
-      .execute();
+  // if so, delete it.
+  await db.transaction()
+    .addQuery('DELETE FROM config_rubric_item WHERE config_rubric_id = ?;', [req.params.id])
+    .addQuery('DELETE FROM config_rubric WHERE id = ?;', [req.params.id])
+    .execute();
 
-    res.sendStatus(204);
+  res.sendStatus(204);
 
-  } catch (e) {
-    next(e);
-  }
 }
 
 // get list of rubrics configurations

--- a/server/controllers/payroll/rubrics/index.js
+++ b/server/controllers/payroll/rubrics/index.js
@@ -95,8 +95,8 @@ async function update(req, res) {
 }
 
 // DELETE /rubrics/:id
-function del(req, res, next) {
-  db.delete('rubric_payroll', 'id', req.params.id, res, next, `Could not find a Rubric with id ${req.params.id}`);
+async function del(req, res) {
+  await db.delete('rubric_payroll', 'id', req.params.id, res, `Could not find a Rubric with id ${req.params.id}`);
 }
 
 // get list of Rubric

--- a/server/controllers/payroll/rubrics/index.js
+++ b/server/controllers/payroll/rubrics/index.js
@@ -23,7 +23,7 @@ function lookupRubric(id) {
 }
 
 // Lists the Payroll Rubrics
-async function list(req, res, next) {
+async function list(req, res) {
   const filters = new FilterParser(req.query, { tableAlias : 'r' });
 
   const sql = `
@@ -47,10 +47,8 @@ async function list(req, res, next) {
   const query = filters.applyQuery(sql);
   const parameters = filters.parameters();
 
-  try {
-    const rows = await db.exec(query, parameters);
-    res.status(200).json(rows);
-  } catch (e) { next(e); }
+  const rows = await db.exec(query, parameters);
+  res.status(200).json(rows);
 }
 
 /**
@@ -66,16 +64,14 @@ async function detail(req, res) {
 }
 
 // POST /rubrics
-async function create(req, res, next) {
+async function create(req, res) {
   const sql = `INSERT INTO rubric_payroll SET ?`;
   const data = req.body;
-  try {
-    const result = await db.exec(sql, [data]);
-    res.status(201).json({ id : result.insertId });
-  } catch (e) { next(e); }
+  const result = await db.exec(sql, [data]);
+  res.status(201).json({ id : result.insertId });
 }
 
-async function importIndexes(req, res, next) {
+async function importIndexes(req, res) {
   const { lang } = req.body;
   const transaction = db.transaction();
   const trslt = translate(lang);
@@ -85,21 +81,17 @@ async function importIndexes(req, res, next) {
     transaction.addQuery('INSERT INTO rubric_payroll SET ?', rubric);
   });
 
-  try {
-    await transaction.execute();
-    res.sendStatus(201);
-  } catch (e) { next(e); }
+  await transaction.execute();
+  res.sendStatus(201);
 }
 
 // PUT /rubrics/:id
-async function update(req, res, next) {
+async function update(req, res) {
   const sql = `UPDATE rubric_payroll SET ? WHERE id = ?;`;
   const rubricPayrollId = req.params.id;
-  try {
-    await db.exec(sql, [req.body, rubricPayrollId]);
-    const record = await lookupRubric(rubricPayrollId);
-    res.status(200).json(record);
-  } catch (e) { next(e); }
+  await db.exec(sql, [req.body, rubricPayrollId]);
+  const record = await lookupRubric(rubricPayrollId);
+  res.status(200).json(record);
 }
 
 // DELETE /rubrics/:id

--- a/server/controllers/payroll/weekendConfig/index.js
+++ b/server/controllers/payroll/weekendConfig/index.js
@@ -80,9 +80,9 @@ async function update(req, res) {
 }
 
 // DELETE /weekend_config/:id
-function del(req, res, next) {
-  db.delete(
-    'weekend_config', 'id', req.params.id, res, next, `Could not find a Weekend configuration with id ${req.params.id}`,
+async function del(req, res) {
+  await db.delete(
+    'weekend_config', 'id', req.params.id, res, `Could not find a Weekend configuration with id ${req.params.id}`,
   );
 }
 

--- a/server/controllers/stock/api/rumer.js
+++ b/server/controllers/stock/api/rumer.js
@@ -13,11 +13,7 @@ const rumer = require('../functions/rumer.function');
  */
 exports.getData = getData;
 
-async function getData(req, res, next) {
-  try {
-    const output = await rumer.getData(req.query);
-    res.status(200).json(output.data);
-  } catch (error) {
-    next(error);
-  }
+async function getData(req, res) {
+  const output = await rumer.getData(req.query);
+  res.status(200).json(output.data);
 }

--- a/server/controllers/stock/core.js
+++ b/server/controllers/stock/core.js
@@ -1367,14 +1367,10 @@ async function getInventoryMovements(params) {
   };
 }
 
-async function listStatus(req, res, next) {
+async function listStatus(req, res) {
   const sql = `SELECT id, status_key, title_key, class_style FROM status`;
-  try {
-    const status = await db.exec(sql);
-    res.status(200).json(status);
-  } catch (e) {
-    next(e);
-  }
+  const status = await db.exec(sql);
+  res.status(200).json(status);
 }
 
 // Add the tags for the lots

--- a/server/controllers/stock/functions/rumer.function.js
+++ b/server/controllers/stock/functions/rumer.function.js
@@ -1,4 +1,3 @@
-const _ = require('lodash');
 const moment = require('moment');
 
 const db = require('../../../lib/db');
@@ -22,7 +21,7 @@ const DEFAULT_PARAMS = {
  * GET /stock/rumer
  */
 async function getData(reqQuery) {
-  const params = reqQuery;
+  let params = reqQuery;
   params.depotUuid = params.depotUuid || params.depot_uuid;
   params.exclude_out_stock = parseInt(params.exclude_out_stock, 10);
   params.include_daily_balances = parseInt(params.include_daily_balances, 10);
@@ -59,7 +58,7 @@ async function getData(reqQuery) {
     includeEmptyLot : 1,
   };
 
-  _.defaults(params, DEFAULT_PARAMS);
+  params = { ...DEFAULT_PARAMS, ...params };
 
   try {
 

--- a/server/controllers/stock/index.js
+++ b/server/controllers/stock/index.js
@@ -66,120 +66,115 @@ exports.dashboard = dashboard;
  * POST /stock/lots
  * Create a new stock lots entry
  */
-async function createStock(req, res, next) {
+async function createStock(req, res) {
+  const params = req.body;
+  const documentUuid = uuid();
 
-  try {
-    const params = req.body;
-    const documentUuid = uuid();
+  const period = await Fiscal.lookupFiscalYearByDate(params.date);
+  const periodId = period.id;
 
-    const period = await Fiscal.lookupFiscalYearByDate(params.date);
-    const periodId = period.id;
+  const transaction = db.transaction();
+  const document = {
+    uuid : documentUuid,
+    date : new Date(params.date),
+    user : req.session.user.id,
+    depot_uuid : params.depot_uuid,
+    flux_id : params.flux_id,
+    description : params.description,
+    reference_number : params.reference_number,
+    serial_number : params.serial_number,
+  };
 
-    const transaction = db.transaction();
-    const document = {
-      uuid : documentUuid,
-      date : new Date(params.date),
-      user : req.session.user.id,
-      depot_uuid : params.depot_uuid,
-      flux_id : params.flux_id,
-      description : params.description,
-      reference_number : params.reference_number,
-      serial_number : params.serial_number,
-    };
+  // prepare lot insertion query
+  const createLotQuery = 'INSERT INTO lot SET ?';
 
-    // prepare lot insertion query
-    const createLotQuery = 'INSERT INTO lot SET ?';
+  // prepare movement insertion query
+  const createMovementQuery = 'INSERT INTO stock_movement SET ?';
 
-    // prepare movement insertion query
-    const createMovementQuery = 'INSERT INTO stock_movement SET ?';
+  params.lots.forEach(lot => {
 
-    params.lots.forEach(lot => {
+    let lotUuid = lot.uuid;
 
-      let lotUuid = lot.uuid;
+    if (lotUuid === null || typeof lotUuid === 'undefined') {
+      // Create new lot (if one it does not already exist)
+      lotUuid = uuid();
 
-      if (lotUuid === null || typeof lotUuid === 'undefined') {
-        // Create new lot (if one it does not already exist)
-        lotUuid = uuid();
+      // parse the dates
+      const date = new Date(lot.expiration_date);
+      const acquitionDate = new Date(lot.acquisition_date);
 
-        // parse the dates
-        const date = new Date(lot.expiration_date);
-        const acquitionDate = new Date(lot.acquisition_date);
-
-        // the lot object to insert
-        const createLotObject = {
-          uuid : db.bid(lotUuid),
-          label : lot.label,
-          quantity : lot.quantity,
-          unit_cost : lot.unit_cost,
-          description : lot.description,
-          expiration_date : date,
-          inventory_uuid : db.bid(lot.inventory_uuid),
-          reference_number : lot.reference_number,
-          serial_number : lot.serial_number,
-          acquisition_date : acquitionDate || null,
-          package_size : lot.package_size || 1,
-          funding_source_uuid : lot.funding_source_uuid ? db.bid(lot.funding_source_uuid) : null,
-        };
-
-        // adding a lot insertion query into the transaction
-        transaction.addQuery(createLotQuery, [createLotObject]);
-      }
-
-      // the movement object to insert
-      const createMovementObject = {
-        uuid : db.bid(uuid()),
-        lot_uuid : db.bid(lotUuid),
-        depot_uuid : db.bid(document.depot_uuid),
-        document_uuid : db.bid(documentUuid),
-        flux_id : params.flux_id,
-        date : document.date,
+      // the lot object to insert
+      const createLotObject = {
+        uuid : db.bid(lotUuid),
+        label : lot.label,
         quantity : lot.quantity,
         unit_cost : lot.unit_cost,
-        is_exit : 0,
-        user_id : document.user,
-        description : document.description,
-        period_id : periodId,
+        description : lot.description,
+        expiration_date : date,
+        inventory_uuid : db.bid(lot.inventory_uuid),
+        reference_number : lot.reference_number,
+        serial_number : lot.serial_number,
+        acquisition_date : acquitionDate || null,
+        package_size : lot.package_size || 1,
+        funding_source_uuid : lot.funding_source_uuid ? db.bid(lot.funding_source_uuid) : null,
       };
 
-      if (params.entity_uuid) {
-        createMovementObject.entity_uuid = db.bid(params.entity_uuid);
-      }
+      // adding a lot insertion query into the transaction
+      transaction.addQuery(createLotQuery, [createLotObject]);
+    }
 
-      // adding a movement insertion query into the transaction
-      transaction.addQuery(createMovementQuery, [createMovementObject]);
+    // the movement object to insert
+    const createMovementObject = {
+      uuid : db.bid(uuid()),
+      lot_uuid : db.bid(lotUuid),
+      depot_uuid : db.bid(document.depot_uuid),
+      document_uuid : db.bid(documentUuid),
+      flux_id : params.flux_id,
+      date : document.date,
+      quantity : lot.quantity,
+      unit_cost : lot.unit_cost,
+      is_exit : 0,
+      user_id : document.user,
+      description : document.description,
+      period_id : periodId,
+    };
+
+    if (params.entity_uuid) {
+      createMovementObject.entity_uuid = db.bid(params.entity_uuid);
+    }
+
+    // adding a movement insertion query into the transaction
+    transaction.addQuery(createMovementQuery, [createMovementObject]);
+  });
+
+  const isExit = 0;
+  const postingParams = [db.bid(documentUuid), isExit, req.session.project.id];
+
+  if (req.session.stock_settings.enable_auto_stock_accounting) {
+    transaction.addQuery('CALL PostStockMovement(?)', [postingParams]);
+  }
+
+  // gather unique inventory uuids for use later recomputing the stock quantities
+  const inventoryUuids = params.lots
+    .map(lot => lot.inventory_uuid)
+    .filter((uid, index, array) => array.lastIndexOf(uid) === index);
+
+  // if we are adding stock, we must update the weighted average cost
+  if (!isExit && params.flux_id !== core.flux.FROM_OTHER_DEPOT) {
+    inventoryUuids.forEach(uid => {
+      transaction.addQuery('CALL StageInventoryForStockValue(?);', [db.bid(uid)]);
     });
 
-    const isExit = 0;
-    const postingParams = [db.bid(documentUuid), isExit, req.session.project.id];
-
-    if (req.session.stock_settings.enable_auto_stock_accounting) {
-      transaction.addQuery('CALL PostStockMovement(?)', [postingParams]);
-    }
-
-    // gather unique inventory uuids for use later recomputing the stock quantities
-    const inventoryUuids = params.lots
-      .map(lot => lot.inventory_uuid)
-      .filter((uid, index, array) => array.lastIndexOf(uid) === index);
-
-    // if we are adding stock, we must update the weighted average cost
-    if (!isExit && params.flux_id !== core.flux.FROM_OTHER_DEPOT) {
-      inventoryUuids.forEach(uid => {
-        transaction.addQuery('CALL StageInventoryForStockValue(?);', [db.bid(uid)]);
-      });
-
-      transaction.addQuery('CALL RecomputeStockValueForStagedInventory(NULL);');
-    }
-
-    // execute all operations as one transaction
-    await transaction.execute();
-
-    // update the quantity in stock as needed
-    await updateQuantityInStockAfterMovement(inventoryUuids, params.date, document.depot_uuid);
-
-    res.status(201).json({ uuid : documentUuid });
-  } catch (ex) {
-    next(ex);
+    transaction.addQuery('CALL RecomputeStockValueForStagedInventory(NULL);');
   }
+
+  // execute all operations as one transaction
+  await transaction.execute();
+
+  // update the quantity in stock as needed
+  await updateQuantityInStockAfterMovement(inventoryUuids, params.date, document.depot_uuid);
+
+  res.status(201).json({ uuid : documentUuid });
 }
 
 /**
@@ -281,175 +276,168 @@ async function insertNewStock(session, params) {
  * POST /stock/integration
  * create a new integration entry
  */
-function createIntegration(req, res, next) {
-  insertNewStock(req.session, req.body)
-    .then(documentUuid => {
-      res.status(201).json({ uuid : documentUuid });
-    })
-    .catch(next);
+async function createIntegration(req, res) {
+  const documentUuid = await insertNewStock(req.session, req.body);
+  res.status(201).json({ uuid : documentUuid });
 }
 
 /**
  * POST /stock/inventory_adjustment
  * Stock inventory adjustment
  */
-async function createInventoryAdjustment(req, res, next) {
-  try {
-    let movement = req.body;
-    const isMobileSync = movement.sync_mobile;
+async function createInventoryAdjustment(req, res) {
+  let movement = req.body;
+  const isMobileSync = movement.sync_mobile;
 
-    if (isMobileSync === 1) {
-      movement = await movementsFromMobile(movement);
+  if (isMobileSync === 1) {
+    movement = await movementsFromMobile(movement);
+  }
+  let filteredInvalidData = [];
+
+  const paramsStock = {
+    dateTo : new Date(),
+    depot_uuid : movement.depot_uuid,
+    includeEmptyLot : 0,
+    month_average_consumption : req.session.stock_settings.month_average_consumption,
+    average_consumption_algo : req.session.stock_settings.average_consumption_algo,
+  };
+
+  const stockAvailable = await core.getLotsDepot(null, paramsStock);
+
+  if (!movement.depot_uuid) {
+    throw new Error('No defined depot');
+  }
+
+  // only consider lots that have changed.
+  const lots = movement.lots
+    .filter(l => l.quantity !== l.oldQuantity);
+
+  const period = await Fiscal.lookupFiscalYearByDate(new Date(movement.date));
+  const periodId = period.id;
+
+  const trx = db.transaction();
+  const uniqueAdjustmentUuid = uuid();
+
+  let countNeedIncrease = 0;
+  let countNeedDecrease = 0;
+
+  lots.forEach(lot => {
+    lot.quantityAvailable = 0;
+
+    if (lot.oldQuantity > lot.quantity) {
+      lot.isExit = 1;
+      lot.outputQuantity = lot.oldQuantity - lot.quantity;
+
+      if (stockAvailable) {
+        stockAvailable.forEach(stock => {
+          if (stock.uuid === lot.uuid) {
+            lot.quantityAvailable = stock.quantity;
+          }
+        });
+      }
     }
-    let filteredInvalidData = [];
+  });
 
-    const paramsStock = {
-      dateTo : new Date(),
-      depot_uuid : movement.depot_uuid,
-      includeEmptyLot : 0,
-      month_average_consumption : req.session.stock_settings.month_average_consumption,
-      average_consumption_algo : req.session.stock_settings.average_consumption_algo,
+  filteredInvalidData = await lots.filter(l => l.outputQuantity > l.quantityAvailable);
+
+  if (filteredInvalidData.length) {
+    throw new BadRequest(
+      `This stock adjustement will overconsume the quantity in stock and generate negative quantity in stock`,
+      `ERRORS.ER_PREVENT_NEGATIVE_QUANTITY_IN_ADJUSTMENT_STOCK`,
+    );
+  }
+
+  // get unit costs from stock_value
+  const inventoryUuids = lots.map(l => db.bid(l.inventory_uuid));
+  const unitCosts = await db.exec(
+    'SELECT BUID(inventory_uuid) as inventory_uuid, wac FROM stock_value WHERE inventory_uuid in (?);',
+    [inventoryUuids]);
+
+  const unitCostMap = new Map(unitCosts.map(cost => [cost.inventory_uuid, cost.wac]));
+
+  lots.forEach(lot => {
+    // adjust lot's unit cost with the wac cost of the inventory
+    // so that the receipt will reflect the stock sheet paper
+    lot.unit_cost = unitCostMap.get(lot.inventory_uuid);
+
+    const difference = lot.quantity - lot.oldQuantity;
+
+    const adjustmentMovement = {
+      uuid : db.bid(uuid()),
+      lot_uuid : db.bid(lot.uuid),
+      depot_uuid : db.bid(movement.depot_uuid),
+      document_uuid : db.bid(uniqueAdjustmentUuid),
+      quantity : Math.abs(difference),
+      unit_cost : lot.unit_cost,
+      date : new Date(movement.date),
+      entity_uuid : movement.entity_uuid,
+      flux_id : core.flux.INVENTORY_ADJUSTMENT,
+      description : movement.description,
+      user_id : req.session.user.id,
+      period_id : periodId,
     };
 
-    const stockAvailable = await core.getLotsDepot(null, paramsStock);
+    const log = {
+      movement_uuid : adjustmentMovement.uuid,
+      old_quantity : lot.oldQuantity,
+      new_quantity : lot.quantity,
+    };
 
-    if (!movement.depot_uuid) {
-      throw new Error('No defined depot');
+    if (difference < 0) {
+      // we have to do a stock exit movement
+      // we must subtract the |difference| to the current quantity
+      countNeedDecrease++;
+      adjustmentMovement.is_exit = 1;
+    } else {
+      // we must do increase the current quantity by the |difference|
+      countNeedIncrease++;
+      adjustmentMovement.is_exit = 0;
     }
 
-    // only consider lots that have changed.
-    const lots = movement.lots
-      .filter(l => l.quantity !== l.oldQuantity);
+    trx.addQuery('INSERT INTO stock_movement SET ?', adjustmentMovement);
+    trx.addQuery('INSERT INTO stock_adjustment_log SET ?', log);
+  });
 
-    const period = await Fiscal.lookupFiscalYearByDate(new Date(movement.date));
-    const periodId = period.id;
+  const decreaseParams = [
+    db.bid(uniqueAdjustmentUuid), 1, req.session.project.id,
+  ];
 
-    const trx = db.transaction();
-    const uniqueAdjustmentUuid = uuid();
+  const increaseParams = [
+    db.bid(uniqueAdjustmentUuid), 0, req.session.project.id,
+  ];
 
-    let countNeedIncrease = 0;
-    let countNeedDecrease = 0;
-
-    lots.forEach(lot => {
-      lot.quantityAvailable = 0;
-
-      if (lot.oldQuantity > lot.quantity) {
-        lot.isExit = 1;
-        lot.outputQuantity = lot.oldQuantity - lot.quantity;
-
-        if (stockAvailable) {
-          stockAvailable.forEach(stock => {
-            if (stock.uuid === lot.uuid) {
-              lot.quantityAvailable = stock.quantity;
-            }
-          });
-        }
-      }
-    });
-
-    filteredInvalidData = await lots.filter(l => l.outputQuantity > l.quantityAvailable);
-
-    if (filteredInvalidData.length) {
-      throw new BadRequest(
-        `This stock adjustement will overconsume the quantity in stock and generate negative quantity in stock`,
-        `ERRORS.ER_PREVENT_NEGATIVE_QUANTITY_IN_ADJUSTMENT_STOCK`,
-      );
+  if (req.session.stock_settings.enable_auto_stock_accounting) {
+    if (countNeedDecrease > 0) {
+      trx.addQuery('CALL PostStockMovement(?)', [decreaseParams]);
     }
 
-    // get unit costs from stock_value
-    const inventoryUuids = lots.map(l => db.bid(l.inventory_uuid));
-    const unitCosts = await db.exec(
-      'SELECT BUID(inventory_uuid) as inventory_uuid, wac FROM stock_value WHERE inventory_uuid in (?);',
-      [inventoryUuids]);
-
-    const unitCostMap = new Map(unitCosts.map(cost => [cost.inventory_uuid, cost.wac]));
-
-    lots.forEach(lot => {
-      // adjust lot's unit cost with the wac cost of the inventory
-      // so that the receipt will reflect the stock sheet paper
-      lot.unit_cost = unitCostMap.get(lot.inventory_uuid);
-
-      const difference = lot.quantity - lot.oldQuantity;
-
-      const adjustmentMovement = {
-        uuid : db.bid(uuid()),
-        lot_uuid : db.bid(lot.uuid),
-        depot_uuid : db.bid(movement.depot_uuid),
-        document_uuid : db.bid(uniqueAdjustmentUuid),
-        quantity : Math.abs(difference),
-        unit_cost : lot.unit_cost,
-        date : new Date(movement.date),
-        entity_uuid : movement.entity_uuid,
-        flux_id : core.flux.INVENTORY_ADJUSTMENT,
-        description : movement.description,
-        user_id : req.session.user.id,
-        period_id : periodId,
-      };
-
-      const log = {
-        movement_uuid : adjustmentMovement.uuid,
-        old_quantity : lot.oldQuantity,
-        new_quantity : lot.quantity,
-      };
-
-      if (difference < 0) {
-        // we have to do a stock exit movement
-        // we must subtract the |difference| to the current quantity
-        countNeedDecrease++;
-        adjustmentMovement.is_exit = 1;
-      } else {
-        // we must do increase the current quantity by the |difference|
-        countNeedIncrease++;
-        adjustmentMovement.is_exit = 0;
-      }
-
-      trx.addQuery('INSERT INTO stock_movement SET ?', adjustmentMovement);
-      trx.addQuery('INSERT INTO stock_adjustment_log SET ?', log);
-    });
-
-    const decreaseParams = [
-      db.bid(uniqueAdjustmentUuid), 1, req.session.project.id,
-    ];
-
-    const increaseParams = [
-      db.bid(uniqueAdjustmentUuid), 0, req.session.project.id,
-    ];
-
-    if (req.session.stock_settings.enable_auto_stock_accounting) {
-      if (countNeedDecrease > 0) {
-        trx.addQuery('CALL PostStockMovement(?)', [decreaseParams]);
-      }
-
-      if (countNeedIncrease > 0) {
-        trx.addQuery('CALL PostStockMovement(?)', [increaseParams]);
-      }
+    if (countNeedIncrease > 0) {
+      trx.addQuery('CALL PostStockMovement(?)', [increaseParams]);
     }
+  }
 
-    trx.addQuery('CALL RecomputeStockValue(NULL);');
+  trx.addQuery('CALL RecomputeStockValue(NULL);');
 
-    // reset all previous lots
-    await trx.execute();
+  // reset all previous lots
+  await trx.execute();
 
-    if (isMobileSync === 1) {
-      const uuids = lots.map(l => l.uuid).join(',');
-      return res.status(201)
-        .json({
-          uuid : uniqueAdjustmentUuid,
-          date : new Date(movement.date),
-          user : req.session.user.id,
-          uuids,
-        });
-    }
-    // await normalMovement(document, movement, req.session);
+  if (isMobileSync === 1) {
+    const uuids = lots.map(l => l.uuid).join(',');
     return res.status(201)
       .json({
         uuid : uniqueAdjustmentUuid,
         date : new Date(movement.date),
         user : req.session.user.id,
+        uuids,
       });
-  } catch (err) {
-    return next(err);
   }
+  // await normalMovement(document, movement, req.session);
+  return res.status(201)
+    .json({
+      uuid : uniqueAdjustmentUuid,
+      date : new Date(movement.date),
+      user : req.session.user.id,
+    });
 }
 
 async function movementsFromMobile(params) {
@@ -581,7 +569,7 @@ async function movementsFromMobile(params) {
  *
  * POST /stock/lots/movement
  */
-async function createMovement(req, res, next) {
+async function createMovement(req, res) {
   let params = req.body;
   const isMobileSync = params.sync_mobile;
 
@@ -590,7 +578,7 @@ async function createMovement(req, res, next) {
   }
 
   if (!params.lots || !params.lots.length) {
-    return next(new BadRequest('The stock movement is not valid'));
+    throw new BadRequest('The stock movement is not valid');
   }
 
   const document = {
@@ -606,67 +594,63 @@ async function createMovement(req, res, next) {
     stock_settings : req.session.stock_settings,
   };
 
-  try {
-    // when exit, we need to check that we are not accidentally over-consuming items
-    if (params.is_exit) {
-      // NOTE(@jniles) - we use _today's_ date because we want to know if this movement will
-      // cause a negative value at any point in the future.
-      const stockInDepot = await depots.getLotsInStockForDate(params.depot_uuid, new Date());
+  // when exit, we need to check that we are not accidentally over-consuming items
+  if (params.is_exit) {
+    // NOTE(@jniles) - we use _today's_ date because we want to know if this movement will
+    // cause a negative value at any point in the future.
+    const stockInDepot = await depots.getLotsInStockForDate(params.depot_uuid, new Date());
 
-      // get a list of the lots that are being overconsumed
-      // if the lot is in the depot, that means it was totally consumed at some point
-      const overconsumed = params.lots.filter(lot => {
-        const lotInDepot = stockInDepot.find(l => l.lot_uuid === lot.uuid);
-        if (!lotInDepot) { return true; }
-        return lot.quantity > lotInDepot.quantity;
-      });
-
-      // show a nicer error if the quantity in stock is overconsumed
-      if (overconsumed.length) {
-        const labels = overconsumed.map(l => l.label).join(', ').trim();
-        throw new BadRequest(
-          `This stock exit will overconsume the lots in stock and create negative quantity in stock for ${labels}.`,
-          `ERRORS.ER_PREVENT_NEGATIVE_QUANTITY_IN_EXIT_STOCK`,
-        );
-      }
-    }
-
-    // get unit costs from stock_value
-    const inventoryUuids = params.lots.map(l => db.bid(l.inventory_uuid));
-    const unitCosts = await db.exec(
-      'SELECT BUID(inventory_uuid) as inventory_uuid, wac FROM stock_value WHERE inventory_uuid in (?);',
-      [inventoryUuids]);
-
-    const unitCostMap = new Map(unitCosts.map(cost => [cost.inventory_uuid, cost.wac]));
-
-    params.lots.forEach(lot => {
-      lot.unit_cost = unitCostMap.get(lot.inventory_uuid);
+    // get a list of the lots that are being overconsumed
+    // if the lot is in the depot, that means it was totally consumed at some point
+    const overconsumed = params.lots.filter(lot => {
+      const lotInDepot = stockInDepot.find(l => l.lot_uuid === lot.uuid);
+      if (!lotInDepot) { return true; }
+      return lot.quantity > lotInDepot.quantity;
     });
 
-    // NOTE(@jniles) - the id here is the period id, not the fiscal year id.
-    const periodId = (await Fiscal.lookupFiscalYearByDate(params.date)).id;
-    params.period_id = periodId;
-
-    const isDepotMovement = (params.from_depot && params.to_depot);
-    const stockMovementFn = isDepotMovement ? depotMovement : normalMovement;
-    await stockMovementFn(document, params, metadata);
-
-    if (isMobileSync === 1) {
-      const uuids = params.lots.map(l => l.uuid).join(',');
-      return res.status(201).json({ uuid : document.uuid, uuids });
+    // show a nicer error if the quantity in stock is overconsumed
+    if (overconsumed.length) {
+      const labels = overconsumed.map(l => l.label).join(', ').trim();
+      throw new BadRequest(
+        `This stock exit will overconsume the lots in stock and create negative quantity in stock for ${labels}.`,
+        `ERRORS.ER_PREVENT_NEGATIVE_QUANTITY_IN_EXIT_STOCK`,
+      );
     }
-
-    return res.status(201).json({ uuid : document.uuid });
-  } catch (err) {
-    return next(err);
   }
+
+  // get unit costs from stock_value
+  const inventoryUuids = params.lots.map(l => db.bid(l.inventory_uuid));
+  const unitCosts = await db.exec(
+    'SELECT BUID(inventory_uuid) as inventory_uuid, wac FROM stock_value WHERE inventory_uuid in (?);',
+    [inventoryUuids]);
+
+  const unitCostMap = new Map(unitCosts.map(cost => [cost.inventory_uuid, cost.wac]));
+
+  params.lots.forEach(lot => {
+    lot.unit_cost = unitCostMap.get(lot.inventory_uuid);
+  });
+
+  // NOTE(@jniles) - the id here is the period id, not the fiscal year id.
+  const periodId = (await Fiscal.lookupFiscalYearByDate(params.date)).id;
+  params.period_id = periodId;
+
+  const isDepotMovement = (params.from_depot && params.to_depot);
+  const stockMovementFn = isDepotMovement ? depotMovement : normalMovement;
+  await stockMovementFn(document, params, metadata);
+
+  if (isMobileSync === 1) {
+    const uuids = params.lots.map(l => l.uuid).join(',');
+    return res.status(201).json({ uuid : document.uuid, uuids });
+  }
+
+  return res.status(201).json({ uuid : document.uuid });
 }
 
 /**
  * @method deleteMovement
  * @desc perform a stock movement deletion based on its document uuid
  */
-async function deleteMovement(req, res, next) {
+async function deleteMovement(req, res) {
   const tx = db.transaction();
   const identifier = db.bid(req.params.document_uuid);
   const stockSettings = req.session.stock_settings;
@@ -674,14 +658,12 @@ async function deleteMovement(req, res, next) {
   // delete stock movement.
   const isUserAuthorized = req.session.actions.includes(DELETE_STOCK_MOVEMENT);
 
-  try {
+  if (!isUserAuthorized) {
+    throw new Unauthorized(`User ${req.session.user.username} is not authorized to delete stock movements.`);
+  }
 
-    if (!isUserAuthorized) {
-      throw new Unauthorized(`User ${req.session.user.username} is not authorized to delete stock movements.`);
-    }
-
-    // movement details for future quantity update
-    const movementDetailsQuery = `
+  // movement details for future quantity update
+  const movementDetailsQuery = `
       SELECT DISTINCT BUID(m.depot_uuid) AS depot_uuid, BUID(l.inventory_uuid) AS inventory_uuid,
         m.is_exit, m.date
       FROM stock_movement m
@@ -689,57 +671,54 @@ async function deleteMovement(req, res, next) {
       WHERE m.document_uuid = ?
     `;
 
-    const movementDetails = await db.exec(movementDetailsQuery, [identifier]);
+  const movementDetails = await db.exec(movementDetailsQuery, [identifier]);
 
-    // delete the movement(s)
-    const movementDeletionQuery = `
+  // delete the movement(s)
+  const movementDeletionQuery = `
       DELETE FROM stock_movement WHERE document_uuid = ?;
     `;
 
-    tx.addQuery(movementDeletionQuery, [identifier]);
+  tx.addQuery(movementDeletionQuery, [identifier]);
 
-    const oldestDate = Math.min(...movementDetails.map(m => m.date));
+  const oldestDate = Math.min(...movementDetails.map(m => m.date));
 
-    // delete lots from (purchase, donation and integration)
-    const deleteLots = `
+  // delete lots from (purchase, donation and integration)
+  const deleteLots = `
       DELETE FROM lot WHERE uuid IN (
         SELECT uuid FROM stock_movement WHERE document_uuid = ? AND flux_id IN (1, 6, 13)
       );
     `;
 
-    tx.addQuery(deleteLots, [identifier]);
+  tx.addQuery(deleteLots, [identifier]);
 
-    tx.addQuery('CALL RecomputeStockValue(NULL);');
+  tx.addQuery('CALL RecomputeStockValue(NULL);');
 
-    // remove stock movements and related lots
-    // by removing stock movements, only quantities are affected
-    // accounting amounts are not touched in the next line
-    await tx.execute();
+  // remove stock movements and related lots
+  // by removing stock movements, only quantities are affected
+  // accounting amounts are not touched in the next line
+  await tx.execute();
 
-    if (stockSettings.enable_auto_stock_accounting) {
-      // find transaction's record_uuid from journal
-      // safely delete voucher related to record_uuid found
-      const findTransactionInJournal = `
+  if (stockSettings.enable_auto_stock_accounting) {
+    // find transaction's record_uuid from journal
+    // safely delete voucher related to record_uuid found
+    const findTransactionInJournal = `
         SELECT DISTINCT record_uuid FROM posting_journal WHERE reference_uuid = ?
       `;
-      const records = await db.exec(findTransactionInJournal, [identifier]);
-      const dbPromise = records.map(item => vouchers.safelyDeleteVoucher(item.record_uuid));
-      await Promise.all(dbPromise);
-    }
-
-    // update the quantity of inventories
-    const inventoriesByDepots = _.groupBy(movementDetails, 'depot_uuid');
-    const inventoriesToUpdates = Object.keys(inventoriesByDepots).map(depot => {
-      const inventories = inventoriesByDepots[depot].map(item => item.inventory_uuid);
-      return updateQuantityInStockAfterMovement(inventories, new Date(oldestDate), depot);
-    });
-
-    await Promise.all(inventoriesToUpdates);
-
-    res.sendStatus(204);
-  } catch (error) {
-    next(error);
+    const records = await db.exec(findTransactionInJournal, [identifier]);
+    const dbPromise = records.map(item => vouchers.safelyDeleteVoucher(item.record_uuid));
+    await Promise.all(dbPromise);
   }
+
+  // update the quantity of inventories
+  const inventoriesByDepots = _.groupBy(movementDetails, 'depot_uuid');
+  const inventoriesToUpdates = Object.keys(inventoriesByDepots).map(depot => {
+    const inventories = inventoriesByDepots[depot].map(item => item.inventory_uuid);
+    return updateQuantityInStockAfterMovement(inventories, new Date(oldestDate), depot);
+  });
+
+  await Promise.all(inventoriesToUpdates);
+
+  res.sendStatus(204);
 }
 
 /**
@@ -886,67 +865,51 @@ async function depotMovement(document, params, metadata) {
  * GET /stock/assetLots
  * Get the assets lots
  */
-async function listAssetLots(req, res, next) {
+async function listAssetLots(req, res) {
   const params = req.query;
-  try {
-    const rows = await core.getAssets(params);
-    res.status(200).json(rows);
-  } catch (error) {
-    next(error);
-  }
+  const rows = await core.getAssets(params);
+  res.status(200).json(rows);
 }
 
 /**
  * GET /stock/lots
  * this function helps to list lots
  */
-async function listLots(req, res, next) {
+async function listLots(req, res) {
   const params = req.query;
-  try {
-    const rows = await core.getLots(null, params);
-    res.status(200).json(rows);
-  } catch (error) {
-    next(error);
-  }
+  const rows = await core.getLots(null, params);
+  res.status(200).json(rows);
 }
 
 /**
  * GET /stock/lots/movements
  * returns list of stock movements
  */
-function listLotsMovements(req, res, next) {
-  const params = req.query;
-
-  core.getLotsMovements(null, params)
-    .then((rows) => {
-      res.status(200).json(rows);
-    })
-    .catch(next);
+async function listLotsMovements(req, res) {
+  const rows = await core.getLotsMovements(null, req.query);
+  res.status(200).json(rows);
 }
 
 /**
  * GET /stock/movements
  * returns list of stock movements
  */
-function listMovements(req, res, next) {
+async function listMovements(req, res) {
   const params = req.query;
 
   if (req.session.stock_settings.enable_strict_depot_permission) {
     params.check_user_id = req.session.user.id;
   }
 
-  core.getMovements(null, params)
-    .then((rows) => {
-      res.status(200).json(rows);
-    })
-    .catch(next);
+  const rows = await core.getMovements(null, params);
+  res.status(200).json(rows);
 }
 
 /**
  * GET /stock/dashboard
  * returns data for stock dashboard
  */
-function dashboard(req, res, next) {
+async function dashboard(req, res) {
   // eslint-disable-next-line
   const { month_average_consumption, average_consumption_algo, min_delay, enable_expired_stock_out } = req.session.stock_settings;
 
@@ -969,149 +932,144 @@ function dashboard(req, res, next) {
     JOIN depot AS d ON d.uuid = dep.depot_uuid
     ORDER BY d.text ASC;`;
 
-  db.exec(getDepotsByUser, [req.session.user.id, req.session.user.id])
-    .then((_depots) => {
-      depotsByUser = _depots;
+  const _depots = await db.exec(getDepotsByUser, [req.session.user.id, req.session.user.id]);
+  depotsByUser = _depots;
 
-      _depots.forEach(depot => {
-        if (status === 'expired') {
-          const paramsFilter = {
-            dateTo : new Date(),
-            depot_uuid : depot.depot_uuid,
-            includeEmptyLot : 0,
-            is_expired : 1,
-          };
+  _depots.forEach(depot => {
+    if (status === 'expired') {
+      const paramsFilter = {
+        dateTo : new Date(),
+        depot_uuid : depot.depot_uuid,
+        includeEmptyLot : 0,
+        is_expired : 1,
+      };
 
-          dbPromises.push(core.getInventoryQuantityAndConsumption(
-            paramsFilter,
-            month_average_consumption,
-          ));
-        } else if (status === 'out_of_stock') {
-          // add the params for considered expired stock as being out of stock
-          const paramsFilter = {
-            dateTo : new Date(),
-            depot_uuid : depot.depot_uuid,
-            status : 'stock_out',
-            enable_expired_stock_out,
-            month_average_consumption,
-            average_consumption_algo,
-            min_delay,
-          };
+      dbPromises.push(core.getInventoryQuantityAndConsumption(
+        paramsFilter,
+        month_average_consumption,
+      ));
+    } else if (status === 'out_of_stock') {
+      // add the params for considered expired stock as being out of stock
+      const paramsFilter = {
+        dateTo : new Date(),
+        depot_uuid : depot.depot_uuid,
+        status : 'stock_out',
+        enable_expired_stock_out,
+        month_average_consumption,
+        average_consumption_algo,
+        min_delay,
+      };
 
-          dbPromises.push(core.getInventoryQuantityAndConsumption(
-            paramsFilter,
-            month_average_consumption,
-          ));
-        } else if (status === 'at_risk_expiration') {
-          const paramsGetLots = {
-            depot_uuid : depot.depot_uuid,
-            period : 'allTime',
-            includeEmptyLot : '0',
-            is_expiry_risk : '1',
-            month_average_consumption,
-            average_consumption_algo,
-            min_delay,
-          };
+      dbPromises.push(core.getInventoryQuantityAndConsumption(
+        paramsFilter,
+        month_average_consumption,
+      ));
+    } else if (status === 'at_risk_expiration') {
+      const paramsGetLots = {
+        depot_uuid : depot.depot_uuid,
+        period : 'allTime',
+        includeEmptyLot : '0',
+        is_expiry_risk : '1',
+        month_average_consumption,
+        average_consumption_algo,
+        min_delay,
+      };
 
-          dbPromises.push(core.getLotsDepot(
-            null,
-            paramsGetLots,
-          ));
-        } else if (status === 'at_risk_out_stock') {
-          const paramsFilter = {
-            period : 'allTime',
-            depot_uuid : depot.depot_uuid,
-            includeEmptyLot : '0',
-            status : 'security_reached',
-          };
+      dbPromises.push(core.getLotsDepot(
+        null,
+        paramsGetLots,
+      ));
+    } else if (status === 'at_risk_out_stock') {
+      const paramsFilter = {
+        period : 'allTime',
+        depot_uuid : depot.depot_uuid,
+        includeEmptyLot : '0',
+        status : 'security_reached',
+      };
 
-          dbPromises.push(core.getInventoryQuantityAndConsumption(
-            paramsFilter,
-            month_average_consumption,
-            average_consumption_algo,
-          ));
-        } else if (status === 'over_max') {
-          const paramsFilter = {
-            period : 'allTime',
-            depot_uuid : depot.depot_uuid,
-            includeEmptyLot : '0',
-            status : 'over_maximum',
-          };
+      dbPromises.push(core.getInventoryQuantityAndConsumption(
+        paramsFilter,
+        month_average_consumption,
+        average_consumption_algo,
+      ));
+    } else if (status === 'over_max') {
+      const paramsFilter = {
+        period : 'allTime',
+        depot_uuid : depot.depot_uuid,
+        includeEmptyLot : '0',
+        status : 'over_maximum',
+      };
 
-          dbPromises.push(core.getInventoryQuantityAndConsumption(
-            paramsFilter,
-            month_average_consumption,
-            average_consumption_algo,
-          ));
-        } else if (status === 'require_po') {
-          const paramsFilter = {
-            period : 'allTime',
-            depot_uuid : depot.depot_uuid,
-            includeEmptyLot : '1',
-            require_po : '1',
-          };
+      dbPromises.push(core.getInventoryQuantityAndConsumption(
+        paramsFilter,
+        month_average_consumption,
+        average_consumption_algo,
+      ));
+    } else if (status === 'require_po') {
+      const paramsFilter = {
+        period : 'allTime',
+        depot_uuid : depot.depot_uuid,
+        includeEmptyLot : '1',
+        require_po : '1',
+      };
 
-          dbPromises.push(core.getInventoryQuantityAndConsumption(
-            paramsFilter,
-            month_average_consumption,
-            average_consumption_algo,
-          ));
-        } else if (status === 'minimum_reached') {
-          const paramsFilter = {
-            period : 'allTime',
-            depot_uuid : depot.depot_uuid,
-            includeEmptyLot : '0',
-            status : 'minimum_reached',
-          };
+      dbPromises.push(core.getInventoryQuantityAndConsumption(
+        paramsFilter,
+        month_average_consumption,
+        average_consumption_algo,
+      ));
+    } else if (status === 'minimum_reached') {
+      const paramsFilter = {
+        period : 'allTime',
+        depot_uuid : depot.depot_uuid,
+        includeEmptyLot : '0',
+        status : 'minimum_reached',
+      };
 
-          dbPromises.push(core.getInventoryQuantityAndConsumption(
-            paramsFilter,
-            month_average_consumption,
-            average_consumption_algo,
-          ));
-        }
-      });
+      dbPromises.push(core.getInventoryQuantityAndConsumption(
+        paramsFilter,
+        month_average_consumption,
+        average_consumption_algo,
+      ));
+    }
+  });
 
-      return Promise.all(dbPromises);
-    })
-    .then((rows) => {
-      depotsByUser.forEach((depot) => {
-        let count = 0;
-        depot.count = count;
+  const rows = await Promise.all(dbPromises);
+  depotsByUser.forEach((depot) => {
+    let count = 0;
+    depot.count = count;
 
-        rows.forEach(row => {
-          if (row.length) {
-            if (status !== 'at_risk_expiration') {
-              row.forEach(item => {
-                if (depot.depot_uuid === item.depot_uuid) {
-                  count++;
-                }
-              });
-            } else {
-              const filteredData = row.filter(i => i.depot_uuid === depot.depot_uuid);
-
-              if (filteredData.length) {
-                const inventoriesAtRisk = filteredData.map(i => i.inventory_uuid);
-
-                // Remove duplicate values from Inventory at risk expiration
-                const uniqInventory = inventoriesAtRisk.reduce((a, b) => {
-                  if (a.indexOf(b) < 0) a.push(b);
-                  return a;
-                }, []);
-                count = uniqInventory.length;
-              }
+    rows.forEach(row => {
+      if (row.length) {
+        if (status !== 'at_risk_expiration') {
+          row.forEach(item => {
+            if (depot.depot_uuid === item.depot_uuid) {
+              count++;
             }
+          });
+        } else {
+          const filteredData = row.filter(i => i.depot_uuid === depot.depot_uuid);
+
+          if (filteredData.length) {
+            const inventoriesAtRisk = filteredData.map(i => i.inventory_uuid);
+
+            // Remove duplicate values from Inventory at risk expiration
+            const uniqInventory = inventoriesAtRisk.reduce((a, b) => {
+              if (a.indexOf(b) < 0) a.push(b);
+              return a;
+            }, []);
+            count = uniqInventory.length;
           }
-        });
+        }
+      }
+    });
 
-        depot.count = count;
-      });
+    depot.count = count;
+  });
 
-      const filteredData = depotsByUser.filter(item => item.count > 0);
+  const filteredData = depotsByUser.filter(item => item.count > 0);
 
-      res.status(200).json(filteredData);
-    })
-    .catch(next);
+  res.status(200).json(filteredData);
 
 }
 
@@ -1119,7 +1077,7 @@ function dashboard(req, res, next) {
  * GET /stock/lots/depots/
  * returns list of each lots in each depots with their quantities
  */
-async function listLotsDepot(req, res, next) {
+async function listLotsDepot(req, res) {
   const params = req.query;
 
   params.month_average_consumption = req.session.stock_settings.month_average_consumption;
@@ -1136,30 +1094,26 @@ async function listLotsDepot(req, res, next) {
     delete params.period;
   }
 
-  try {
-    const data = await core.getLotsDepot(null, params);
+  const data = await core.getLotsDepot(null, params);
 
-    // if no data is returned or if the skipTags flag is set, we don't need to do any processing
-    // of tags.  Skip the SQL query and JS loops.
-    if (!params.paging && data.length !== 0 && !params.skipTags) {
-      await core.addLotTags(data);
-    }
-
-    if (params.paging && data.rows.length !== 0 && !params.skipTags) {
-      await core.addLotTags(data.rows);
-    }
-
-    res.status(200).json(data);
-  } catch (error) {
-    next(error);
+  // if no data is returned or if the skipTags flag is set, we don't need to do any processing
+  // of tags.  Skip the SQL query and JS loops.
+  if (!params.paging && data.length !== 0 && !params.skipTags) {
+    await core.addLotTags(data);
   }
+
+  if (params.paging && data.rows.length !== 0 && !params.skipTags) {
+    await core.addLotTags(data.rows);
+  }
+
+  res.status(200).json(data);
 }
 
 /**
  * GET /stock/lots/depots/
  * returns list of each lots in each depots with their quantities
  */
-async function listLotsDepotDetailed(req, res, next) {
+async function listLotsDepotDetailed(req, res) {
   const params = req.query;
 
   params.startDate = moment(new Date(params.startDate)).format('YYYY-MM-DD');
@@ -1191,8 +1145,7 @@ async function listLotsDepotDetailed(req, res, next) {
     check_user_id : params.check_user_id,
   };
 
-  try {
-    const sqlGetMonthlyStockMovements = `
+  const sqlGetMonthlyStockMovements = `
       SELECT BUID(l.inventory_uuid) AS inventory_uuid, BUID(sm.lot_uuid) AS lot_uuid,
         sm.date, inv.text AS inventoryText,
         l.label, SUM(IF(sm.is_exit = 1, sm.quantity, 0)) AS exit_quantity,
@@ -1205,62 +1158,59 @@ async function listLotsDepotDetailed(req, res, next) {
       GROUP BY l.uuid, sm.date;
     `;
 
-    const [
-      data,
-      dataPreviousMonth,
-      dataStockMovements,
-    ] = await Promise.all([
-      core.getLotsDepot(null, params),
-      core.getLotsDepot(null, paramsPrevious),
-      db.exec(sqlGetMonthlyStockMovements, [db.bid(params.depot_uuid), params.startDate, params.dateTo]),
-    ]);
+  const [
+    data,
+    dataPreviousMonth,
+    dataStockMovements,
+  ] = await Promise.all([
+    core.getLotsDepot(null, params),
+    core.getLotsDepot(null, paramsPrevious),
+    db.exec(sqlGetMonthlyStockMovements, [db.bid(params.depot_uuid), params.startDate, params.dateTo]),
+  ]);
 
-    const dataPaged = !params.paging ? data : data.rows;
-    const dataPagedPreviousMonth = !params.paging ? dataPreviousMonth : dataPreviousMonth.rows;
+  const dataPaged = !params.paging ? data : data.rows;
+  const dataPagedPreviousMonth = !params.paging ? dataPreviousMonth : dataPreviousMonth.rows;
 
-    (dataPaged || []).forEach(current => {
-      current.quantity_opening = 0;
-      current.total_quantity_entry = 0;
-      current.total_quantity_exit = 0;
+  (dataPaged || []).forEach(current => {
+    current.quantity_opening = 0;
+    current.total_quantity_entry = 0;
+    current.total_quantity_exit = 0;
 
-      (dataPagedPreviousMonth || []).forEach(previous => {
-        if (current.uuid === previous.uuid) {
-          current.quantity_opening = previous.quantity;
-        }
-      });
-
-      (dataStockMovements || []).forEach(row => {
-        if (current.uuid === row.lot_uuid) {
-          current.total_quantity_entry = row.entry_quantity;
-          current.total_quantity_exit = row.exit_quantity;
-        }
-      });
+    (dataPagedPreviousMonth || []).forEach(previous => {
+      if (current.uuid === previous.uuid) {
+        current.quantity_opening = previous.quantity;
+      }
     });
 
-    const queryTags = `
+    (dataStockMovements || []).forEach(row => {
+      if (current.uuid === row.lot_uuid) {
+        current.total_quantity_entry = row.entry_quantity;
+        current.total_quantity_exit = row.exit_quantity;
+      }
+    });
+  });
+
+  const queryTags = `
       SELECT BUID(t.uuid) uuid, t.name, t.color, BUID(lt.lot_uuid) lot_uuid
       FROM tags t
         JOIN lot_tag lt ON lt.tag_uuid = t.uuid
       WHERE lt.lot_uuid IN (?)
     `;
 
-    // if we have an empty set, do not query tags.
-    if (dataPaged.length !== 0) {
-      const lotUuids = dataPaged.map(row => db.bid(row.uuid));
-      const tags = await db.exec(queryTags, [lotUuids]);
+  // if we have an empty set, do not query tags.
+  if (dataPaged.length !== 0) {
+    const lotUuids = dataPaged.map(row => db.bid(row.uuid));
+    const tags = await db.exec(queryTags, [lotUuids]);
 
-      // make a lot_uuid -> tags map.
-      const tagMap = _.groupBy(tags, 'lot_uuid');
+    // make a lot_uuid -> tags map.
+    const tagMap = _.groupBy(tags, 'lot_uuid');
 
-      dataPaged.forEach(lot => {
-        lot.tags = tagMap[lot.uuid] || [];
-      });
-    }
-
-    res.status(200).json(params.paging ? { pager : data.pager, rows : dataPaged } : dataPaged);
-  } catch (error) {
-    next(error);
+    dataPaged.forEach(lot => {
+      lot.tags = tagMap[lot.uuid] || [];
+    });
   }
+
+  res.status(200).json(params.paging ? { pager : data.pager, rows : dataPaged } : dataPaged);
 }
 
 /**
@@ -1269,7 +1219,7 @@ async function listLotsDepotDetailed(req, res, next) {
  * @todo process stock alert, rupture of stock
  * @todo prevision for purchase
  */
-async function listInventoryDepot(req, res, next) {
+async function listInventoryDepot(req, res) {
   const params = req.query;
 
   // expose connected user data
@@ -1287,112 +1237,98 @@ async function listInventoryDepot(req, res, next) {
   params.default_purchase_interval = req.session.stock_settings.default_purchase_interval;
   params.enable_expired_stock_out = req.session.stock_settings.enable_expired_stock_out;
 
-  try {
-    // FIXME(@jniles) - these two call essentially the same route.  Do we need both?
-    const [inventories, lots] = await Promise.all([
-      core.getInventoryQuantityAndConsumption(params),
-      core.getLotsDepot(null, params),
-    ]);
+  // FIXME(@jniles) - these two call essentially the same route.  Do we need both?
+  const [inventories, lots] = await Promise.all([
+    core.getInventoryQuantityAndConsumption(params),
+    core.getLotsDepot(null, params),
+  ]);
 
-    for (let i = 0; i < inventories.length; i++) {
-      let hasRiskyLots = false;
-      let hasExpiredLots = false;
-      let hasNearExpireLots = false;
+  for (let i = 0; i < inventories.length; i++) {
+    let hasRiskyLots = false;
+    let hasExpiredLots = false;
+    let hasNearExpireLots = false;
 
-      let riskyLotsQuantity = 0;
-      let expiredLotsQuantity = 0;
-      let nearExpireLotsQuantity = 0;
+    let riskyLotsQuantity = 0;
+    let expiredLotsQuantity = 0;
+    let nearExpireLotsQuantity = 0;
 
-      for (let j = 0; j < lots.length; j++) {
-        const hasSameDepot = lots[j].depot_uuid === inventories[i].depot_uuid;
-        const hasSameInventory = lots[j].inventory_uuid === inventories[i].inventory_uuid;
-        if (hasSameDepot && hasSameInventory) {
+    for (let j = 0; j < lots.length; j++) {
+      const hasSameDepot = lots[j].depot_uuid === inventories[i].depot_uuid;
+      const hasSameInventory = lots[j].inventory_uuid === inventories[i].inventory_uuid;
+      if (hasSameDepot && hasSameInventory) {
 
-          // NOTE(@jniles): at this point, we've called computeLotIndicators() in the
-          // core.getLotsDepot() function.  This means we can use all the flags defined
-          // in that function to compute those here.
-          const lot = lots[j];
+        // NOTE(@jniles): at this point, we've called computeLotIndicators() in the
+        // core.getLotsDepot() function.  This means we can use all the flags defined
+        // in that function to compute those here.
+        const lot = lots[j];
 
-          if (lot.exhausted) {
-            // skip exhausted lots
-          } else if (lot.expired) {
-            hasExpiredLots = true;
-            expiredLotsQuantity += lot.quantity;
-          } else if (lot.near_expiration) {
-            hasNearExpireLots = true;
-            nearExpireLotsQuantity += lot.quantity;
+        if (lot.exhausted) {
+          // skip exhausted lots
+        } else if (lot.expired) {
+          hasExpiredLots = true;
+          expiredLotsQuantity += lot.quantity;
+        } else if (lot.near_expiration) {
+          hasNearExpireLots = true;
+          nearExpireLotsQuantity += lot.quantity;
 
           // flag if any lots are at risk of running out
-          } else if (lot.S_RISK_QUANTITY > 0) {
-            hasRiskyLots = true;
-            riskyLotsQuantity += lot.S_RISK_QUANTITY;
-          }
+        } else if (lot.S_RISK_QUANTITY > 0) {
+          hasRiskyLots = true;
+          riskyLotsQuantity += lot.S_RISK_QUANTITY;
         }
       }
-
-      inventories[i].hasNearExpireLots = hasNearExpireLots;
-      inventories[i].hasRiskyLots = hasRiskyLots;
-      inventories[i].hasExpiredLots = hasExpiredLots;
-
-      inventories[i].nearExpireLotsQuantity = nearExpireLotsQuantity;
-      inventories[i].riskyLotsQuantity = riskyLotsQuantity;
-      inventories[i].expiredLotsQuantity = expiredLotsQuantity;
-      inventories[i].usableAvailableStock = inventories[i].quantity - expiredLotsQuantity;
     }
 
-    let rows = inventories;
+    inventories[i].hasNearExpireLots = hasNearExpireLots;
+    inventories[i].hasRiskyLots = hasRiskyLots;
+    inventories[i].hasExpiredLots = hasExpiredLots;
 
-    if (params.show_only_risky) {
-      rows = inventories.filter(item => (item.hasRiskyLots || item.hasNearExpireLots || item.hasExpiredLots));
-    }
-
-    res.status(200).json(rows);
-  } catch (error) {
-    next(error);
+    inventories[i].nearExpireLotsQuantity = nearExpireLotsQuantity;
+    inventories[i].riskyLotsQuantity = riskyLotsQuantity;
+    inventories[i].expiredLotsQuantity = expiredLotsQuantity;
+    inventories[i].usableAvailableStock = inventories[i].quantity - expiredLotsQuantity;
   }
+
+  let rows = inventories;
+
+  if (params.show_only_risky) {
+    rows = inventories.filter(item => (item.hasRiskyLots || item.hasNearExpireLots || item.hasExpiredLots));
+  }
+
+  res.status(200).json(rows);
 }
 
 /**
  * GET /stock/flux
  * returns list of stock flux
  */
-function listStockFlux(req, res, next) {
-  db.exec('SELECT id, label FROM flux;')
-    .then((rows) => {
-      res.status(200).json(rows);
-    })
-    .catch(next);
+async function listStockFlux(req, res) {
+  const rows = await db.exec('SELECT id, label FROM flux;');
+  res.status(200).json(rows);
 }
 
 /**
  * GET /stock/consumptions/:periodId
  */
-function getStockConsumption(req, res, next) {
+async function getStockConsumption(req, res) {
   const { params } = req;
-  core.getStockConsumption(params.periodId)
-    .then((rows) => {
-      res.status(200).send(rows);
-    })
-    .catch(next);
+  const rows = await core.getStockConsumption(params.periodId);
+  res.status(200).send(rows);
 }
 
 /**
  * GET /stock/consumptions/average/:periodId?number_of_months=...
  */
-function getStockConsumptionAverage(req, res, next) {
+async function getStockConsumptionAverage(req, res) {
   const { query, params } = req;
-  core.getStockConsumptionAverage(params.periodId, query.number_of_months)
-    .then((rows) => {
-
-      res.status(200).send(rows);
-    })
-    .catch(next);
+  const rows = await core.getStockConsumptionAverage(params.periodId, query.number_of_months);
+  res.status(200).send(rows);
 }
 
 /**
  * GET /stock/transfer
  */
-function getStockTransfers(req, res, next) {
+async function getStockTransfers(req, res) {
   const params = req.query;
 
   // Get received transfer for the given depot
@@ -1430,237 +1366,229 @@ function getStockTransfers(req, res, next) {
     GROUP BY m.document_uuid
   `;
 
-  db.exec(query, [db.bid(params.depot_uuid), db.bid(params.depot_uuid)])
-    .then((rows) => {
-      res.status(200).json(rows);
-    })
-    .catch(next);
-
+  const rows = await db.exec(query, [db.bid(params.depot_uuid), db.bid(params.depot_uuid)]);
+  res.status(200).json(rows);
 }
 
 /**
  * POST /stock/aggregated_consumption
  * Stock Aggregated Consumption
  */
-async function createAggregatedConsumption(req, res, next) {
-  try {
-    const movement = req.body;
-    let filteredInvalidData = [];
+async function createAggregatedConsumption(req, res) {
+  const movement = req.body;
+  let filteredInvalidData = [];
 
-    const paramsStock = {
-      dateTo : new Date(),
-      depot_uuid : movement.depot_uuid,
-      includeEmptyLot : 0,
-      month_average_consumption : req.session.stock_settings.month_average_consumption,
-      average_consumption_algo : req.session.stock_settings.average_consumption_algo,
-    };
+  const paramsStock = {
+    dateTo : new Date(),
+    depot_uuid : movement.depot_uuid,
+    includeEmptyLot : 0,
+    month_average_consumption : req.session.stock_settings.month_average_consumption,
+    average_consumption_algo : req.session.stock_settings.average_consumption_algo,
+  };
 
-    if (!movement.depot_uuid) {
-      throw new Error('No defined depot');
+  if (!movement.depot_uuid) {
+    throw new Error('No defined depot');
+  }
+
+  const checkInvalid = movement.lots
+    .filter(l => ((l.quantity_consumed + l.quantity_lost) > l.oldQuantity));
+
+  if (checkInvalid.length) {
+    throw new Error('Invalid data!  Some lots have consumed or lost more stock than they originally had.');
+  }
+
+  const stockAvailable = await core.getLotsDepot(null, paramsStock);
+
+  movement.lots.forEach(lot => {
+    lot.quantityAvailable = 0;
+
+    lot.outputQuantity = lot.quantity_consumed + lot.quantity_lost;
+
+    if (stockAvailable) {
+      stockAvailable.forEach(stock => {
+        if (stock.uuid === lot.uuid) {
+          lot.quantityAvailable = stock.quantity;
+        }
+      });
     }
+  });
 
-    const checkInvalid = movement.lots
-      .filter(l => ((l.quantity_consumed + l.quantity_lost) > l.oldQuantity));
+  filteredInvalidData = await movement.lots.filter(l => l.outputQuantity > l.quantityAvailable);
 
-    if (checkInvalid.length) {
-      throw new Error('Invalid data!  Some lots have consumed or lost more stock than they originally had.');
-    }
-
-    const stockAvailable = await core.getLotsDepot(null, paramsStock);
-
-    movement.lots.forEach(lot => {
-      lot.quantityAvailable = 0;
-
-      lot.outputQuantity = lot.quantity_consumed + lot.quantity_lost;
-
-      if (stockAvailable) {
-        stockAvailable.forEach(stock => {
-          if (stock.uuid === lot.uuid) {
-            lot.quantityAvailable = stock.quantity;
-          }
-        });
-      }
-    });
-
-    filteredInvalidData = await movement.lots.filter(l => l.outputQuantity > l.quantityAvailable);
-
-    if (filteredInvalidData.length) {
-      throw new BadRequest(
-        `This aggregate stock consumption will overconsume
+  if (filteredInvalidData.length) {
+    throw new BadRequest(
+      `This aggregate stock consumption will overconsume
           the quantity in stock and generate negative quantity in stock`,
-        `ERRORS.ER_PREVENT_NEGATIVE_QUANTITY_IN_AGGREGATE_CONSUMPTION`,
-      );
+      `ERRORS.ER_PREVENT_NEGATIVE_QUANTITY_IN_AGGREGATE_CONSUMPTION`,
+    );
+  }
+
+  // Here we want that the detailed consumption can only concern the periods when there is out of stock
+  movement.lots.forEach(lot => {
+    if (movement.stock_out[lot.inventory_uuid] === 0) {
+      lot.detailed = [];
     }
 
-    // Here we want that the detailed consumption can only concern the periods when there is out of stock
-    movement.lots.forEach(lot => {
-      if (movement.stock_out[lot.inventory_uuid] === 0) {
-        lot.detailed = [];
-      }
+    // Here we initialize an empty array just to check that there are no details
+    if (!lot.detailed) {
+      lot.detailed = [];
+    }
+  });
 
-      // Here we initialize an empty array just to check that there are no details
-      if (!lot.detailed) {
-        lot.detailed = [];
-      }
+  // only consider lots that have consumed or lost.
+  // Here we filter the consumption of batches that do not have chronological details
+  const lots = movement.lots
+    .filter(l => ((l.quantity_consumed > 0 || l.quantity_lost > 0) && (l.detailed.length === 0)));
+
+  const consumptionDetailed = movement.lots
+    .filter(l => l.detailed);
+
+  const periodId = movement.period_id;
+
+  // pass reverse operations
+  const trx = db.transaction();
+
+  // unique inventoryUuids
+  const inventoryUuids = lots
+    .map(lot => lot.inventory_uuid)
+    .filter((uid, index, array) => array.lastIndexOf(uid) === index);
+
+  inventoryUuids.forEach(inventoryUuid => {
+    const daysStockOut = movement.stock_out[inventoryUuid];
+    let movementDate = (daysStockOut > 0) ? moment(movement.date).subtract(daysStockOut, 'day') : movement.date;
+    movementDate = new Date(movementDate);
+    movementDate = movementDate.setHours(23, 30, 0);
+
+    const consumptionUuid = uuid();
+    const lossUuid = uuid();
+
+    // get all lots with positive quantity_consumed
+    const stockConsumptionQuantities = lots.filter(lot => (
+      lot.inventory_uuid === inventoryUuid && lot.quantity_consumed > 0));
+
+    // get all lots with negative quantity_lost
+    const stockLossQuantities = lots.filter(lot => (lot.inventory_uuid === inventoryUuid && lot.quantity_lost > 0));
+
+    stockConsumptionQuantities.forEach(lot => {
+      const consumptionMovementObject = {
+        uuid : db.bid(uuid()),
+        lot_uuid : db.bid(lot.uuid),
+        depot_uuid : db.bid(movement.depot_uuid),
+        document_uuid : db.bid(consumptionUuid),
+        quantity : lot.quantity_consumed,
+        unit_cost : lot.unit_cost,
+        date : new Date(movementDate),
+        is_exit : 1,
+        flux_id : core.flux.AGGREGATE_CONSUMPTION,
+        description : movement.description,
+        user_id : req.session.user.id,
+        period_id : periodId,
+      };
+
+      trx.addQuery('INSERT INTO stock_movement SET ?', consumptionMovementObject);
     });
 
-    // only consider lots that have consumed or lost.
-    // Here we filter the consumption of batches that do not have chronological details
-    const lots = movement.lots
-      .filter(l => ((l.quantity_consumed > 0 || l.quantity_lost > 0) && (l.detailed.length === 0)));
+    stockLossQuantities.forEach(lot => {
+      const lossMovementObject = {
+        uuid : db.bid(uuid()),
+        lot_uuid : db.bid(lot.uuid),
+        depot_uuid : db.bid(movement.depot_uuid),
+        document_uuid : db.bid(lossUuid),
+        quantity : lot.quantity_lost,
+        unit_cost : lot.unit_cost,
+        date : new Date(movementDate),
+        is_exit : 1,
+        flux_id : core.flux.TO_LOSS,
+        description : movement.description,
+        user_id : req.session.user.id,
+        period_id : periodId,
+      };
 
-    const consumptionDetailed = movement.lots
-      .filter(l => l.detailed);
+      trx.addQuery('INSERT INTO stock_movement SET ?', lossMovementObject);
+    });
 
-    const periodId = movement.period_id;
+    const stockConsumptionParams = [
+      db.bid(consumptionUuid), 1, req.session.project.id,
+    ];
 
-    // pass reverse operations
-    const trx = db.transaction();
+    const stockLossParams = [
+      db.bid(lossUuid), 1, req.session.project.id,
+    ];
 
-    // unique inventoryUuids
-    const inventoryUuids = lots
-      .map(lot => lot.inventory_uuid)
-      .filter((uid, index, array) => array.lastIndexOf(uid) === index);
+    if (req.session.stock_settings.enable_auto_stock_accounting) {
+      if (stockConsumptionQuantities.length > 0) {
+        trx.addQuery('CALL PostStockMovement(?)', [stockConsumptionParams]);
+      }
 
-    inventoryUuids.forEach(inventoryUuid => {
-      const daysStockOut = movement.stock_out[inventoryUuid];
-      let movementDate = (daysStockOut > 0) ? moment(movement.date).subtract(daysStockOut, 'day') : movement.date;
-      movementDate = new Date(movementDate);
-      movementDate = movementDate.setHours(23, 30, 0);
+      if (stockLossQuantities.length > 0) {
+        trx.addQuery('CALL PostStockMovement(?)', [stockLossParams]);
+      }
+    }
+  });
 
+  consumptionDetailed.forEach(item => {
+    item.detailed.forEach(elt => {
       const consumptionUuid = uuid();
       const lossUuid = uuid();
 
-      // get all lots with positive quantity_consumed
-      const stockConsumptionQuantities = lots.filter(lot => (
-        lot.inventory_uuid === inventoryUuid && lot.quantity_consumed > 0));
+      let eltDate = new Date(elt.end_date);
+      eltDate = eltDate.setHours(23, 30, 0);
 
-      // get all lots with negative quantity_lost
-      const stockLossQuantities = lots.filter(lot => (lot.inventory_uuid === inventoryUuid && lot.quantity_lost > 0));
+      const formatStartDate = moment(elt.start_date).format('DD/MM/YYYY');
+      const formatEndDate = moment(elt.end_date).format('DD/MM/YYYY');
 
-      stockConsumptionQuantities.forEach(lot => {
+      if (elt.quantity_consumed > 0) {
         const consumptionMovementObject = {
           uuid : db.bid(uuid()),
-          lot_uuid : db.bid(lot.uuid),
+          lot_uuid : db.bid(item.uuid),
           depot_uuid : db.bid(movement.depot_uuid),
           document_uuid : db.bid(consumptionUuid),
-          quantity : lot.quantity_consumed,
-          unit_cost : lot.unit_cost,
-          date : new Date(movementDate),
+          quantity : elt.quantity_consumed,
+          unit_cost : item.unit_cost,
+          date : new Date(eltDate),
           is_exit : 1,
           flux_id : core.flux.AGGREGATE_CONSUMPTION,
-          description : movement.description,
+          description : `${movement.description} [${formatStartDate} - ${formatEndDate}]`,
           user_id : req.session.user.id,
           period_id : periodId,
         };
 
         trx.addQuery('INSERT INTO stock_movement SET ?', consumptionMovementObject);
-      });
+      }
 
-      stockLossQuantities.forEach(lot => {
+      if (elt.quantity_lost > 0) {
         const lossMovementObject = {
           uuid : db.bid(uuid()),
-          lot_uuid : db.bid(lot.uuid),
+          lot_uuid : db.bid(item.uuid),
           depot_uuid : db.bid(movement.depot_uuid),
           document_uuid : db.bid(lossUuid),
-          quantity : lot.quantity_lost,
-          unit_cost : lot.unit_cost,
-          date : new Date(movementDate),
+          quantity : elt.quantity_lost,
+          unit_cost : item.unit_cost,
+          date : new Date(eltDate),
           is_exit : 1,
           flux_id : core.flux.TO_LOSS,
-          description : movement.description,
+          description : `${movement.description} [${formatStartDate} - ${formatEndDate}]`,
           user_id : req.session.user.id,
           period_id : periodId,
         };
 
         trx.addQuery('INSERT INTO stock_movement SET ?', lossMovementObject);
-      });
-
-      const stockConsumptionParams = [
-        db.bid(consumptionUuid), 1, req.session.project.id,
-      ];
-
-      const stockLossParams = [
-        db.bid(lossUuid), 1, req.session.project.id,
-      ];
-
-      if (req.session.stock_settings.enable_auto_stock_accounting) {
-        if (stockConsumptionQuantities.length > 0) {
-          trx.addQuery('CALL PostStockMovement(?)', [stockConsumptionParams]);
-        }
-
-        if (stockLossQuantities.length > 0) {
-          trx.addQuery('CALL PostStockMovement(?)', [stockLossParams]);
-        }
       }
     });
+  });
 
-    consumptionDetailed.forEach(item => {
-      item.detailed.forEach(elt => {
-        const consumptionUuid = uuid();
-        const lossUuid = uuid();
+  trx.addQuery('CALL RecomputeStockValue(NULL);');
 
-        let eltDate = new Date(elt.end_date);
-        eltDate = eltDate.setHours(23, 30, 0);
+  await trx.execute();
 
-        const formatStartDate = moment(elt.start_date).format('DD/MM/YYYY');
-        const formatEndDate = moment(elt.end_date).format('DD/MM/YYYY');
+  // we need to update the quantities at the beginning of the period.  So, we
+  // construct the start date of the period from the period_id.
+  const year = String(movement.period_id).slice(0, 4);
+  const month = String(movement.period_id).slice(4);
+  const date = `${year}-${month}-01`;
 
-        if (elt.quantity_consumed > 0) {
-          const consumptionMovementObject = {
-            uuid : db.bid(uuid()),
-            lot_uuid : db.bid(item.uuid),
-            depot_uuid : db.bid(movement.depot_uuid),
-            document_uuid : db.bid(consumptionUuid),
-            quantity : elt.quantity_consumed,
-            unit_cost : item.unit_cost,
-            date : new Date(eltDate),
-            is_exit : 1,
-            flux_id : core.flux.AGGREGATE_CONSUMPTION,
-            description : `${movement.description} [${formatStartDate} - ${formatEndDate}]`,
-            user_id : req.session.user.id,
-            period_id : periodId,
-          };
+  // update quantities in stock after movement
+  await updateQuantityInStockAfterMovement(inventoryUuids, date, movement.depot_uuid);
 
-          trx.addQuery('INSERT INTO stock_movement SET ?', consumptionMovementObject);
-        }
-
-        if (elt.quantity_lost > 0) {
-          const lossMovementObject = {
-            uuid : db.bid(uuid()),
-            lot_uuid : db.bid(item.uuid),
-            depot_uuid : db.bid(movement.depot_uuid),
-            document_uuid : db.bid(lossUuid),
-            quantity : elt.quantity_lost,
-            unit_cost : item.unit_cost,
-            date : new Date(eltDate),
-            is_exit : 1,
-            flux_id : core.flux.TO_LOSS,
-            description : `${movement.description} [${formatStartDate} - ${formatEndDate}]`,
-            user_id : req.session.user.id,
-            period_id : periodId,
-          };
-
-          trx.addQuery('INSERT INTO stock_movement SET ?', lossMovementObject);
-        }
-      });
-    });
-
-    trx.addQuery('CALL RecomputeStockValue(NULL);');
-
-    await trx.execute();
-
-    // we need to update the quantities at the beginning of the period.  So, we
-    // construct the start date of the period from the period_id.
-    const year = String(movement.period_id).slice(0, 4);
-    const month = String(movement.period_id).slice(4);
-    const date = `${year}-${month}-01`;
-
-    // update quantities in stock after movement
-    await updateQuantityInStockAfterMovement(inventoryUuids, date, movement.depot_uuid);
-
-    res.status(201).json({});
-  } catch (err) {
-    next(err);
-  }
+  res.status(201).json({});
 }

--- a/server/controllers/stock/reports/index.js
+++ b/server/controllers/stock/reports/index.js
@@ -66,74 +66,70 @@ async function determineReceiptType(uuid, isDepotTransferExit = -1) {
   return row.flux_id;
 }
 
-async function renderStockReceipt(req, res, next) {
-  try {
-    const documentUuid = req.params.uuid;
+async function renderStockReceipt(req, res) {
+  const documentUuid = req.params.uuid;
 
-    let isDepotTransferExit = -1;
-    if (req.query.is_depot_transfer_exit) {
-      isDepotTransferExit = Number(req.query.is_depot_transfer_exit);
-    }
-
-    const receiptType = await determineReceiptType(documentUuid, isDepotTransferExit);
-
-    let renderer;
-
-    switch (receiptType) {
-    case Stock.flux.FROM_PURCHASE:
-      renderer = stockEntryPurchaseReceipt;
-      break;
-
-    case Stock.flux.FROM_OTHER_DEPOT:
-      renderer = stockEntryDepotReceipt;
-      break;
-
-    case Stock.flux.FROM_ADJUSTMENT:
-    case Stock.flux.TO_ADJUSTMENT:
-    case Stock.flux.INVENTORY_ADJUSTMENT:
-    case Stock.flux.INVENTORY_RESET:
-      renderer = stockAdjustmentReceipt;
-      break;
-
-    case Stock.flux.FROM_INTEGRATION:
-    case Stock.flux.TO_INTEGRATION:
-      renderer = stockEntryIntegrationReceipt;
-      break;
-
-    case Stock.flux.TO_PATIENT:
-      renderer = stockExitPatientReceipt;
-      break;
-
-    case Stock.flux.TO_OTHER_DEPOT:
-      renderer = stockExitDepotReceipt;
-      break;
-
-    case Stock.flux.TO_SERVICE:
-      renderer = stockExitServiceReceipt;
-      break;
-
-    case Stock.flux.TO_LOSS:
-      renderer = stockExitLossReceipt;
-      break;
-
-    case Stock.flux.FROM_DONATION:
-      renderer = stockEntryDonationReceipt;
-      break;
-
-    case Stock.flux.AGGREGATE_CONSUMPTION:
-      renderer = stockExitAggregateConsumptionReceipt;
-      break;
-
-    default:
-      throw new BadRequest('Could not determine stock receipt.');
-    }
-
-    // render the receipt and send it back to the client
-    const { headers, report } = await renderer(documentUuid, req.session, req.query);
-    res.set(headers).send(report);
-  } catch (e) {
-    next(e);
+  let isDepotTransferExit = -1;
+  if (req.query.is_depot_transfer_exit) {
+    isDepotTransferExit = Number(req.query.is_depot_transfer_exit);
   }
+
+  const receiptType = await determineReceiptType(documentUuid, isDepotTransferExit);
+
+  let renderer;
+
+  switch (receiptType) {
+  case Stock.flux.FROM_PURCHASE:
+    renderer = stockEntryPurchaseReceipt;
+    break;
+
+  case Stock.flux.FROM_OTHER_DEPOT:
+    renderer = stockEntryDepotReceipt;
+    break;
+
+  case Stock.flux.FROM_ADJUSTMENT:
+  case Stock.flux.TO_ADJUSTMENT:
+  case Stock.flux.INVENTORY_ADJUSTMENT:
+  case Stock.flux.INVENTORY_RESET:
+    renderer = stockAdjustmentReceipt;
+    break;
+
+  case Stock.flux.FROM_INTEGRATION:
+  case Stock.flux.TO_INTEGRATION:
+    renderer = stockEntryIntegrationReceipt;
+    break;
+
+  case Stock.flux.TO_PATIENT:
+    renderer = stockExitPatientReceipt;
+    break;
+
+  case Stock.flux.TO_OTHER_DEPOT:
+    renderer = stockExitDepotReceipt;
+    break;
+
+  case Stock.flux.TO_SERVICE:
+    renderer = stockExitServiceReceipt;
+    break;
+
+  case Stock.flux.TO_LOSS:
+    renderer = stockExitLossReceipt;
+    break;
+
+  case Stock.flux.FROM_DONATION:
+    renderer = stockEntryDonationReceipt;
+    break;
+
+  case Stock.flux.AGGREGATE_CONSUMPTION:
+    renderer = stockExitAggregateConsumptionReceipt;
+    break;
+
+  default:
+    throw new BadRequest('Could not determine stock receipt.');
+  }
+
+  // render the receipt and send it back to the client
+  const { headers, report } = await renderer(documentUuid, req.session, req.query);
+  res.set(headers).send(report);
 }
 
 exports.renderStockReceipt = renderStockReceipt;

--- a/server/controllers/stock/reports/purchase_order_analysis/index.js
+++ b/server/controllers/stock/reports/purchase_order_analysis/index.js
@@ -1,4 +1,3 @@
-const _ = require('lodash');
 const db = require('../../../../lib/db');
 const ReportManager = require('../../../../lib/ReportManager');
 const Purchases = require('../../../finance/purchases');
@@ -19,8 +18,8 @@ const DEFAULT_PARAMS = {
  * @description
  * This function renders the purchase order analysis report.
  */
-async function report(req, res, next) {
-  const params = req.query;
+async function report(req, res) {
+  let params = req.query;
   const data = {};
 
   params.shouldShowDetails = parseInt(params.shouldShowDetails, 10);
@@ -64,13 +63,11 @@ async function report(req, res, next) {
     },
   };
 
-  _.defaults(params, DEFAULT_PARAMS);
+  params = { ...DEFAULT_PARAMS, ...params };
+  const reporting = new ReportManager(TEMPLATE, req.session, params);
 
-  try {
-    const reporting = new ReportManager(TEMPLATE, req.session, params);
-
-    // This request makes it possible to obtain the quantities of the ordered products
-    const sqlInventoriesOrdered = `
+  // This request makes it possible to obtain the quantities of the ordered products
+  const sqlInventoriesOrdered = `
       SELECT BUID(p.uuid) AS purchase_uuid, BUID(iv.uuid) AS inventory_uuid, iv.code,
         iv.text AS inventory_text, pi.quantity AS quantity_ordered, pi.package_size
       FROM purchase AS p
@@ -80,8 +77,8 @@ async function report(req, res, next) {
       ORDER BY iv.text ASC;
     `;
 
-    // This query is used to get the quantities in stock for a purchase order
-    const sqlInventoriesInStock = `
+  // This query is used to get the quantities in stock for a purchase order
+  const sqlInventoriesInStock = `
       SELECT BUID(p.uuid) AS purchase_uuid, BUID(inv.uuid) AS inventory_uuid, inv.text AS inventoryText,
         l.label AS lotLabel, p.project_id, p.reference, p.user_id, SUM(sm.quantity) AS quantity_inStock,
         l.expiration_date, inv.code
@@ -94,13 +91,13 @@ async function report(req, res, next) {
       ORDER BY inv.text ASC;
     `;
 
-    // NOTE: Removed entry_date from previous query since it was removed from the lot table.
-    //       If it is needed, it should be retrieved from stock_movements table.
-    //       See getLots() query in server/controllers/stock/core.js for an example query.
-    //       jmcameron 2021-03-26.
+  // NOTE: Removed entry_date from previous query since it was removed from the lot table.
+  //       If it is needed, it should be retrieved from stock_movements table.
+  //       See getLots() query in server/controllers/stock/core.js for an example query.
+  //       jmcameron 2021-03-26.
 
-    // This request tracks the entries in stock of a purchase order, by date, by deposit but also by product
-    const sqlInventoriesInStockDetailled = `
+  // This request tracks the entries in stock of a purchase order, by date, by deposit but also by product
+  const sqlInventoriesInStockDetailled = `
       SELECT BUID(p.uuid) AS purchase_uuid, BUID(iv.uuid) AS inventory_uuid, iv.text AS inventoryText,
         l.label AS lotLabel, p.project_id, p.reference, p.user_id, l.uuid AS lotUuid, l.quantity,
         l.expiration_date,
@@ -117,82 +114,79 @@ async function report(req, res, next) {
       ORDER BY iv.text ASC, entry_date ASC
     `;
 
-    const uidPurchase = db.bid(params.purchase_uuid);
-    const PURCHASE_FLUX_ID = 1;
+  const uidPurchase = db.bid(params.purchase_uuid);
+  const PURCHASE_FLUX_ID = 1;
 
-    const [
-      [purchase], inventoriesOrdered, inventoriesInStock, inventoriesInStockDetailled,
-    ] = await Promise.all([
-      Purchases.find({ uuid : params.purchase_uuid }),
-      db.exec(sqlInventoriesOrdered, uidPurchase),
-      db.exec(sqlInventoriesInStock, uidPurchase),
-      db.exec(sqlInventoriesInStockDetailled, [uidPurchase, PURCHASE_FLUX_ID]),
-    ]);
+  const [
+    [purchase], inventoriesOrdered, inventoriesInStock, inventoriesInStockDetailled,
+  ] = await Promise.all([
+    Purchases.find({ uuid : params.purchase_uuid }),
+    db.exec(sqlInventoriesOrdered, uidPurchase),
+    db.exec(sqlInventoriesInStock, uidPurchase),
+    db.exec(sqlInventoriesInStockDetailled, [uidPurchase, PURCHASE_FLUX_ID]),
+  ]);
 
-    inventoriesOrdered.forEach(ordered => {
-      // Initialization of the quantity received
-      ordered.quantity_inStock = 0;
-      ordered.quantity_difference = ordered.quantity_ordered;
-      ordered.last_entry_date = null;
+  inventoriesOrdered.forEach(ordered => {
+    // Initialization of the quantity received
+    ordered.quantity_inStock = 0;
+    ordered.quantity_difference = ordered.quantity_ordered;
+    ordered.last_entry_date = null;
 
-      inventoriesInStock.forEach(inStock => {
-        if (ordered.inventory_uuid === inStock.inventory_uuid) {
-          ordered.quantity_inStock += inStock.quantity_inStock;
-          ordered.quantity_difference -= inStock.quantity_inStock;
-          ordered.last_entry_date = inStock.entry_date;
-        }
-      });
-    });
-
-    inventoriesOrdered.forEach(ordered => {
-      if (ordered.quantity_difference === ordered.quantity_ordered) {
-        ordered.status = statusDisplay.waiting;
-      } else if (ordered.quantity_difference < 0) {
-        ordered.status = statusDisplay.exessive;
-      } else if (ordered.quantity_difference === 0) {
-        ordered.status = statusDisplay.received;
-      } else if (ordered.quantity_difference > 0 && ordered.quantity_difference < ordered.quantity_ordered) {
-        ordered.status = statusDisplay.partial;
+    inventoriesInStock.forEach(inStock => {
+      if (ordered.inventory_uuid === inStock.inventory_uuid) {
+        ordered.quantity_inStock += inStock.quantity_inStock;
+        ordered.quantity_difference -= inStock.quantity_inStock;
+        ordered.last_entry_date = inStock.entry_date;
       }
-
-      // if the purchase order is canceled, it should display canceled for all
-      // items
-      if (purchase.status_id === 5) {
-        ordered.status = statusDisplay.canceled;
-      }
-
     });
+  });
 
-    inventoriesOrdered.forEach(ordered => {
-      ordered.detailled = [];
-      inventoriesInStockDetailled.forEach(detailled => {
-        if (ordered.inventory_uuid === detailled.inventory_uuid) {
-          ordered.detailled.push(detailled);
-        }
-      });
-    });
-
-    data.inventoriesOrdered = inventoriesOrdered;
-
-    data.purchase = purchase;
-
-    if (data.purchase.status_id === 1) {
-      data.purchase.statusDisplay = statusDisplay.waiting;
-    } else if (data.purchase.status_id === 2) {
-      data.purchase.statusDisplay = statusDisplay.confirmed;
-    } if (data.purchase.status_id === 3) {
-      data.purchase.statusDisplay = statusDisplay.received;
-    } else if (data.purchase.status_id === 4) {
-      data.purchase.statusDisplay = statusDisplay.partial;
-    } else if (data.purchase.status_id === 5) {
-      data.purchase.statusDisplay = statusDisplay.canceled;
-    } else if (data.purchase.status_id === 6) {
-      data.purchase.statusDisplay = statusDisplay.exessive;
+  inventoriesOrdered.forEach(ordered => {
+    if (ordered.quantity_difference === ordered.quantity_ordered) {
+      ordered.status = statusDisplay.waiting;
+    } else if (ordered.quantity_difference < 0) {
+      ordered.status = statusDisplay.exessive;
+    } else if (ordered.quantity_difference === 0) {
+      ordered.status = statusDisplay.received;
+    } else if (ordered.quantity_difference > 0 && ordered.quantity_difference < ordered.quantity_ordered) {
+      ordered.status = statusDisplay.partial;
     }
 
-    const result = await reporting.render(data);
-    res.set(result.headers).send(result.report);
-  } catch (e) {
-    next(e);
+    // if the purchase order is canceled, it should display canceled for all
+    // items
+    if (purchase.status_id === 5) {
+      ordered.status = statusDisplay.canceled;
+    }
+
+  });
+
+  inventoriesOrdered.forEach(ordered => {
+    ordered.detailled = [];
+    inventoriesInStockDetailled.forEach(detailled => {
+      if (ordered.inventory_uuid === detailled.inventory_uuid) {
+        ordered.detailled.push(detailled);
+      }
+    });
+  });
+
+  data.inventoriesOrdered = inventoriesOrdered;
+
+  data.purchase = purchase;
+
+  if (data.purchase.status_id === 1) {
+    data.purchase.statusDisplay = statusDisplay.waiting;
+  } else if (data.purchase.status_id === 2) {
+    data.purchase.statusDisplay = statusDisplay.confirmed;
+  } if (data.purchase.status_id === 3) {
+    data.purchase.statusDisplay = statusDisplay.received;
+  } else if (data.purchase.status_id === 4) {
+    data.purchase.statusDisplay = statusDisplay.partial;
+  } else if (data.purchase.status_id === 5) {
+    data.purchase.statusDisplay = statusDisplay.canceled;
+  } else if (data.purchase.status_id === 6) {
+    data.purchase.statusDisplay = statusDisplay.exessive;
   }
+
+  const result = await reporting.render(data);
+  res.set(result.headers).send(result.report);
 }

--- a/server/controllers/stock/reports/stock/aggregated_consumption_report.js
+++ b/server/controllers/stock/reports/stock/aggregated_consumption_report.js
@@ -11,10 +11,9 @@ const {
  *
  * GET /reports/stock/aggregated_consumption
  */
-function stockAggregatedConsumptionReport(req, res, next) {
-  reporting(req.query, req.session).then(result => {
-    res.set(result.headers).send(result.report);
-  }).catch(next);
+async function stockAggregatedConsumptionReport(req, res) {
+  const result = await reporting(req.query, req.session);
+  res.set(result.headers).send(result.report);
 }
 
 async function reporting(_options, session) {

--- a/server/controllers/stock/reports/stock/assignment/stock_assign.registry.js
+++ b/server/controllers/stock/reports/stock/assignment/stock_assign.registry.js
@@ -12,8 +12,7 @@ const stockAssign = require('../../../assign');
  *
  * GET /reports/stock/assign
  */
-function stockAssignRegistry(req, res, next) {
-  let report;
+async function stockAssignRegistry(req, res) {
   let display;
 
   const params = req.query;
@@ -24,33 +23,23 @@ function stockAssignRegistry(req, res, next) {
   });
 
   // set up the report with report manager
-  try {
-    if (req.query.displayNames) {
-      display = JSON.parse(req.query.displayNames);
-      delete req.query.displayNames;
-    }
-
-    report = new ReportManager(STOCK_ASSIGN_REGISTRY_TEMPLATE, req.session, optionReport);
-  } catch (e) {
-    return next(e);
+  if (req.query.displayNames) {
+    display = JSON.parse(req.query.displayNames);
+    delete req.query.displayNames;
   }
 
-  return stockAssign.find(params)
-    .then(rows => {
-      const filters = _.uniqBy(formatFilters(params), 'field');
-      const data = {
-        enterprise : req.session.enterprise,
-        rows,
-        display,
-        filters,
-      };
-      return report.render(data);
-    })
-    .then((result) => {
-      res.set(result.headers).send(result.report);
-    })
-    .catch(next);
+  const report = new ReportManager(STOCK_ASSIGN_REGISTRY_TEMPLATE, req.session, optionReport);
 
+  const rows = await stockAssign.find(params);
+  const filters = _.uniqBy(formatFilters(params), 'field');
+  const data = {
+    enterprise : req.session.enterprise,
+    rows,
+    display,
+    filters,
+  };
+  const result = await report.render(data);
+  res.set(result.headers).send(result.report);
 }
 
 module.exports = stockAssignRegistry;

--- a/server/controllers/stock/reports/stock/consumption_graph.js
+++ b/server/controllers/stock/reports/stock/consumption_graph.js
@@ -17,7 +17,7 @@ const chartjs = {};
    */
 async function stockConsumptionGraphReport(req, res) {
 
-  const params = _.clone(req.query);
+  const params = structuredClone(req.query);
 
   const optionReport = _.extend(params, {
     filename : 'REPORT.STOCK_CONSUMPTION_GRAPH_REPORT.TITLE',

--- a/server/controllers/stock/reports/stock/consumption_graph.js
+++ b/server/controllers/stock/reports/stock/consumption_graph.js
@@ -15,70 +15,66 @@ const chartjs = {};
    *
    * GET /reports/stock/consumption_graph
    */
-async function stockConsumptionGraphReport(req, res, next) {
-  try {
+async function stockConsumptionGraphReport(req, res) {
 
-    const params = _.clone(req.query);
+  const params = _.clone(req.query);
 
-    const optionReport = _.extend(params, {
-      filename : 'REPORT.STOCK_CONSUMPTION_GRAPH_REPORT.TITLE',
-    });
+  const optionReport = _.extend(params, {
+    filename : 'REPORT.STOCK_CONSUMPTION_GRAPH_REPORT.TITLE',
+  });
 
-    // set up the report with report manager
-    const report = new ReportManager(STOCK_CONSUMPTION_GRAPTH_TEMPLATE, req.session, optionReport);
-    const options = req.query;
-    let depot = {};
+  // set up the report with report manager
+  const report = new ReportManager(STOCK_CONSUMPTION_GRAPTH_TEMPLATE, req.session, optionReport);
+  const options = req.query;
+  let depot = {};
 
-    if (options.depot_uuid) {
-      depot = await db.one('SELECT text FROM depot WHERE uuid=?', db.bid(options.depot_uuid));
-    }
-
-    options.consumption = true;
-
-    const collection = [];
-    const reportType = options.reportType || 'quantity';
-    const result = await stockCore.getDailyStockConsumption(options);
-
-    result.forEach(item => {
-      const line = {
-        label : item.inventory_name,
-        value : item[reportType],
-      };
-      collection.push(line);
-    });
-
-    const data = {
-      labels : collection.map(item => item.label),
-      datasets : [{
-        data : collection.map(item => item.value),
-        backgroundColor : 'rgba(8, 84, 132, 1)',
-      }],
-    };
-
-    const chartRenderOptions = {
-      chart_canvas_id : 'stockConsumptionChart',
-      chart_data : data,
-      chart_x_axis_label : i18n(options.lang)(`FORM.LABELS.${reportType.toUpperCase()}`),
-      chart_type : 'horizontalBar',
-      chart_option : { maintainAspectRatio : false },
-    };
-
-    const lineHeight = 16; // height of an inventory line
-    const defaultPadding = 100;
-    const chartHeight = String((result.length * lineHeight) + defaultPadding).concat('px');
-
-    const reportResult = await report.render({
-      chartHeight,
-      depotName : depot.text,
-      dateFrom : options.dateFrom,
-      dateTo : options.dateTo,
-      chartjs : chartjs.renderChart(chartRenderOptions),
-      destinationType : `STOCK_FLUX.${options.destinationType || 'ALL_DESTINATION'}`,
-    });
-    res.set(reportResult.headers).send(reportResult.report);
-  } catch (error) {
-    next(error);
+  if (options.depot_uuid) {
+    depot = await db.one('SELECT text FROM depot WHERE uuid=?', db.bid(options.depot_uuid));
   }
+
+  options.consumption = true;
+
+  const collection = [];
+  const reportType = options.reportType || 'quantity';
+  const result = await stockCore.getDailyStockConsumption(options);
+
+  result.forEach(item => {
+    const line = {
+      label : item.inventory_name,
+      value : item[reportType],
+    };
+    collection.push(line);
+  });
+
+  const data = {
+    labels : collection.map(item => item.label),
+    datasets : [{
+      data : collection.map(item => item.value),
+      backgroundColor : 'rgba(8, 84, 132, 1)',
+    }],
+  };
+
+  const chartRenderOptions = {
+    chart_canvas_id : 'stockConsumptionChart',
+    chart_data : data,
+    chart_x_axis_label : i18n(options.lang)(`FORM.LABELS.${reportType.toUpperCase()}`),
+    chart_type : 'horizontalBar',
+    chart_option : { maintainAspectRatio : false },
+  };
+
+  const lineHeight = 16; // height of an inventory line
+  const defaultPadding = 100;
+  const chartHeight = String((result.length * lineHeight) + defaultPadding).concat('px');
+
+  const reportResult = await report.render({
+    chartHeight,
+    depotName : depot.text,
+    dateFrom : options.dateFrom,
+    dateTo : options.dateTo,
+    chartjs : chartjs.renderChart(chartRenderOptions),
+    destinationType : `STOCK_FLUX.${options.destinationType || 'ALL_DESTINATION'}`,
+  });
+  res.set(reportResult.headers).send(reportResult.report);
 }
 
 module.exports = stockConsumptionGraphReport;

--- a/server/controllers/stock/reports/stock/entry_report.js
+++ b/server/controllers/stock/reports/stock/entry_report.js
@@ -18,8 +18,8 @@ const StockEntryFromTransfer = require('./entry/entryFromTransfer');
    *
    * GET /reports/stock/entry
    */
-// function stockEntryReport(req, res, next) {
-async function stockEntryReport(req, res, next) {
+// function stockEntryReport(req, res) {
+async function stockEntryReport(req, res) {
 
   const params = util.convertStringToNumber(req.query);
 
@@ -28,27 +28,23 @@ async function stockEntryReport(req, res, next) {
   });
 
   // set up the report with report manager
-  try {
-    const report = new ReportManager(STOCK_ENTRY_REPORT_TEMPLATE, req.session, optionReport);
+  const report = new ReportManager(STOCK_ENTRY_REPORT_TEMPLATE, req.session, optionReport);
 
-    const [depot, exchange] = await Promise.all([
-      fetchDepotDetails(params.depotUuid),
-      Exchange.getExchangeRate(req.session.enterprise.id, params.currencyId, new Date()),
-    ]);
+  const [depot, exchange] = await Promise.all([
+    fetchDepotDetails(params.depotUuid),
+    Exchange.getExchangeRate(req.session.enterprise.id, params.currencyId, new Date()),
+  ]);
 
-    params.exchangeRate = exchange.rate || 1;
+  params.exchangeRate = exchange.rate || 1;
 
-    params.depotName = depot.text;
-    const collection = await collect(params);
-    const bundle = await groupCollection(collection);
+  params.depotName = depot.text;
+  const collection = await collect(params);
+  const bundle = await groupCollection(collection);
 
-    _.extend(bundle, params);
+  _.extend(bundle, params);
 
-    const result = await report.render(bundle);
-    res.set(result.headers).send(result.report);
-  } catch (e) {
-    next(e);
-  }
+  const result = await report.render(bundle);
+  res.set(result.headers).send(result.report);
 }
 
 /**

--- a/server/controllers/stock/reports/stock/exit_report.js
+++ b/server/controllers/stock/reports/stock/exit_report.js
@@ -19,7 +19,7 @@ const StockExitAggregateConsumption = require('./exit/exitAggregateConsumption')
  *
  * GET /reports/stock/exit
  */
-async function stockExitReport(req, res, next) {
+async function stockExitReport(req, res) {
 
   const params = util.convertStringToNumber(req.query);
 
@@ -28,27 +28,23 @@ async function stockExitReport(req, res, next) {
   });
 
   // set up the report with report manager
-  try {
-    const report = new ReportManager(STOCK_EXIT_REPORT_TEMPLATE, req.session, optionReport);
+  const report = new ReportManager(STOCK_EXIT_REPORT_TEMPLATE, req.session, optionReport);
 
-    const [depot, exchange] = await Promise.all([
-      fetchDepotDetails(params.depotUuid),
-      Exchange.getExchangeRate(req.session.enterprise.id, params.currencyId, new Date()),
-    ]);
+  const [depot, exchange] = await Promise.all([
+    fetchDepotDetails(params.depotUuid),
+    Exchange.getExchangeRate(req.session.enterprise.id, params.currencyId, new Date()),
+  ]);
 
-    params.exchangeRate = exchange.rate || 1;
-    params.depotName = depot.text;
+  params.exchangeRate = exchange.rate || 1;
+  params.depotName = depot.text;
 
-    const collection = await collect(params);
-    const bundle = await groupCollection(collection);
+  const collection = await collect(params);
+  const bundle = await groupCollection(collection);
 
-    _.extend(bundle, params);
+  _.extend(bundle, params);
 
-    const result = await report.render(bundle);
-    res.set(result.headers).send(result.report);
-  } catch (e) {
-    next(e);
-  }
+  const result = await report.render(bundle);
+  res.set(result.headers).send(result.report);
 }
 
 /**

--- a/server/controllers/stock/reports/stock/inline_movements_report.js
+++ b/server/controllers/stock/reports/stock/inline_movements_report.js
@@ -13,7 +13,7 @@ const i18n = require('../../../../lib/helpers/translate');
  *
  * GET /reports/stock/inline-movements
  */
-async function stockInlineMovementsReport(req, res, next) {
+async function stockInlineMovementsReport(req, res) {
   const { lang } = req.query;
   const optionReport = _.extend(req.query, {
     filename : 'TREE.STOCK_INLINE_MOVEMENTS',
@@ -21,49 +21,45 @@ async function stockInlineMovementsReport(req, res, next) {
   });
 
   // set up the report with report manager
-  try {
-    const report = new ReportManager(STOCK_INLINE_MOVEMENTS_REPORT_TEMPLATE, req.session, optionReport);
+  const report = new ReportManager(STOCK_INLINE_MOVEMENTS_REPORT_TEMPLATE, req.session, optionReport);
 
-    const params = req.query;
+  const params = req.query;
 
-    if (req.session.stock_settings.enable_strict_depot_permission) {
-      params.check_user_id = req.session.user.id;
-    }
+  if (req.session.stock_settings.enable_strict_depot_permission) {
+    params.check_user_id = req.session.user.id;
+  }
 
-    const rows = await Stock.getMovements(null, params);
+  const rows = await Stock.getMovements(null, params);
 
-    const purgeKeys = ['depot_uuid', 'document_uuid', 'entity_uuid', 'flux_id', 'invoice_uuid',
-      'is_exit', 'stock_requisition_uuid',
-    ];
+  const purgeKeys = ['depot_uuid', 'document_uuid', 'entity_uuid', 'flux_id', 'invoice_uuid',
+    'is_exit', 'stock_requisition_uuid',
+  ];
 
-    rows.forEach(row => {
-      // Purge unneeded fields from the row
-      purgeKeys.forEach(key => {
-        delete row[key];
-      });
-
-      // Translate the Flux type
-      row.fluxName = i18n(lang)(row.flux_label);
-      delete row.flux_label;
+  rows.forEach(row => {
+    // Purge unneeded fields from the row
+    purgeKeys.forEach(key => {
+      delete row[key];
     });
 
-    const data = {
-      rows,
-      filters : formatFilters(req.query),
-    };
+    // Translate the Flux type
+    row.fluxName = i18n(lang)(row.flux_label);
+    delete row.flux_label;
+  });
 
-    const depots = _.chain(rows)
-      .groupBy(d => d.depot_text)
-      .mapValues(lines => _.sortBy(lines, 'depot_text'))
-      .value();
+  const data = {
+    rows,
+    filters : formatFilters(req.query),
+  };
 
-    data.depots = depots;
+  const depots = _.chain(rows)
+    .groupBy(d => d.depot_text)
+    .mapValues(lines => _.sortBy(lines, 'depot_text'))
+    .value();
 
-    const result = await report.render(data);
-    res.set(result.headers).send(result.report);
-  } catch (e) {
-    next(e);
-  }
+  data.depots = depots;
+
+  const result = await report.render(data);
+  res.set(result.headers).send(result.report);
 }
 
 module.exports = stockInlineMovementsReport;

--- a/server/controllers/stock/reports/stock/inventories_report.js
+++ b/server/controllers/stock/reports/stock/inventories_report.js
@@ -13,7 +13,7 @@ const i18n = require('../../../../lib/helpers/translate');
  *
  * GET /reports/stock/inventories
  */
-async function stockInventoriesReport(req, res, next) {
+async function stockInventoriesReport(req, res) {
   const { lang } = req.query;
   const monthAverageConsumption = req.session.stock_settings.month_average_consumption;
   const averageConsumptionAlgo = req.session.stock_settings.average_consumption_algo;
@@ -25,81 +25,77 @@ async function stockInventoriesReport(req, res, next) {
     title : 'TREE.STOCK_INVENTORY',
   });
 
-  try {
-    const options = req.query;
-    delete options.label;
+  const options = req.query;
+  delete options.label;
 
-    const filters = formatFilters(options);
+  const filters = formatFilters(options);
 
-    // Update the name for the depot filter if specified
-    const depotFilter = filters.find(filt => filt.field === 'depot_uuid');
-    if (depotFilter) {
-      const depot = await db.one('SELECT text FROM depot WHERE uuid = ?', db.bid(depotFilter.value));
-      depotFilter.value = depot.text;
-    }
-
-    // Update the name for the inventory filter if specified
-    const inventoryFilter = filters.find(filt => filt.field === 'inventory_uuid');
-    if (inventoryFilter) {
-      const inventory = await db.one('SELECT text FROM inventory WHERE uuid = ?', db.bid(inventoryFilter.value));
-      inventoryFilter.value = inventory.text;
-    }
-
-    if (req.session.stock_settings.enable_strict_depot_permission) {
-      options.check_user_id = req.session.user.id;
-    }
-
-    const inventoriesParameters = [options, monthAverageConsumption, averageConsumptionAlgo];
-    const report = new ReportManager(STOCK_INVENTORIES_REPORT_TEMPLATE, req.session, optionReport);
-    const rows = await Stock.getInventoryQuantityAndConsumption(...inventoriesParameters);
-
-    const purgeKeys = ['uuid', 'cmms', 'default_purchase_interval', 'delay', 'depot_uuid',
-      'documentReference', 'enterprisePurchaseInterval', 'enterprise_id', 'entry_date',
-      'expiration_date', 'group_uuid', 'inventory_uuid', 'last_movement_date', 'label',
-      'min_delay', 'min_months_security_stock', 'NO_CONSUMPTION', 'purchase_interval',
-      'S_MONTH', 'tag_color', 'tag_name', 'tracking_consumption', 'tracking_expiration',
-      'unit_cost'];
-
-    rows.forEach(row => {
-      // Get the quantity out of CMMS
-      row.quantity = row.cmms.quantity_in_stock;
-
-      // Purge unneeded fields from the row
-      purgeKeys.forEach(key => {
-        delete row[key];
-      });
-
-      // translate the status field
-      if (row.status in stockStatusLabelKeys) {
-        row.status = i18n(lang)(stockStatusLabelKeys[row.status]);
-      }
-
-      // Capitalize status column header
-      row.Status = row.status;
-      delete row.status;
-    });
-
-    data.rows = rows;
-    data.filters = filters;
-    data.csv = rows;
-
-    data.dateTo = options.dateTo;
-
-    // group by depot
-    const groupedDepots = _.groupBy(rows, d => d.depot_text);
-    const depots = {};
-
-    Object.keys(groupedDepots).sort(compare).forEach(d => {
-      depots[d] = _.sortBy(groupedDepots[d], line => String(line.text).toLocaleLowerCase());
-    });
-
-    data.depots = depots;
-
-    const result = await report.render(data);
-    res.set(result.headers).send(result.report);
-  } catch (e) {
-    next(e);
+  // Update the name for the depot filter if specified
+  const depotFilter = filters.find(filt => filt.field === 'depot_uuid');
+  if (depotFilter) {
+    const depot = await db.one('SELECT text FROM depot WHERE uuid = ?', db.bid(depotFilter.value));
+    depotFilter.value = depot.text;
   }
+
+  // Update the name for the inventory filter if specified
+  const inventoryFilter = filters.find(filt => filt.field === 'inventory_uuid');
+  if (inventoryFilter) {
+    const inventory = await db.one('SELECT text FROM inventory WHERE uuid = ?', db.bid(inventoryFilter.value));
+    inventoryFilter.value = inventory.text;
+  }
+
+  if (req.session.stock_settings.enable_strict_depot_permission) {
+    options.check_user_id = req.session.user.id;
+  }
+
+  const inventoriesParameters = [options, monthAverageConsumption, averageConsumptionAlgo];
+  const report = new ReportManager(STOCK_INVENTORIES_REPORT_TEMPLATE, req.session, optionReport);
+  const rows = await Stock.getInventoryQuantityAndConsumption(...inventoriesParameters);
+
+  const purgeKeys = ['uuid', 'cmms', 'default_purchase_interval', 'delay', 'depot_uuid',
+    'documentReference', 'enterprisePurchaseInterval', 'enterprise_id', 'entry_date',
+    'expiration_date', 'group_uuid', 'inventory_uuid', 'last_movement_date', 'label',
+    'min_delay', 'min_months_security_stock', 'NO_CONSUMPTION', 'purchase_interval',
+    'S_MONTH', 'tag_color', 'tag_name', 'tracking_consumption', 'tracking_expiration',
+    'unit_cost'];
+
+  rows.forEach(row => {
+    // Get the quantity out of CMMS
+    row.quantity = row.cmms.quantity_in_stock;
+
+    // Purge unneeded fields from the row
+    purgeKeys.forEach(key => {
+      delete row[key];
+    });
+
+    // translate the status field
+    if (row.status in stockStatusLabelKeys) {
+      row.status = i18n(lang)(stockStatusLabelKeys[row.status]);
+    }
+
+    // Capitalize status column header
+    row.Status = row.status;
+    delete row.status;
+  });
+
+  data.rows = rows;
+  data.filters = filters;
+  data.csv = rows;
+
+  data.dateTo = options.dateTo;
+
+  // group by depot
+  const groupedDepots = _.groupBy(rows, d => d.depot_text);
+  const depots = {};
+
+  Object.keys(groupedDepots).sort(compare).forEach(d => {
+    depots[d] = _.sortBy(groupedDepots[d], line => String(line.text).toLocaleLowerCase());
+  });
+
+  data.depots = depots;
+
+  const result = await report.render(data);
+  res.set(result.headers).send(result.report);
 }
 
 function compare(a, b) {

--- a/server/controllers/stock/reports/stock/rumer.js
+++ b/server/controllers/stock/reports/stock/rumer.js
@@ -15,15 +15,11 @@ exports.report = report;
  *
  * GET /reports/stock/rumer_report
  */
-async function report(req, res, next) {
-  try {
-    const output = await rumer.getData(req.query);
-    const { params, data } = output;
-    const template = params.condensed_report ? TEMPLATE2 : TEMPLATE1;
-    const reporting = new ReportManager(template, req.session, params);
-    const result = await reporting.render(data);
-    res.set(result.headers).send(result.report);
-  } catch (e) {
-    next(e);
-  }
+async function report(req, res) {
+  const output = await rumer.getData(req.query);
+  const { params, data } = output;
+  const template = params.condensed_report ? TEMPLATE2 : TEMPLATE1;
+  const reporting = new ReportManager(template, req.session, params);
+  const result = await reporting.render(data);
+  res.set(result.headers).send(result.report);
 }

--- a/server/controllers/stock/reports/stock/satisfaction_rate_data.js
+++ b/server/controllers/stock/reports/stock/satisfaction_rate_data.js
@@ -12,14 +12,9 @@ const satisfaction = require('./satisfaction');
  * @param {object} next - next middleware object to pass control to
  * @returns {Promise} for the results
  */
-async function satisfactionRates(req, res, next) {
-  try {
-    const data = await satisfaction.getSatisfactionData(req.query);
-    res.status(200).json(data);
-  } catch (e) {
-    next(e);
-  }
-
+async function satisfactionRates(req, res) {
+  const data = await satisfaction.getSatisfactionData(req.query);
+  res.status(200).json(data);
 }
 
 module.exports = satisfactionRates;

--- a/server/controllers/stock/reports/stock/satisfaction_rate_report.js
+++ b/server/controllers/stock/reports/stock/satisfaction_rate_report.js
@@ -16,14 +16,10 @@ const satisfaction = require('./satisfaction');
  *
  * @param {object} req - the request object
  * @param {object} res - the response object
- * @param {object} next - next middleware object to pass control to
  */
-function satisfactionRateReport(req, res, next) {
-  reporting(req.query, req.session)
-    .then((result) => {
-      res.set(result.headers).send(result.report);
-    })
-    .catch(next);
+async function satisfactionRateReport(req, res) {
+  const result = await reporting(req.query, req.session);
+  res.set(result.headers).send(result.report);
 }
 
 async function reporting(_options, session) {

--- a/server/controllers/stock/reports/stock/stock_sheet.js
+++ b/server/controllers/stock/reports/stock/stock_sheet.js
@@ -14,7 +14,7 @@ const Exchange = require('../../../finance/exchange');
  *
  * GET /reports/stock/sheet
  */
-async function stockSheetReport(req, res, next) {
+async function stockSheetReport(req, res) {
   const optionReport = {
     ...req.query,
     filename : 'REPORT.STOCK.INVENTORY_REPORT',
@@ -24,94 +24,90 @@ async function stockSheetReport(req, res, next) {
   delete req.query.label;
 
   // set up the report with report manager
-  try {
-    const options = { ...util.convertStringToNumber(req.query) };
+  const options = { ...util.convertStringToNumber(req.query) };
 
-    if (options.period) {
-      // compute the dateFrom and dateTo required for having opening balance
-      const period = new PeriodService();
-      const target = period.lookupPeriod(options.period);
-      if (options.period === 'custom') {
-        options.dateFrom = new Date(options.custom_period_start);
-        options.dateTo = new Date(options.custom_period_end);
-      } else if (options.period === 'allTime') {
-        // Do not add dateFrom/dateTo so that the inventory
-        // movements query below does not limit search
-      } else {
-        options.dateFrom = target.limit.start();
-        options.dateTo = target.limit.end();
-      }
-      delete options.period;
-    }
-
-    const report = new ReportManager(STOCK_SHEET_REPORT_TEMPLATE, req.session, optionReport);
-
-    const exchangeRate = await Exchange.getExchangeRate(req.session.enterprise.id, options.currencyId, new Date());
-
-    const data = {};
-
-    data.exchangeRate = exchangeRate.rate || 1;
-    data.currencyId = options.currencyId;
-
-    options.exchangeRate = data.exchangeRate;
-
-    const [inventory, depot, rows] = await Promise.all([
-      db.one('SELECT code, text FROM inventory WHERE uuid = ?;', [db.bid(options.inventory_uuid)]),
-      options.depot_uuid
-        ? db.one('SELECT text FROM depot WHERE uuid = ?;', [db.bid(options.depot_uuid)])
-        : null,
-      Stock.getInventoryMovements(options),
-    ]);
-
-    Object.assign(data, { inventory, depot });
-
-    if (!parseInt(options.orderByCreatedAt, 10)) {
-      data.rows = rows.movements.sort((x, y) => x.date - y.date);
+  if (options.period) {
+    // compute the dateFrom and dateTo required for having opening balance
+    const period = new PeriodService();
+    const target = period.lookupPeriod(options.period);
+    if (options.period === 'custom') {
+      options.dateFrom = new Date(options.custom_period_start);
+      options.dateTo = new Date(options.custom_period_end);
+    } else if (options.period === 'allTime') {
+      // Do not add dateFrom/dateTo so that the inventory
+      // movements query below does not limit search
     } else {
-      // already sorted by created_at by mysql
-      data.rows = rows.movements;
+      options.dateFrom = target.limit.start();
+      options.dateTo = target.limit.end();
     }
-
-    // mark rows if they contain negative balances
-    data.rows.forEach(row => {
-      row.hasNegativeValues = row.stock.quantity < 0;
-    });
-
-    const header = rows.openingBalance;
-    header.hasNegativeValues = rows.openingBalance && rows.openingBalance.value < 0;
-
-    // if this is negative, show 0 for total value
-    if (header.hasNegativeValues) {
-      header.value = 0;
-    }
-
-    data.totals = rows.totals;
-    data.result = rows.result;
-    data.header = header;
-    data.dateFrom = options.dateFrom;
-    data.dateTo = options.dateTo;
-    data.depotName = depot?.text || null;
-
-    // get last row for wac
-    const lastRow = data.rows[data.rows.length - 1]?.stock;
-
-    if (lastRow) {
-      data.wacDetails = {
-        value : lastRow.value,
-        unit_cost : lastRow.unit_cost,
-      };
-    } else {
-      data.wacDetails = {
-        value : 0,
-        unit_cost : 0,
-      };
-    }
-
-    const result = await report.render(data);
-    res.set(result.headers).send(result.report);
-  } catch (e) {
-    next(e);
+    delete options.period;
   }
+
+  const report = new ReportManager(STOCK_SHEET_REPORT_TEMPLATE, req.session, optionReport);
+
+  const exchangeRate = await Exchange.getExchangeRate(req.session.enterprise.id, options.currencyId, new Date());
+
+  const data = {};
+
+  data.exchangeRate = exchangeRate.rate || 1;
+  data.currencyId = options.currencyId;
+
+  options.exchangeRate = data.exchangeRate;
+
+  const [inventory, depot, rows] = await Promise.all([
+    db.one('SELECT code, text FROM inventory WHERE uuid = ?;', [db.bid(options.inventory_uuid)]),
+    options.depot_uuid
+      ? db.one('SELECT text FROM depot WHERE uuid = ?;', [db.bid(options.depot_uuid)])
+      : null,
+    Stock.getInventoryMovements(options),
+  ]);
+
+  Object.assign(data, { inventory, depot });
+
+  if (!parseInt(options.orderByCreatedAt, 10)) {
+    data.rows = rows.movements.sort((x, y) => x.date - y.date);
+  } else {
+    // already sorted by created_at by mysql
+    data.rows = rows.movements;
+  }
+
+  // mark rows if they contain negative balances
+  data.rows.forEach(row => {
+    row.hasNegativeValues = row.stock.quantity < 0;
+  });
+
+  const header = rows.openingBalance;
+  header.hasNegativeValues = rows.openingBalance && rows.openingBalance.value < 0;
+
+  // if this is negative, show 0 for total value
+  if (header.hasNegativeValues) {
+    header.value = 0;
+  }
+
+  data.totals = rows.totals;
+  data.result = rows.result;
+  data.header = header;
+  data.dateFrom = options.dateFrom;
+  data.dateTo = options.dateTo;
+  data.depotName = depot?.text || null;
+
+  // get last row for wac
+  const lastRow = data.rows[data.rows.length - 1]?.stock;
+
+  if (lastRow) {
+    data.wacDetails = {
+      value : lastRow.value,
+      unit_cost : lastRow.unit_cost,
+    };
+  } else {
+    data.wacDetails = {
+      value : 0,
+      unit_cost : 0,
+    };
+  }
+
+  const result = await report.render(data);
+  res.set(result.headers).send(result.report);
 }
 
 module.exports = stockSheetReport;

--- a/server/controllers/stock/reports/stock/value.js
+++ b/server/controllers/stock/reports/stock/value.js
@@ -13,10 +13,9 @@ const Exchange = require('../../../finance/exchange');
  *
  * GET /reports/stock/value
  */
-function stockValue(req, res, next) {
-  reporting(req.query, req.session).then(result => {
-    res.set(result.headers).send(result.report);
-  }).catch(next);
+async function stockValue(req, res) {
+  const result = await reporting(req.query, req.session);
+  res.set(result.headers).send(result.report);
 }
 
 async function reporting(_options, session) {

--- a/server/controllers/stock/required_inventory_scans.js
+++ b/server/controllers/stock/required_inventory_scans.js
@@ -62,14 +62,10 @@ function getFilters(parameters) {
  *
  * GET /inventory/required/scans
  */
-exports.getRequiredInventoryScans = async function getRequiredInventoryScans(req, res, next) {
+exports.getRequiredInventoryScans = async function getRequiredInventoryScans(req, res) {
   const params = req.query;
-  try {
-    const rows = await list(params);
-    res.status(200).json(rows);
-  } catch (error) {
-    next(error);
-  }
+  const rows = await list(params);
+  res.status(200).json(rows);
 };
 
 /**
@@ -77,13 +73,9 @@ exports.getRequiredInventoryScans = async function getRequiredInventoryScans(req
  *
  * GET /inventory/required/scan/:uuid
  */
-exports.getRequiredInventoryScan = async function getRequiredInventoryScan(req, res, next) {
-  try {
-    const rows = await list(req.params);
-    res.status(200).json(rows[0]);
-  } catch (error) {
-    next(error);
-  }
+exports.getRequiredInventoryScan = async function getRequiredInventoryScan(req, res) {
+  const rows = await list(req.params);
+  res.status(200).json(rows[0]);
 };
 
 /**
@@ -114,7 +106,7 @@ exports.requiredInventoryScans = list;
  *
  * POST /inventory/required/scan'
  */
-exports.createRequiredInventoryScan = async function createRequiredInventoryScan(req, res, next) {
+exports.createRequiredInventoryScan = async function createRequiredInventoryScan(req, res) {
   // Limit fields for creating new asset scan
   const allowedInCreate = [
     'depot_uuid', 'title', 'description', 'start_date', 'end_date', 'is_asset', 'reference_number',
@@ -130,9 +122,8 @@ exports.createRequiredInventoryScan = async function createRequiredInventoryScan
 
   const sql = 'INSERT INTO required_inventory_scan SET ?;';
 
-  db.exec(sql, [binarize(params)])
-    .then(() => res.status(201).json({ uuid : newUuid }))
-    .catch(next);
+  await db.exec(sql, [binarize(params)]);
+  res.status(201).json({ uuid : newUuid });
 
 };
 
@@ -141,7 +132,7 @@ exports.createRequiredInventoryScan = async function createRequiredInventoryScan
  *
  * PUT /inventory/required/scan'
  */
-exports.updateRequiredInventoryScan = async function updateRequiredInventoryScan(req, res, next) {
+exports.updateRequiredInventoryScan = async function updateRequiredInventoryScan(req, res) {
   const uuid = db.bid(req.params.uuid);
 
   // Limit which fields can be updated
@@ -163,10 +154,8 @@ exports.updateRequiredInventoryScan = async function updateRequiredInventoryScan
   params.updated_at = new Date();
 
   const sql = 'UPDATE required_inventory_scan SET ? WHERE uuid = ?;';
-  db.exec(sql, [params, uuid])
-    .then(() => res.sendStatus(200))
-    .catch(next);
-
+  await db.exec(sql, [params, uuid]);
+  res.sendStatus(200);
 };
 
 /**
@@ -174,11 +163,9 @@ exports.updateRequiredInventoryScan = async function updateRequiredInventoryScan
  *
  * DELETE /inventory/required/scan'
  */
-exports.deleteRequiredInventoryScan = async function deleteRequiredInventoryScan(req, res, next) {
+exports.deleteRequiredInventoryScan = async function deleteRequiredInventoryScan(req, res) {
   const uuid = db.bid(req.params.uuid);
   const sql = 'DELETE FROM required_inventory_scan WHERE uuid = ?;';
-  db.one(sql, [uuid])
-    .then(() => res.sendStatus(200))
-    .catch(next);
-
+  await db.one(sql, [uuid]);
+  res.sendStatus(200);
 };

--- a/server/controllers/stock/requisition/requestor_type.js
+++ b/server/controllers/stock/requisition/requestor_type.js
@@ -17,21 +17,15 @@ function find(options) {
 
 function lookup(id) {
   const sql = 'SELECT id, type_key, title_key FROM stock_requestor_type WHERE id = ?';
-  db.one(sql, [id]);
+  return db.one(sql, [id]);
 }
 
-module.exports.list = (req, res, next) => {
-  find(req.query)
-    .then(rows => {
-      res.status(200).json(rows);
-    })
-    .catch(next);
+module.exports.list = async (req, res) => {
+  const rows = await find(req.query);
+  res.status(200).json(rows);
 };
 
-module.exports.details = (req, res, next) => {
-  lookup(req.params.id)
-    .then(row => {
-      res.status(200).json(row);
-    })
-    .catch(next);
+module.exports.details = async (req, res) => {
+  const row = await lookup(req.params.id);
+  res.status(200).json(row);
 };

--- a/server/controllers/stock/requisition/requisition.receipt.js
+++ b/server/controllers/stock/requisition/requisition.receipt.js
@@ -18,35 +18,31 @@ const STOCK_REQUISITION_TEMPLATE = `${BASE_PATH}/requisition.receipt.handlebars`
    *
    * GET /receipts/stock/requisition/:uuid
    */
-async function stockRequisitionReceipt(req, res, next) {
+async function stockRequisitionReceipt(req, res) {
   const data = {};
   const uuid = db.bid(req.params.uuid);
   const optionReport = _.extend(req.query, { filename : 'REQUISITION.STOCK_REQUISITION' });
 
   // set up the report with report manager
-  try {
-    const report = new ReportManager(STOCK_REQUISITION_TEMPLATE, req.session, optionReport);
-    const details = await api.getDetails(db.bid(uuid));
-    data.barcode = barcode.generate(identifiers.REQUISITION.key, details.uuid);
-    data.enterprise = req.session.enterprise;
-    data.details = details;
+  const report = new ReportManager(STOCK_REQUISITION_TEMPLATE, req.session, optionReport);
+  const details = await api.getDetails(db.bid(uuid));
+  data.barcode = barcode.generate(identifiers.REQUISITION.key, details.uuid);
+  data.enterprise = req.session.enterprise;
+  data.details = details;
 
-    // If the sum of old quantity is greater than Zero,
-    // this implies that the requisition has been validated.
-    let sumOldQuantity = 0;
+  // If the sum of old quantity is greater than Zero,
+  // this implies that the requisition has been validated.
+  let sumOldQuantity = 0;
 
-    let i;
-    for (i = 0; i < data.details.items.length; i++) {
-      sumOldQuantity += data.details.items[i].old_quantity;
-    }
-
-    data.displayValidationData = sumOldQuantity > 0;
-
-    const result = await report.render(data);
-    res.set(result.headers).send(result.report);
-  } catch (e) {
-    next(e);
+  let i;
+  for (i = 0; i < data.details.items.length; i++) {
+    sumOldQuantity += data.details.items[i].old_quantity;
   }
+
+  data.displayValidationData = sumOldQuantity > 0;
+
+  const result = await report.render(data);
+  res.set(result.headers).send(result.report);
 }
 
 module.exports = stockRequisitionReceipt;

--- a/server/controllers/stock/setting/index.js
+++ b/server/controllers/stock/setting/index.js
@@ -12,7 +12,7 @@ const NotFound = require('../../../lib/errors/NotFound');
 // Get the current stock settings for the Enterprise
 //    If req.query.enterprise_id is set, it will use that,
 //    otherwise it will look up the entry for Enterprise.id=1
-exports.list = function list(req, res, next) {
+exports.list = async function list(req, res) {
   let enterpriseId = req.session.enterprise.id;
   if (req.params.id) {
     // If the enterprise was passed in as a parameter, use it
@@ -31,39 +31,28 @@ exports.list = function list(req, res, next) {
     WHERE enterprise_id = ? LIMIT 1;
     `;
 
-  db.exec(sql, [enterpriseId])
-    .then(rows => {
-      if (rows.length === 1) {
-        res.status(200).json(rows);
-      } else {
-        throw new NotFound(`Could not find stock_setting data with enterprise id ${req.params.id} (get)`);
-      }
-
-    })
-    .catch(next);
-
+  const rows = await db.exec(sql, [enterpriseId]);
+  if (rows.length === 1) {
+    res.status(200).json(rows);
+  } else {
+    throw new NotFound(`Could not find stock_setting data with enterprise id ${req.params.id} (get)`);
+  }
 };
 
 // PUT /stock/setting/:id
 //
 //  Update the settings in stock_settings for the settings
 //  with enterprise_id given by the 'id' parameter
-exports.update = function update(req, res, next) {
+exports.update = async function update(req, res) {
   const sql = 'UPDATE stock_setting SET ? WHERE enterprise_id = ?';
   const { settings } = req.body;
 
-  db.exec(sql, [settings, req.params.id])
-    .then((row) => {
-      if (!row.affectedRows) {
-        throw new NotFound(`Could not find stock_setting row with enterprise id ${req.params.id} (put)`);
-      }
-      // Get the updated values
-      return db.exec('UPDATE stock_setting SET ? WHERE enterprise_id = ?',
-        [settings, req.params.id]);
-    })
-    .then((updatedSettings) => {
-      res.status(200).json(updatedSettings);
-    })
-    .catch(next);
-
+  const row = await db.exec(sql, [settings, req.params.id]);
+  if (!row.affectedRows) {
+    throw new NotFound(`Could not find stock_setting row with enterprise id ${req.params.id} (put)`);
+  }
+  // Get the updated values
+  const updatedSettings = await db.exec('UPDATE stock_setting SET ? WHERE enterprise_id = ?',
+    [settings, req.params.id]);
+  res.status(200).json(updatedSettings);
 };

--- a/test/server-unit/payroll_test_unit/accounts.spec.js
+++ b/test/server-unit/payroll_test_unit/accounts.spec.js
@@ -101,7 +101,7 @@ describe('test/server-unit/payroll-test-unit/accounts', () => {
     req.params.id = 10;
     req.body = { label : 'Test Config' };
 
-    await expect(controller.update(req, res)).to.eventually.be.rejectedWith('Erreur SQL');
+    await expect(controller.update(req, res)).to.be.rejectedWith('Erreur SQL');
   });
 
   // ---------------------------------------------------------
@@ -122,6 +122,6 @@ describe('test/server-unit/payroll-test-unit/accounts', () => {
 
     sinon.stub(db, 'delete').callsFake(() => { throw fakeError; });
     req.params.id = 20;
-    await expect(controller.delete(req, res)).to.eventually.be.rejectedWith('Delete failed');
+    await expect(controller.delete(req, res)).to.be.rejectedWith('Delete failed');
   });
 });

--- a/test/server-unit/payroll_test_unit/accounts.spec.js
+++ b/test/server-unit/payroll_test_unit/accounts.spec.js
@@ -59,7 +59,7 @@ describe('test/server-unit/payroll-test-unit/accounts', () => {
     sinon.stub(db, 'one').rejects(fakeError);
     req.params.id = 22;
 
-    await expect(controller.detail(req, res)).to.eventually.be.rejectedWith('DB error');
+    await expect(controller.detail(req, res)).to.be.rejectedWith('DB error');
   });
 
   // ---------------------------------------------------------

--- a/test/server-unit/payroll_test_unit/accounts.spec.js
+++ b/test/server-unit/payroll_test_unit/accounts.spec.js
@@ -11,7 +11,6 @@ describe('test/server-unit/payroll-test-unit/accounts', () => {
   // reusable mocks
   let req;
   let res;
-  let next;
 
   beforeEach(() => {
     req = { params : {}, body : {} };
@@ -19,30 +18,24 @@ describe('test/server-unit/payroll-test-unit/accounts', () => {
       status : sinon.stub().returnsThis(),
       json : sinon.stub(),
     };
-    next = sinon.spy();
   });
-
-  afterEach(() => {
-    sinon.restore(); // reset everything after each test
-  });
+  // reset everything after each test
+  afterEach(() => { sinon.restore(); });
 
   it('list() should return a status 200 with the list of payroll accounts configuration', async () => {
-    const accountsConfig = [
-      {
-        id : 1,
-        label : 'Salary Account Configuration 2025',
-        account_id : 220,
-      },
-      {
-        id : 2,
-        label : 'Salary Account Configuration 2026',
-        account_id : 221,
-      },
-    ];
+    const accountsConfig = [{
+      id : 1,
+      label : 'Salary Account Configuration 2025',
+      account_id : 220,
+    }, {
+      id : 2,
+      label : 'Salary Account Configuration 2026',
+      account_id : 221,
+    }];
 
     sinon.stub(db, 'exec').resolves(accountsConfig);
 
-    await controller.list(req, res, next);
+    await controller.list(req, res);
 
     expect(db.exec.calledOnce).to.equal(true);
     expect(res.status.calledWith(200)).to.equal(true);
@@ -54,7 +47,7 @@ describe('test/server-unit/payroll-test-unit/accounts', () => {
     sinon.stub(db, 'one').resolves(record);
     req.params.id = 26;
 
-    await controller.detail(req, res, next);
+    await controller.detail(req, res);
 
     expect(db.one.calledOnce).to.equal(true);
     expect(res.status.calledWith(200)).to.equal(true);
@@ -66,8 +59,7 @@ describe('test/server-unit/payroll-test-unit/accounts', () => {
     sinon.stub(db, 'one').rejects(fakeError);
     req.params.id = 22;
 
-    await expect(controller.detail(req, res, next))
-      .to.be.rejectedWith('DB error');
+    expect(() => controller.detail(req, res)).to.eventually.be.rejectedWith('DB error');
   });
 
   // ---------------------------------------------------------
@@ -80,7 +72,7 @@ describe('test/server-unit/payroll-test-unit/accounts', () => {
       account_id : 222,
     };
 
-    await controller.create(req, res, next);
+    await controller.create(req, res);
 
     expect(db.exec.calledOnce).to.equal(true);
     expect(res.status.calledWith(201)).to.equal(true);
@@ -96,7 +88,7 @@ describe('test/server-unit/payroll-test-unit/accounts', () => {
     req.params.id = 25;
     req.body = { label : 'Salary Account Configuration', account_id : 219 };
 
-    await controller.update(req, res, next);
+    await controller.update(req, res);
 
     expect(db.exec.calledOnce).to.equal(true);
     expect(res.status.calledWith(200)).to.equal(true);
@@ -109,16 +101,15 @@ describe('test/server-unit/payroll-test-unit/accounts', () => {
     req.params.id = 10;
     req.body = { label : 'Test Config' };
 
-    await expect(controller.update(req, res, next))
-      .to.be.rejectedWith('Erreur SQL');
+    expect(() => controller.update(req, res)).to.eventually.be.rejectedWith('Erreur SQL');
   });
 
   // ---------------------------------------------------------
-  it('delete() must call db.delete() with the correct arguments', () => {
+  it('delete() must call db.delete() with the correct arguments', async () => {
     const deleteStub = sinon.stub(db, 'delete');
     req.params.id = 25;
 
-    controller.delete(req, res, next);
+    await controller.delete(req, res);
 
     expect(deleteStub.calledOnce).to.equal(true);
     expect(deleteStub.firstCall.args[0]).to.equal('config_accounting');
@@ -126,19 +117,11 @@ describe('test/server-unit/payroll-test-unit/accounts', () => {
     expect(deleteStub.firstCall.args[2]).to.equal(25);
   });
 
-  it('deleteConfig() should call next() if delete fails', () => {
+  it('deleteConfig() should throw an error if delete fails', () => {
     const fakeError = new Error('Delete failed');
 
-    const deleteStub = sinon.stub(db, 'delete').callsFake(() => {
-      next(fakeError);
-    });
-
+    sinon.stub(db, 'delete').callsFake(() => { throw fakeError; });
     req.params.id = 20;
-
-    controller.delete(req, res, next);
-
-    expect(deleteStub.calledOnce).to.equal(true);
-    expect(next.calledOnce).to.equal(true);
-    expect(next.firstCall.args[0].message).to.equal('Delete failed');
+    expect(() => controller.delete(req, res)).to.eventually.be.rejectedWith('Delete failed');
   });
 });

--- a/test/server-unit/payroll_test_unit/accounts.spec.js
+++ b/test/server-unit/payroll_test_unit/accounts.spec.js
@@ -59,7 +59,7 @@ describe('test/server-unit/payroll-test-unit/accounts', () => {
     sinon.stub(db, 'one').rejects(fakeError);
     req.params.id = 22;
 
-    expect(() => controller.detail(req, res)).to.eventually.be.rejectedWith('DB error');
+    await expect(controller.detail(req, res)).to.eventually.be.rejectedWith('DB error');
   });
 
   // ---------------------------------------------------------
@@ -101,7 +101,7 @@ describe('test/server-unit/payroll-test-unit/accounts', () => {
     req.params.id = 10;
     req.body = { label : 'Test Config' };
 
-    expect(() => controller.update(req, res)).to.eventually.be.rejectedWith('Erreur SQL');
+    await expect(controller.update(req, res)).to.eventually.be.rejectedWith('Erreur SQL');
   });
 
   // ---------------------------------------------------------
@@ -117,11 +117,11 @@ describe('test/server-unit/payroll-test-unit/accounts', () => {
     expect(deleteStub.firstCall.args[2]).to.equal(25);
   });
 
-  it('deleteConfig() should throw an error if delete fails', () => {
+  it('deleteConfig() should throw an error if delete fails', async () => {
     const fakeError = new Error('Delete failed');
 
     sinon.stub(db, 'delete').callsFake(() => { throw fakeError; });
     req.params.id = 20;
-    expect(() => controller.delete(req, res)).to.eventually.be.rejectedWith('Delete failed');
+    await expect(controller.delete(req, res)).to.eventually.be.rejectedWith('Delete failed');
   });
 });

--- a/test/server-unit/payroll_test_unit/employeeConfig.spec.js
+++ b/test/server-unit/payroll_test_unit/employeeConfig.spec.js
@@ -8,7 +8,6 @@ const controller = require('../../../server/controllers/payroll/employeeConfig')
 describe('test/server-unit/payroll-test-unit/employeeConfig', () => {
   let req;
   let res;
-  let next;
 
   beforeEach(() => {
     req = { params : {}, body : {} };
@@ -17,7 +16,6 @@ describe('test/server-unit/payroll-test-unit/employeeConfig', () => {
       json : sinon.stub(),
       sendStatus : sinon.stub(),
     };
-    next = sinon.spy();
   });
 
   afterEach(() => sinon.restore());
@@ -51,7 +49,7 @@ describe('test/server-unit/payroll-test-unit/employeeConfig', () => {
     const fakeError = new Error('DB Error');
     sinon.stub(db, 'exec').rejects(fakeError);
 
-    await expect(controller.list(req, res, next))
+    await expect(controller.list(req, res))
       .to.be.rejectedWith('DB Error');
   });
 
@@ -62,7 +60,7 @@ describe('test/server-unit/payroll-test-unit/employeeConfig', () => {
     sinon.stub(db, 'exec').resolves([]);
 
     req.params.id = 2;
-    await controller.detail(req, res, next);
+    await controller.detail(req, res);
 
     expect(res.status.calledWith(200)).to.equal(true);
     expect(res.json.calledOnce).to.equal(true);
@@ -73,7 +71,7 @@ describe('test/server-unit/payroll-test-unit/employeeConfig', () => {
     sinon.stub(db, 'one').rejects(new Error('Failed'));
     req.params.id = 5;
 
-    await expect(controller.detail(req, res, next))
+    await expect(controller.detail(req, res))
       .to.be.rejectedWith('Failed');
   });
 
@@ -143,7 +141,7 @@ describe('test/server-unit/payroll-test-unit/employeeConfig', () => {
     sinon.stub(db, 'exec').rejects(new Error('Insert failed'));
     req.body = { label : 'Bad Config', configuration : ['F40B3859E623438BA2E994776E4CF8BC'] };
 
-    await expect(controller.create(req, res, next))
+    await expect(controller.create(req, res))
       .to.be.rejectedWith('Insert failed');
   });
 
@@ -168,7 +166,7 @@ describe('test/server-unit/payroll-test-unit/employeeConfig', () => {
       return row;
     };
 
-    await controller.update(req, res, next);
+    await controller.update(req, res);
 
     expect(execStub.calledTwice).to.equal(true);
 
@@ -179,7 +177,6 @@ describe('test/server-unit/payroll-test-unit/employeeConfig', () => {
 
     expect(res.status.calledWith(200)).to.equal(true);
     expect(res.json.calledWith(fakeRecord)).to.equal(true);
-    expect(next.called).to.equal(false);
 
     controller.lookupEmployeeConfig = originalLookup;
   });
@@ -195,7 +192,7 @@ describe('test/server-unit/payroll-test-unit/employeeConfig', () => {
 
     sinon.stub(db, 'exec').rejects(new Error('Update failed'));
 
-    await controller.update(req, res, next).catch(err => {
+    await controller.update(req, res).catch(err => {
       expect(err.message).to.equal('Update failed');
     });
 
@@ -214,11 +211,10 @@ describe('test/server-unit/payroll-test-unit/employeeConfig', () => {
 
     sinon.stub(db, 'transaction').returns(fakeTransaction);
 
-    await controller.delete(req, res, next);
+    await controller.delete(req, res);
 
     expect(fakeTransaction.addQuery.calledTwice).to.equal(true);
     expect(res.sendStatus.calledWith(204)).to.equal(true);
-    expect(next.called).to.equal(false);
   });
 
   it('Delete should throw NotFound if no rows are affected', async () => {
@@ -233,15 +229,13 @@ describe('test/server-unit/payroll-test-unit/employeeConfig', () => {
     sinon.stub(db, 'transaction').callsFake(() => fakeTransaction);
 
     try {
-      await controller.delete(req, res, next);
-
+      await controller.delete(req, res);
       throw new Error('Expected NotFound error but none thrown');
     } catch (err) {
       expect(err).to.be.instanceOf(NotFound);
       expect(err.description).to.include('Could not find an employee configuration');
       expect(err.status).to.equal(404);
       expect(res.sendStatus.called).to.equal(false);
-      expect(next.called).to.equal(false);
     }
   });
 
@@ -255,12 +249,11 @@ describe('test/server-unit/payroll-test-unit/employeeConfig', () => {
     sinon.stub(db, 'transaction').returns(fakeTransaction);
 
     try {
-      await controller.delete(req, res, next);
+      await controller.delete(req, res);
       throw new Error('Expected DB error but none thrown');
     } catch (err) {
       expect(err).to.equal(fakeError);
       expect(res.sendStatus.called).to.equal(false);
-      expect(next.called).to.equal(false);
     }
   });
 });

--- a/test/server-unit/payroll_test_unit/function.spec.js
+++ b/test/server-unit/payroll_test_unit/function.spec.js
@@ -11,7 +11,6 @@ describe('test/server-unit/payroll-test-unit/function', () => {
   // reusable mocks
   let req;
   let res;
-  let next;
 
   beforeEach(() => {
     req = { params : {}, body : {} };
@@ -19,7 +18,6 @@ describe('test/server-unit/payroll-test-unit/function', () => {
       status : sinon.stub().returnsThis(),
       json : sinon.stub(),
     };
-    next = sinon.spy();
   });
 
   afterEach(() => {
@@ -34,7 +32,7 @@ describe('test/server-unit/payroll-test-unit/function', () => {
 
     sinon.stub(db, 'exec').resolves(fonctionData);
 
-    await controller.list(req, res, next);
+    await controller.list(req, res);
 
     expect(db.exec.calledOnce).to.equal(true);
     expect(res.status.calledWith(200)).to.equal(true);
@@ -46,7 +44,7 @@ describe('test/server-unit/payroll-test-unit/function', () => {
     sinon.stub(db, 'one').resolves(record);
     req.params.id = 1;
 
-    await controller.detail(req, res, next);
+    await controller.detail(req, res);
 
     expect(db.one.calledOnce).to.equal(true);
     expect(res.status.calledWith(200)).to.equal(true);
@@ -73,7 +71,7 @@ describe('test/server-unit/payroll-test-unit/function', () => {
 
     req.body = { fonction_txt : 'Radiologue' };
 
-    await controller.create(req, res, next);
+    await controller.create(req, res);
 
     expect(db.exec.calledOnce).to.equal(true);
     expect(res.status.calledWith(201)).to.equal(true);
@@ -89,7 +87,7 @@ describe('test/server-unit/payroll-test-unit/function', () => {
     req.params.id = 10;
     req.body = { fonction_txt : 'Biologiste' };
 
-    await controller.update(req, res, next);
+    await controller.update(req, res);
 
     expect(db.exec.calledOnce).to.equal(true);
     expect(res.status.calledWith(200)).to.equal(true);
@@ -110,11 +108,11 @@ describe('test/server-unit/payroll-test-unit/function', () => {
   });
 
   // ---------------------------------------------------------
-  it('delete() must call db.delete() with the correct arguments', () => {
+  it('delete() must call db.delete() with the correct arguments', async () => {
     const deleteStub = sinon.stub(db, 'delete');
     req.params.id = 5;
 
-    controller.delete(req, res, next);
+    await controller.delete(req, res);
 
     expect(deleteStub.calledOnce).to.equal(true);
     expect(deleteStub.firstCall.args[0]).to.equal('fonction');

--- a/test/server-unit/payroll_test_unit/grades.spec.js
+++ b/test/server-unit/payroll_test_unit/grades.spec.js
@@ -150,7 +150,7 @@ describe('test/server-unit/payroll-test-unit/grade', () => {
     sinon.stub(db, 'exec').resolves({ affectedRows : 1 });
     req.params.uuid = '9AE10D429242B84E09721BF0E8C09880';
 
-    await controller.delete(req, res, next);
+    await controller.delete(req, res);
 
     expect(db.exec.calledOnce).to.equal(true);
     expect(res.status.calledWith(204)).to.equal(true);
@@ -160,10 +160,6 @@ describe('test/server-unit/payroll-test-unit/grade', () => {
     sinon.stub(db, 'exec').resolves({ affectedRows : 0 });
     req.params.uuid = '1350';
 
-    await controller.delete(req, res, next);
-
-    expect(next.calledOnce).to.equal(true);
-    const err = next.firstCall.args[0];
-    expect(err).to.be.instanceOf(NotFound);
+    expect(controller.delete(req, res)).to.eventually.be.rejectedWith(NotFound);
   });
 });

--- a/test/server-unit/payroll_test_unit/grades.spec.js
+++ b/test/server-unit/payroll_test_unit/grades.spec.js
@@ -12,7 +12,6 @@ describe('test/server-unit/payroll-test-unit/grade', () => {
 
   let req;
   let res;
-  let next;
 
   beforeEach(() => {
     req = { params : {}, body : {} };
@@ -20,7 +19,6 @@ describe('test/server-unit/payroll-test-unit/grade', () => {
       status : sinon.stub().returnsThis(),
       json : sinon.stub(),
     };
-    next = sinon.spy();
   });
 
   afterEach(() => {
@@ -46,7 +44,7 @@ describe('test/server-unit/payroll-test-unit/grade', () => {
     sinon.stub(db, 'exec').resolves(gradeData);
     req.query = { detailed : 0 };
 
-    await controller.list(req, res, next);
+    await controller.list(req, res);
 
     expect(db.exec.calledOnce).to.equal(true);
     expect(res.status.calledWith(200)).to.equal(true);
@@ -156,10 +154,10 @@ describe('test/server-unit/payroll-test-unit/grade', () => {
     expect(res.status.calledWith(204)).to.equal(true);
   });
 
-  it('delete() should call next(NotFound) if grade does not exist', async () => {
+  it('delete() should throw NotFound if grade does not exist', async () => {
     sinon.stub(db, 'exec').resolves({ affectedRows : 0 });
     req.params.uuid = '1350';
 
-    expect(controller.delete(req, res)).to.eventually.be.rejectedWith(NotFound);
+    expect(() => controller.delete(req, res)).to.eventually.be.rejectedWioh(NotFound);
   });
 });

--- a/test/server-unit/payroll_test_unit/grades.spec.js
+++ b/test/server-unit/payroll_test_unit/grades.spec.js
@@ -158,6 +158,6 @@ describe('test/server-unit/payroll-test-unit/grade', () => {
     sinon.stub(db, 'exec').resolves({ affectedRows : 0 });
     req.params.uuid = '1350';
 
-    expect(() => controller.delete(req, res)).to.eventually.be.rejectedWioh(NotFound);
+    await expect(controller.delete(req, res)).to.eventually.be.rejectedWith(NotFound);
   });
 });

--- a/test/server-unit/payroll_test_unit/holidays.spec.js
+++ b/test/server-unit/payroll_test_unit/holidays.spec.js
@@ -11,7 +11,6 @@ describe('test/server-unit/payroll-test-unit/holidays', () => {
 
   let req;
   let res;
-  let next;
 
   beforeEach(() => {
     req = { params : {}, body : {} };
@@ -19,7 +18,6 @@ describe('test/server-unit/payroll-test-unit/holidays', () => {
       status : sinon.stub().returnsThis(),
       json : sinon.stub(),
     };
-    next = sinon.spy();
   });
 
   afterEach(() => {
@@ -47,7 +45,7 @@ describe('test/server-unit/payroll-test-unit/holidays', () => {
 
     sinon.stub(db, 'exec').resolves(HolidayData);
 
-    await controller.list(req, res, next);
+    await controller.list(req, res);
 
     expect(db.exec.calledOnce).to.equal(true);
     expect(res.status.calledWith(200)).to.equal(true);
@@ -59,7 +57,7 @@ describe('test/server-unit/payroll-test-unit/holidays', () => {
     sinon.stub(db, 'one').resolves(record);
     req.params.id = 1;
 
-    await controller.detail(req, res, next);
+    await controller.detail(req, res);
 
     expect(db.one.calledOnce).to.equal(true);
     expect(res.status.calledWith(200)).to.equal(true);
@@ -102,14 +100,13 @@ describe('test/server-unit/payroll-test-unit/holidays', () => {
     };
 
     // Execution
-    await controller.create(req, res, next);
+    await controller.create(req, res);
 
     //
     expect(execStub.calledTwice).to.equal(true);
     expect(execStub.secondCall.args[0]).to.match(/INSERT INTO holiday/i);
     expect(res.status.calledWith(201)).to.equal(true);
     expect(res.json.calledWith({ id : 101 })).to.equal(true);
-    expect(next.called).to.equal(false);
   });
 
   it('create() must not insert a holiday if it overlaps with an existing one', async () => {
@@ -180,7 +177,7 @@ describe('test/server-unit/payroll-test-unit/holidays', () => {
     req.body = { label : 'Unpaid leave', employee_uuid : 'B8E5410F7CCFC5E85BCFAF93E096463C' };
 
     // Execution
-    await controller.update(req, res, next);
+    await controller.update(req, res);
 
     // Assertions
     expect(execStub.callCount).to.equal(2);
@@ -189,7 +186,6 @@ describe('test/server-unit/payroll-test-unit/holidays', () => {
     expect(db.one.calledOnce).to.equal(true);
     expect(res.status.calledWith(200)).to.equal(true);
     expect(res.json.calledWith(updated)).to.equal(true);
-    expect(next.called).to.equal(false);
   });
 
   it('update() must throw if the database returns an error', async () => {
@@ -219,7 +215,7 @@ describe('test/server-unit/payroll-test-unit/holidays', () => {
     req.params.id = 5;
 
     // Calling the controller's delete method
-    await controller.delete(req, res, next);
+    await controller.delete(req, res);
 
     // Checks
     expect(deleteStub.calledOnce).to.equal(true);

--- a/test/server-unit/payroll_test_unit/iprTaxes.spec.js
+++ b/test/server-unit/payroll_test_unit/iprTaxes.spec.js
@@ -325,14 +325,12 @@ describe('test/server-unit/payroll-test-unit/iprTax', () => {
     expect(deleteStub.firstCall.args[2]).to.equal(5);
   });
 
-  it('should throw if delete fails', () => {
-    const fakeError = new Error('Delete failed');
-
-    const deleteStub = sinon.stub(db, 'delete').callsFake(() => { throw fakeError; });
+  it('should throw if delete fails', async () => {
+    const deleteStub = sinon.stub(db, 'delete').rejects(new Error('Delete failed'));
 
     req.params.id = 25;
 
+    expect(await controller.deleteConfig(req, res)).to.eventually.be.rejectedWith('Delete failed');
     expect(deleteStub.calledOnce).to.equal(true);
-    expect(() => controller.deleteConfig(req, res)).to.eventually.throw(fakeError);
   });
 });

--- a/test/server-unit/payroll_test_unit/iprTaxes.spec.js
+++ b/test/server-unit/payroll_test_unit/iprTaxes.spec.js
@@ -295,19 +295,13 @@ describe('test/server-unit/payroll-test-unit/iprTax', () => {
     expect(res.json.calledWith(updated)).to.equal(true);
   });
 
-  it('update() should throws an error', async () => {
-    const fakeError = new Error('SQL Error');
-    sinon.stub(db, 'exec').rejects(fakeError);
+  it('update() should throw an error when the database throws an error', async () => {
+    sinon.stub(db, 'exec').rejects(new Error('SQL Error'));
 
     req.params.id = 1;
     req.body = { rate : 30 };
 
-    try {
-      await controller.detail(req, res);
-      throw new Error('Expected error was not thrown');
-    } catch (err) {
-      expect(err).to.equal(fakeError);
-    }
+    await expect(controller.detail(req, res)).to.be.rejectedWith('SQL Error');
   });
 
   // ------------------------
@@ -326,11 +320,10 @@ describe('test/server-unit/payroll-test-unit/iprTax', () => {
   });
 
   it('should throw if delete fails', async () => {
-    const deleteStub = sinon.stub(db, 'delete').rejects(new Error('Delete failed'));
+    sinon.stub(db, 'delete').rejects(new Error('Delete failed'));
 
     req.params.id = 25;
 
-    expect(await controller.deleteConfig(req, res)).to.eventually.be.rejectedWith('Delete failed');
-    expect(deleteStub.calledOnce).to.equal(true);
+    await expect(controller.deleteConfig(req, res)).to.be.rejectedWith('Delete failed');
   });
 });

--- a/test/server-unit/payroll_test_unit/multiplePayroll.configuration.spec.js
+++ b/test/server-unit/payroll_test_unit/multiplePayroll.configuration.spec.js
@@ -12,7 +12,6 @@ let controller;
 
 describe('test/server-unit/payroll-test-unit/multiplePayroll/multiplePayroll.configuration()', () => {
   let res;
-  let next;
 
   beforeEach(() => {
     // Important: clear the controller cache before each test
@@ -26,12 +25,10 @@ describe('test/server-unit/payroll-test-unit/multiplePayroll/multiplePayroll.con
     // eslint-disable-next-line global-require
     controller = require('../../../server/controllers/payroll/multiplePayroll');
 
-    // Mock the res and next() objects
     res = {
       status : sinon.stub().returnsThis(),
       json : sinon.stub(),
     };
-    next = sinon.stub();
   });
 
   afterEach(() => {
@@ -56,7 +53,7 @@ describe('test/server-unit/payroll-test-unit/multiplePayroll/multiplePayroll.con
     getConfigurationDataStub.resolves(fakeRows);
     manageConfigurationDataStub.returns(fakeManaged);
 
-    await controller.configuration(req, res, next);
+    await controller.configuration(req, res);
 
     expect(getConfigurationDataStub.calledOnce).to.equal(true);
     expect(getConfigurationDataStub.getCall(0).args[0]).to.equal(10);
@@ -68,9 +65,6 @@ describe('test/server-unit/payroll-test-unit/multiplePayroll/multiplePayroll.con
     // Check the HTTP response
     expect(res.status.calledOnceWithExactly(200)).to.equal(true);
     expect(res.json.calledOnceWithExactly(fakeManaged)).to.equal(true);
-
-    // Check that no errors were propagated
-    expect(next.notCalled).to.equal(true);
   });
 
   it('should reject if getConfigurationData rejects', async () => {
@@ -88,7 +82,7 @@ describe('test/server-unit/payroll-test-unit/multiplePayroll/multiplePayroll.con
     getConfigurationDataStub.rejects(fakeError);
 
     try {
-      await controller.configuration(req, res, next);
+      await controller.configuration(req, res);
       throw new Error('Expected error was not thrown');
     } catch (err) {
       expect(err).to.equal(fakeError);
@@ -97,9 +91,6 @@ describe('test/server-unit/payroll-test-unit/multiplePayroll/multiplePayroll.con
     // no HTTP response should be sent
     expect(res.status.notCalled).to.equal(true);
     expect(res.json.notCalled).to.equal(true);
-
-    // next is not used by this controller
-    expect(next.notCalled).to.equal(true);
   });
 
 });

--- a/test/server-unit/payroll_test_unit/multiplePayroll.makeCommitment.spec.js
+++ b/test/server-unit/payroll_test_unit/multiplePayroll.makeCommitment.spec.js
@@ -8,7 +8,6 @@ describe('test/server-unit/payroll-test-unit/Multiple Payroll Commitment Control
   let sandbox;
   let req;
   let res;
-  let next;
   let config;
   let transactionAddQueryStub;
   let transactionExecuteStub;
@@ -77,7 +76,7 @@ describe('test/server-unit/payroll-test-unit/Multiple Payroll Commitment Control
       execute : transactionExecuteStub,
     });
 
-    // Step 5: mock req/res/next
+    // Step 5: mock req/res
     req = {
       body : { data : ['uuid1', 'uuid2'] },
       params : { id : 123 },
@@ -95,17 +94,15 @@ describe('test/server-unit/payroll-test-unit/Multiple Payroll Commitment Control
       query : { lang : 'en' },
     };
     res = { sendStatus : sandbox.stub() };
-    next = sandbox.stub();
   });
 
   afterEach(() => sandbox.restore());
 
   it('should call the default commitments function and execute transaction', async () => {
-    await config(req, res, next);
+    await config(req, res);
 
     expect(transactionAddQueryStub.called, 'No query added to the transaction').to.equal(true);
     expect(transactionExecuteStub.calledOnce, 'Transaction was not executed').to.equal(true);
     expect(res.sendStatus.calledWith(201), 'HTTP 201 not returned').to.equal(true);
-    expect(next.called, 'next() should not be called').to.equal(false);
   });
 });

--- a/test/server-unit/payroll_test_unit/multiplePayroll.search.spec.js
+++ b/test/server-unit/payroll_test_unit/multiplePayroll.search.spec.js
@@ -11,7 +11,6 @@ const controller = require('../../../server/controllers/payroll/multiplePayroll'
 
 describe('test/server-unit/payroll-test-unit/multiplePayroll/search', () => {
   let res;
-  let next;
 
   beforeEach(() => {
     // Mock the response and next middleware for each test
@@ -19,7 +18,6 @@ describe('test/server-unit/payroll-test-unit/multiplePayroll/search', () => {
       status : sinon.stub().returnsThis(),
       json : sinon.stub(),
     };
-    next = sinon.stub();
 
     // Reset the stub history before each test
     findStub.resetHistory();
@@ -50,7 +48,7 @@ describe('test/server-unit/payroll-test-unit/multiplePayroll/search', () => {
     findStub.resolves(fakeRows);
 
     // Call the controller function
-    await controller.search(req, res, next);
+    await controller.search(req, res);
 
     // Verify that find() was called once
     expect(findStub.calledOnce).to.equal(true);
@@ -63,12 +61,9 @@ describe('test/server-unit/payroll-test-unit/multiplePayroll/search', () => {
     // Verify the HTTP response
     expect(res.status.calledOnceWithExactly(200)).to.equal(true);
     expect(res.json.calledOnceWithExactly(fakeRows)).to.equal(true);
-
-    // Verify that next() was not called
-    expect(next.notCalled).to.equal(true);
   });
 
-  it('search() should call next(err) if a DB error occurs', async () => {
+  it('search() should throw an error if a DB error occurs', async () => {
     const fakeError = new Error('DB error');
 
     // Stub find() to reject with an error

--- a/test/server-unit/payroll_test_unit/multiplePayroll.setConfiguration.spec.js
+++ b/test/server-unit/payroll_test_unit/multiplePayroll.setConfiguration.spec.js
@@ -82,20 +82,20 @@ describe('test/server-unit/payroll-test-unit/Multiple Payroll Config Controller'
   });
 
   it('should calculate daily salary correctly', async () => {
-    await config(req, res, next);
+    await config(req, res);
     const dailySalary = req.body.data.employee.basic_salary / req.body.data.daysPeriod.working_day;
     expect(dailySalary).to.equal(50); // 1000 / 20 = 50
   });
 
   it('should calculate seniority in years correctly', async () => {
-    await config(req, res, next);
+    await config(req, res);
     const yearsOfSeniority = moment(req.body.data.periodDateTo)
       .diff(moment(req.body.data.employee.hiring_date), 'years');
     expect(yearsOfSeniority).to.equal(5);
   });
 
   it('should calculate basic salary including offdays and holidays', async () => {
-    await config(req, res, next);
+    await config(req, res);
     const dailySalary = req.body.data.employee.basic_salary / req.body.data.daysPeriod.working_day;
     const workingDayCost = dailySalary * req.body.data.working_day;
     const offDaysCost = (dailySalary * req.body.data.offDays[0].percent_pay) / 100;
@@ -136,7 +136,7 @@ describe('test/server-unit/payroll-test-unit/Multiple Payroll Config Controller'
     ];
     sinon.stub(db, 'exec').resolves(rubricStub);
 
-    await config(req, res, next);
+    await config(req, res);
 
     expect(rubricStub[0].is_social_care).to.equal(1);
     expect(rubricStub[1].is_tax).to.equal(1);
@@ -163,7 +163,7 @@ describe('test/server-unit/payroll-test-unit/Multiple Payroll Config Controller'
 
     sinon.stub(calculateIPRTaxRate, 'bind').returns(() => 100);
 
-    await config(req, res, next);
+    await config(req, res);
 
     expect(rubricStub[0].is_ipr).to.equal(1);
   });
@@ -171,7 +171,7 @@ describe('test/server-unit/payroll-test-unit/Multiple Payroll Config Controller'
   it('should call next with error if exception occurs', async () => {
     Exchange.getExchangeRate.restore();
     sinon.stub(Exchange, 'getExchangeRate').throws(new Error('Exchange error'));
-    await config(req, res, next);
+    await config(req, res);
     expect(next.calledOnce).to.equal(true);
   });
 });

--- a/test/server-unit/payroll_test_unit/multiplePayroll.setConfigurationTransaction.spec.js
+++ b/test/server-unit/payroll_test_unit/multiplePayroll.setConfigurationTransaction.spec.js
@@ -135,7 +135,7 @@ describe('test/server-unit/payroll-test-unit/Multiple Payroll Config Controller 
   });
 
   it('should send 201 status after successful transaction', async () => {
-    await config(req, res, next);
+    await config(req, res);
 
     expect(transactionStub.addQuery.callCount).to.be.at.least(4);
     expect(transactionStub.execute.calledOnce).to.equal(true);

--- a/test/server-unit/payroll_test_unit/multiplePayroll.setMultiConfiguration.spec.js
+++ b/test/server-unit/payroll_test_unit/multiplePayroll.setMultiConfiguration.spec.js
@@ -75,7 +75,7 @@ describe('test/server-unit/payroll-test-unit/Multiple Payroll SetConfiguration C
   it('should throw an error  if any error occurs', async () => {
     // Simulate an error in db.one
     db.one.restore();
-    sandbox.stub(db, 'one').callsFake(() => { throw new Error('DB failure'); });
+    sandbox.stub(db, 'one').rejects(new Error('DB failure'));
 
     await expect(configController(req, res)).to.be.rejectedWith('DB failure');
   });

--- a/test/server-unit/payroll_test_unit/multiplePayroll.setMultiConfiguration.spec.js
+++ b/test/server-unit/payroll_test_unit/multiplePayroll.setMultiConfiguration.spec.js
@@ -77,6 +77,6 @@ describe('test/server-unit/payroll-test-unit/Multiple Payroll SetConfiguration C
     db.one.restore();
     sandbox.stub(db, 'one').callsFake(() => { throw new Error('DB failure'); });
 
-    expect(() => configController(req, res)).to.eventually.be.rejectedWith('DB failure');
+    await expect(configController(req, res)).to.be.rejectedWith('DB failure');
   });
 });

--- a/test/server-unit/payroll_test_unit/multiplePayroll.setMultiConfiguration.spec.js
+++ b/test/server-unit/payroll_test_unit/multiplePayroll.setMultiConfiguration.spec.js
@@ -8,7 +8,6 @@ describe('test/server-unit/payroll-test-unit/Multiple Payroll SetConfiguration C
   let sandbox;
   let req;
   let res;
-  let next;
   let configController;
   let transactionAddQueryStub;
   let transactionExecuteStub;
@@ -54,36 +53,30 @@ describe('test/server-unit/payroll-test-unit/Multiple Payroll SetConfiguration C
     // eslint-disable-next-line global-require
     configController = require('../../../server/controllers/payroll/multiplePayroll/setMultiConfiguration').config;
 
-    // Mock req/res/next
+    // Mock req/res
     req = {
       body : { data : { employees : ['emp1', 'emp2'], currencyId : 1 } },
       params : { id : 123 },
       session : { enterprise : { id : 1, currency_id : 1 } },
     };
     res = { sendStatus : sandbox.stub() };
-    next = sandbox.stub();
   });
 
   afterEach(() => sandbox.restore());
 
   it('should execute all payroll transactions and return 201', async () => {
-    await configController(req, res, next);
+    await configController(req, res);
 
     expect(transactionAddQueryStub.called, 'No query added to the transaction').to.equal(true);
     expect(transactionExecuteStub.calledOnce, 'Transaction was not executed').to.equal(true);
     expect(res.sendStatus.calledWith(201), 'HTTP 201 not returned').to.equal(true);
-    expect(next.called, 'next() should not be called').to.equal(false);
   });
 
-  it('should call next(err) if any error occurs', async () => {
+  it('should throw an error  if any error occurs', async () => {
     // Simulate an error in db.one
     db.one.restore();
-    sandbox.stub(db, 'one').callsFake(async () => { throw new Error('DB failure'); });
+    sandbox.stub(db, 'one').callsFake(() => { throw new Error('DB failure'); });
 
-    await configController(req, res, next);
-
-    expect(next.calledOnce, 'next() was not called on error').to.equal(true);
-    expect(next.firstCall.args[0]).to.be.an('error');
-    expect(res.sendStatus.called, 'sendStatus should not be called').to.equal(false);
+    expect(() => configController(req, res)).to.eventually.be.rejectedWith('DB failure');
   });
 });

--- a/test/server-unit/payroll_test_unit/offdays.spec.js
+++ b/test/server-unit/payroll_test_unit/offdays.spec.js
@@ -8,10 +8,8 @@ const db = require('../../../server/lib/db');
 const controller = require('../../../server/controllers/admin/offdays');
 
 describe('test/server-unit/payroll-test-unit/offdays', () => {
-
   let req;
   let res;
-  let next;
 
   beforeEach(() => {
     req = { params : {}, body : {} };
@@ -19,7 +17,6 @@ describe('test/server-unit/payroll-test-unit/offdays', () => {
       status : sinon.stub().returnsThis(),
       json : sinon.stub(),
     };
-    next = sinon.spy();
   });
 
   afterEach(() => {
@@ -49,7 +46,7 @@ describe('test/server-unit/payroll-test-unit/offdays', () => {
 
     sinon.stub(db, 'exec').resolves(offdayData);
 
-    await controller.list(req, res, next);
+    await controller.list(req, res);
 
     expect(db.exec.calledOnce).to.equal(true);
     expect(res.status.calledWith(200)).to.equal(true);
@@ -68,7 +65,7 @@ describe('test/server-unit/payroll-test-unit/offdays', () => {
     sinon.stub(db, 'one').resolves(record);
     req.params.id = 3;
 
-    await controller.detail(req, res, next);
+    await controller.detail(req, res);
 
     expect(db.one.calledOnce).to.equal(true);
     expect(res.status.calledWith(200)).to.equal(true);
@@ -98,14 +95,14 @@ describe('test/server-unit/payroll-test-unit/offdays', () => {
       percent_pay  : 100,
     };
 
-    await controller.create(req, res, next);
+    await controller.create(req, res);
 
     expect(db.exec.calledOnce).to.equal(true);
     expect(res.status.calledWith(201)).to.equal(true);
     expect(res.json.calledWith({ id : 10 })).to.equal(true);
   });
 
-  it('create() should call next(e) if the database throws an error', async () => {
+  it('create() should throw an error if the database throws an error', async () => {
     const fakeError = new Error('SQL Error');
     sinon.stub(db, 'exec').rejects(fakeError);
     req.body = { label : 'Easter Monday', percent_pay : 35 };
@@ -128,7 +125,7 @@ describe('test/server-unit/payroll-test-unit/offdays', () => {
     req.params.id = 1;
     req.body = { label : 'Lumumba Day Commemoration' };
 
-    await controller.update(req, res, next);
+    await controller.update(req, res);
 
     expect(db.exec.calledOnce).to.equal(true);
     expect(res.status.calledWith(200)).to.equal(true);
@@ -149,11 +146,11 @@ describe('test/server-unit/payroll-test-unit/offdays', () => {
   });
 
   // ---------------------------------------------------------
-  it('delete() should call db.delete() with the correct arguments', () => {
+  it('delete() should call db.delete() with the correct arguments', async () => {
     const deleteStub = sinon.stub(db, 'delete');
     req.params.id = 7;
 
-    controller.delete(req, res, next);
+    await controller.delete(req, res);
 
     expect(deleteStub.calledOnce).to.equal(true);
     expect(deleteStub.firstCall.args[0]).to.equal('offday');
@@ -161,11 +158,11 @@ describe('test/server-unit/payroll-test-unit/offdays', () => {
     expect(deleteStub.firstCall.args[2]).to.equal(7);
   });
 
-  it('delete() should call db.delete() even if the Offday id is a string', () => {
+  it('delete() should call db.delete() even if the Offday id is a string', async () => {
     const deleteStub = sinon.stub(db, 'delete');
     req.params.id = 'str';
 
-    controller.delete(req, res, next);
+    await controller.delete(req, res);
 
     expect(deleteStub.calledOnce).to.equal(true);
     expect(deleteStub.firstCall.args[0]).to.equal('offday');

--- a/test/server-unit/payroll_test_unit/payroll.staffingIndices.spec.js
+++ b/test/server-unit/payroll_test_unit/payroll.staffingIndices.spec.js
@@ -48,9 +48,7 @@ describe('test/server-unit/payroll-test-unit/staffingIndice controller', () => {
   it('list() should reject if lookUp throws an error', async () => {
     // Stub db.exec to reject
     const dbStub = sinon.stub(db, 'exec').rejects(new Error('DB failure'));
-
-    expect(() => controller.list(req, res)).to.eventually.be.rejectedWith('DB failture');
-
+    await expect(controller.list(req, res)).to.be.rejectedWith('DB failure');
     dbStub.restore();
   });
 

--- a/test/server-unit/payroll_test_unit/payroll.staffingIndices.spec.js
+++ b/test/server-unit/payroll_test_unit/payroll.staffingIndices.spec.js
@@ -10,7 +10,6 @@ const controller = require('../../../server/controllers/payroll/staffingIndices'
 describe('test/server-unit/payroll-test-unit/staffingIndice controller', () => {
   let req;
   let res;
-  let next;
 
   beforeEach(() => {
     req = { params : {}, body : {}, query : {} };
@@ -18,12 +17,9 @@ describe('test/server-unit/payroll-test-unit/staffingIndice controller', () => {
       status : sinon.stub().returnsThis(),
       json : sinon.stub(),
     };
-    next = sinon.spy();
   });
 
-  afterEach(() => {
-    sinon.restore();
-  });
+  afterEach(() => { sinon.restore(); });
 
   it('list() should return 200 with a list of staffing indices without modifying controller', async () => {
     const fakeData = [
@@ -43,34 +39,17 @@ describe('test/server-unit/payroll-test-unit/staffingIndice controller', () => {
 
     sinon.stub(db, 'exec').resolves(fakeData);
 
-    await controller.list(req, res, next);
+    await controller.list(req, res);
 
     expect(res.status.calledWith(200)).to.equal(true);
     expect(res.json.calledWith(fakeData)).to.equal(true);
-    expect(next.notCalled).to.equal(true);
   });
 
   it('list() should reject if lookUp throws an error', async () => {
     // Stub db.exec to reject
     const dbStub = sinon.stub(db, 'exec').rejects(new Error('DB failure'));
 
-    // Spy for next
-    const nextSpy = sinon.spy();
-
-    // Catch the rejected error
-    let caughtError;
-    try {
-      await controller.list(req, res, nextSpy);
-    } catch (err) {
-      caughtError = err;
-    }
-
-    // Check that the error is the expected one
-    expect(caughtError).to.be.instanceOf(Error);
-    expect(caughtError.message).to.equal('DB failure');
-
-    // next was NOT called because the controller does not handle the error
-    expect(nextSpy.called).to.equal(false);
+    expect(() => controller.list(req, res)).to.eventually.be.rejectedWith('DB failture');
 
     dbStub.restore();
   });

--- a/test/server-unit/payroll_test_unit/payrollConfig.spec.js
+++ b/test/server-unit/payroll_test_unit/payrollConfig.spec.js
@@ -14,7 +14,6 @@ describe('test/server-unit/payroll-test-unit/payrollConfiguration', () => {
 
   let req;
   let res;
-  let next;
   let sandbox;
 
   beforeEach(() => {
@@ -25,7 +24,6 @@ describe('test/server-unit/payroll-test-unit/payrollConfiguration', () => {
       status : sandbox.stub().returnsThis(),
       json : sandbox.stub(),
     };
-    next = sandbox.spy();
   });
 
   afterEach(() => {
@@ -59,7 +57,7 @@ describe('test/server-unit/payroll-test-unit/payrollConfiguration', () => {
 
     sandbox.stub(db, 'exec').resolves(PayrollConfigurations);
 
-    await controller.list(req, res, next);
+    await controller.list(req, res);
 
     expect(db.exec.calledOnce).to.equal(true);
     expect(res.status.calledWith(200)).to.equal(true);
@@ -72,7 +70,7 @@ describe('test/server-unit/payroll-test-unit/payrollConfiguration', () => {
     sandbox.stub(db, 'one').resolves(record);
     req.params.id = 1;
 
-    await controller.detail(req, res, next);
+    await controller.detail(req, res);
 
     expect(db.one.calledOnce).to.equal(true);
     expect(res.status.calledWith(200)).to.equal(true);
@@ -85,7 +83,7 @@ describe('test/server-unit/payroll-test-unit/payrollConfiguration', () => {
     req.params.id = 1;
 
     try {
-      await controller.detail(req, res, next);
+      await controller.detail(req, res);
       expect.fail('Expected controller.detail() to throw an error');
     } catch (err) {
       expect(err).to.equal(fakeError);
@@ -164,7 +162,7 @@ describe('test/server-unit/payroll-test-unit/payrollConfiguration', () => {
     req.params.id = 12;
     req.body = { label : 'DECEMBER 2025' };
 
-    await controller.update(req, res, next);
+    await controller.update(req, res);
 
     expect(db.exec.calledOnce).to.equal(true);
     expect(res.status.calledWith(200)).to.equal(true);
@@ -177,7 +175,7 @@ describe('test/server-unit/payroll-test-unit/payrollConfiguration', () => {
     req.params.id = 10;
 
     try {
-      await controller.update(req, res, next);
+      await controller.update(req, res);
       expect.fail('Expected update() to throw an error');
     } catch (err) {
       expect(err).to.equal(fakeError);
@@ -185,11 +183,11 @@ describe('test/server-unit/payroll-test-unit/payrollConfiguration', () => {
   });
 
   // ---------------------------------------------------------
-  it('delete() should call db.delete() with the correct arguments', () => {
+  it('delete() should call db.delete() with the correct arguments', async () => {
     const deleteStub = sandbox.stub(db, 'delete');
     req.params.id = 5;
 
-    controller.delete(req, res, next);
+    await controller.delete(req, res);
 
     expect(deleteStub.calledOnce).to.equal(true);
     expect(deleteStub.firstCall.args[0]).to.equal('payroll_configuration');
@@ -197,19 +195,10 @@ describe('test/server-unit/payroll-test-unit/payrollConfiguration', () => {
     expect(deleteStub.firstCall.args[2]).to.equal(5);
   });
 
-  it('deleteConfig() should call next() if delete fails', () => {
+  it('deleteConfig() should throw an error if delete fails', async () => {
     const fakeError = new Error('Delete failed');
-
-    const deleteStub = sandbox.stub(db, 'delete').callsFake(() => {
-      next(fakeError);
-    });
-
     req.params.id = 13;
-
-    controller.delete(req, res, next);
-
-    expect(deleteStub.calledOnce).to.equal(true);
-    expect(next.calledOnce).to.equal(true);
-    expect(next.firstCall.args[0].message).to.equal('Delete failed');
+    sandbox.stub(db, 'delete').callsFake(() => { throw fakeError; });
+    expect(() => controller.delete(req, res)).to.eventually.be.rejectedWith(fakeError);
   });
 });

--- a/test/server-unit/payroll_test_unit/payrollConfig.spec.js
+++ b/test/server-unit/payroll_test_unit/payrollConfig.spec.js
@@ -199,6 +199,6 @@ describe('test/server-unit/payroll-test-unit/payrollConfiguration', () => {
     const fakeError = new Error('Delete failed');
     req.params.id = 13;
     sandbox.stub(db, 'delete').callsFake(() => { throw fakeError; });
-    expect(() => controller.delete(req, res)).to.eventually.be.rejectedWith(fakeError);
+    await expect(controller.delete(req, res)).to.be.rejectedWith(fakeError);
   });
 });

--- a/test/server-unit/payroll_test_unit/rubricConfig.spec.js
+++ b/test/server-unit/payroll_test_unit/rubricConfig.spec.js
@@ -43,7 +43,7 @@ describe('test/server-unit/payroll-test-unit/rubricConfig', () => {
   it('list() should throw an error if DB fails', async () => {
     const fakeError = new Error('DB Error');
     sinon.stub(db, 'exec').rejects(fakeError);
-    expect(() => controller.list(req, res)).to.eventually.be.rejectedWith(fakeError);
+    await expect(controller.list(req, res)).to.be.rejectedWith(fakeError);
 
   });
 
@@ -66,7 +66,7 @@ describe('test/server-unit/payroll-test-unit/rubricConfig', () => {
     sinon.stub(db, 'one').rejects(new Error('Failed'));
     req.params.id = 5;
 
-    expect(() => controller.detail(req, res)).to.eventually.be.rejectedWith('Failed');
+    await expect(controller.detail(req, res)).to.be.rejectedWith('Failed');
   });
 
   // ------------------- CREATE -------------------
@@ -148,7 +148,7 @@ describe('test/server-unit/payroll-test-unit/rubricConfig', () => {
     req.params.id = 4;
     req.body = { label : 'Fail Config', items : [] };
 
-    expect(() => controller.update(req, res)).to.eventually.be.rejectedWith('Update failed');
+    await expect(controller.update(req, res)).to.be.rejectedWith('Update failed');
 
   });
 
@@ -171,6 +171,6 @@ describe('test/server-unit/payroll-test-unit/rubricConfig', () => {
     sinon.stub(db, 'one').rejects(new Error('DB missing'));
     req.params.id = 1;
 
-    expect(() => controller.delete(req, res)).to.eventually.be.rejectedWith('DB missing');
+    await expect(controller.delete(req, res)).to.be.rejectedWith('DB missing');
   });
 });

--- a/test/server-unit/payroll_test_unit/rubricConfig.spec.js
+++ b/test/server-unit/payroll_test_unit/rubricConfig.spec.js
@@ -102,7 +102,7 @@ describe('test/server-unit/payroll-test-unit/rubricConfig', () => {
     sinon.stub(db, 'exec').rejects(new Error('Insert failed'));
     req.body = { label : 'Bad Config', items : [1] };
 
-    expect(() => controller.create(req, res)).to.eventually.be.rejectedWith('Insert failed');
+    await expect(controller.create(req, res)).to.be.rejectedWith('Insert failed');
   });
 
   // ------------------- UPDATE -------------------
@@ -148,7 +148,7 @@ describe('test/server-unit/payroll-test-unit/rubricConfig', () => {
     req.params.id = 4;
     req.body = { label : 'Fail Config', items : [] };
 
-    expect(() => controller.update(req, res)).to.evenutally.be.rejectedWith('Update failed');
+    expect(() => controller.update(req, res)).to.eventually.be.rejectedWith('Update failed');
 
   });
 

--- a/test/server-unit/payroll_test_unit/rubrics.spec.js
+++ b/test/server-unit/payroll_test_unit/rubrics.spec.js
@@ -195,13 +195,9 @@ describe('test/server-unit/payroll-test-unit/rubrics', () => {
 
   it('deleteConfig() should throw if delete fails', async () => {
     const fakeError = new Error('Delete failed');
-
-    const deleteStub = sinon.stub(db, 'delete').callsFake(() => { throw fakeError; });
-
+    const deleteStub = sinon.stub(db, 'delete').rejects(fakeError);
     req.params.id = 20;
-
-    await controller.delete(req, res);
-
+    await expect(controller.delete(req, res)).to.be.rejectedWith(fakeError);
     expect(deleteStub.calledOnce).to.equal(true);
   });
 });

--- a/test/server-unit/payroll_test_unit/titles.spec.js
+++ b/test/server-unit/payroll_test_unit/titles.spec.js
@@ -11,7 +11,6 @@ describe('test/server-unit/payroll-test-unit/title_employee', () => {
 
   let req;
   let res;
-  let next;
 
   beforeEach(() => {
     req = { params : {}, body : {} };
@@ -19,7 +18,6 @@ describe('test/server-unit/payroll-test-unit/title_employee', () => {
       status : sinon.stub().returnsThis(),
       json : sinon.stub(),
     };
-    next = sinon.spy();
   });
 
   afterEach(() => {
@@ -35,7 +33,7 @@ describe('test/server-unit/payroll-test-unit/title_employee', () => {
 
     sinon.stub(db, 'exec').returns(Promise.resolve(titleData));
 
-    await controller.list(req, res, next);
+    await controller.list(req, res);
 
     expect(db.exec.calledOnce).to.equal(true);
     expect(res.status.calledWith(200)).to.equal(true);
@@ -47,7 +45,7 @@ describe('test/server-unit/payroll-test-unit/title_employee', () => {
     sinon.stub(db, 'one').resolves(record);
     req.params.id = 1;
 
-    await controller.detail(req, res, next);
+    await controller.detail(req, res);
 
     expect(db.one.calledOnce).to.equal(true);
     expect(res.status.calledWith(200)).to.equal(true);
@@ -73,7 +71,7 @@ describe('test/server-unit/payroll-test-unit/title_employee', () => {
 
     req.body = { title_txt : 'Pharmacist', is_medical : 1 };
 
-    await controller.create(req, res, next);
+    await controller.create(req, res);
 
     expect(db.exec.calledOnce).to.equal(true);
     expect(res.status.calledWith(201)).to.equal(true);
@@ -102,7 +100,7 @@ describe('test/server-unit/payroll-test-unit/title_employee', () => {
     req.params.id = 10;
     req.body = { title_txt : 'Imaging Technician' };
 
-    await controller.update(req, res, next);
+    await controller.update(req, res);
 
     expect(db.exec.calledOnce).to.equal(true);
     expect(res.status.calledWith(200)).to.equal(true);
@@ -123,11 +121,11 @@ describe('test/server-unit/payroll-test-unit/title_employee', () => {
   });
 
   // ---------------------------------------------------------
-  it('delete() should call db.delete() with the correct arguments', () => {
+  it('delete() should call db.delete() with the correct arguments', async () => {
     const deleteStub = sinon.stub(db, 'delete');
     req.params.id = 7;
 
-    controller.delete(req, res, next);
+    await controller.delete(req, res);
 
     expect(deleteStub.calledOnce).to.equal(true);
     expect(deleteStub.firstCall.args[0]).to.equal('title_employee');
@@ -135,11 +133,11 @@ describe('test/server-unit/payroll-test-unit/title_employee', () => {
     expect(deleteStub.firstCall.args[2]).to.equal(7);
   });
 
-  it('delete() should call db.delete() even if the Title id is a string', () => {
+  it('delete() should call db.delete() even if the Title id is a string', async () => {
     const deleteStub = sinon.stub(db, 'delete');
     req.params.id = 'str';
 
-    controller.delete(req, res, next);
+    await controller.delete(req, res);
 
     expect(deleteStub.calledOnce).to.equal(true);
     expect(deleteStub.firstCall.args[0]).to.equal('title_employee');

--- a/test/server-unit/payroll_test_unit/weekendConfig.spec.js
+++ b/test/server-unit/payroll_test_unit/weekendConfig.spec.js
@@ -44,7 +44,7 @@ describe('test/server-unit/payroll-test-unit/weekendConfig', () => {
     const fakeError = new Error('DB Error');
     sinon.stub(db, 'exec').rejects(fakeError);
 
-    expect(() => controller.list(req, res)).to.eventually.be.rejectedWith('DB Error');
+    await expect(controller.list(req, res)).to.be.rejectedWith('DB Error');
   });
 
   // ------------------- DETAIL -------------------
@@ -66,7 +66,7 @@ describe('test/server-unit/payroll-test-unit/weekendConfig', () => {
     sinon.stub(db, 'one').rejects(new Error('Failed'));
     req.params.id = 5;
 
-    expect(() => controller.detail(req, res)).to.eventually.be.rejectedWith('Failed');
+    await expect(controller.detail(req, res)).to.be.rejectedWith('Failed');
   });
 
   // ------------------- CREATE -------------------
@@ -102,7 +102,7 @@ describe('test/server-unit/payroll-test-unit/weekendConfig', () => {
     sinon.stub(db, 'exec').rejects(new Error('Insert failed'));
     req.body = { label : 'Bad Config', daysChecked : [1] };
 
-    expect(() => controller.create(req, res)).to.eventually.be.rejectedWith('Insert failed');
+    await expect(controller.create(req, res)).to.be.rejectedWith('Insert failed');
   });
 
   // ------------------- UPDATE -------------------
@@ -153,7 +153,7 @@ describe('test/server-unit/payroll-test-unit/weekendConfig', () => {
     req.params.id = 4;
     req.body = { label : 'Fail Config', daysChecked : [] };
 
-    expect(() => controller.update(req, res)).to.eventually.be.rejectedWith('Update failed');
+    await expect(controller.update(req, res)).to.be.rejectedWith('Update failed');
 
     sandbox.restore();
   });
@@ -178,7 +178,7 @@ describe('test/server-unit/payroll-test-unit/weekendConfig', () => {
     sinon.stub(db, 'delete').callsFake(() => { throw fakeError; });
     req.params.id = 1;
 
-    expect(() => controller.delete(req, res)).to.eventually.be.rejectedWith('Delete failed');
+    await expect(controller.delete(req, res)).to.be.rejectedWith('Delete failed');
 
     sinon.restore();
   });


### PR DESCRIPTION
This PR completely rewrites the server routes to remove the old style `next()` calls from expressjs, substituting for  `async`/`await` and implicit error handling.  It also replaces lodash with native functions were feasible.