### PR TITLE
perf(stock): use window functions to improve performance

### DIFF
--- a/client/src/js/directives/loading.js
+++ b/client/src/js/directives/loading.js
@@ -2,7 +2,7 @@ angular.module('bhima.directives')
   .directive('loadingIndicator', () => {
     return {
       restrict : 'E',
-      // eslint-disable-next-line
+       
       template: `<p><p class="text-info"><span class="fa fa-circle-o-notch fa-spin"></span> <span translate>FORM.INFO.LOADING</span></p></p>`,
     };
   });

--- a/client/src/modules/stock/lots/modals/schedule.modal.html
+++ b/client/src/modules/stock/lots/modals/schedule.modal.html
@@ -6,7 +6,11 @@
   <div class="modal-header">
     <ol class="headercrumb">
       <li translate class="static" style="font-weight: bold;">LOTS_SCHEDULE.TITLE</li>
-      <li class="title"><span translate>FORM.LABELS.FOR</span>: {{$ctrl.inventory_name}} [{{$ctrl.inventory_code}}]</li>
+      <li class="title">
+        <span ng-show="$ctrl.inventory_code">
+          <span translate>FORM.LABELS.FOR</span>: {{$ctrl.inventory_name}} [{{$ctrl.inventory_code}}]
+        </span>
+      </li>
     </ol>
     <p>{{$ctrl.projection_text}}</p>
     <p ng-if="$ctrl.reorderSuggestion">{{$ctrl.reorderSuggestion}}</p>
@@ -92,8 +96,10 @@
   </div>
 
   <div class="modal-body" ng-show="!$ctrl.lots.length">
-    <b translate>LOTS_SCHEDULE.NO_LOTS_FOUND</b>
+    <loading-indicator ng-show="$ctrl.$loading"></loading-indicator>
+    <b translate ng-show="!$ctrl.$loading">LOTS_SCHEDULE.NO_LOTS_FOUND</b>
   </div>
+
 
   <div class="modal-footer">
     <button type="button" class="btn btn-default" ng-click="$ctrl.close()" data-method="close" translate>

--- a/client/src/modules/stock/lots/modals/schedule.modal.js
+++ b/client/src/modules/stock/lots/modals/schedule.modal.js
@@ -7,12 +7,26 @@ LotsScheduleModalController.$inject = [
   'NotifyService', 'bhConstants', 'moment', '$translate',
 ];
 
+/**
+ *
+ * @param data
+ * @param Instance
+ * @param Stock
+ * @param Lots
+ * @param Notify
+ * @param bhConstants
+ * @param Moment
+ * @param $translate
+ */
 function LotsScheduleModalController(data, Instance, Stock, Lots,
   Notify, bhConstants, Moment, $translate) {
   const vm = this;
   vm.close = () => Instance.close('close');
   vm.lotUuid = data.uuid; // The lot that invoked this modal
   vm.DATE_FMT = bhConstants.dates.format;
+
+  // to show/hide the "no-lots-found" message
+  vm.$loading = true;
 
   // The following numbers are sensitive!
   // If you change them, make sure you test with many inventory articles!
@@ -27,6 +41,9 @@ function LotsScheduleModalController(data, Instance, Stock, Lots,
   vm.startChartDate = new Date(today.getFullYear(), today.getMonth(), 1);
   vm.endChartDate = Moment(vm.startChartDate).add(vm.numMonths, 'months').toDate();
 
+  /**
+   *
+   */
   function startup() {
     Stock.lots.read(null, {
       inventory_uuid : data.inventoryUuid,
@@ -198,7 +215,10 @@ function LotsScheduleModalController(data, Instance, Stock, Lots,
           count : allYears.reduce((n, year) => n + (year === yr), 0),
         }));
       })
-      .catch(Notify.handleError);
+      .catch(Notify.handleError)
+      .finally(() => {
+        vm.$loading = false;
+      });
   }
 
   startup();

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,6 +5,13 @@ const { defineConfig } = require('eslint/config');
 const jsdoc = require('eslint-plugin-jsdoc');
 const eslintPluginYouDontNeedLodashUnderscore = require('eslint-plugin-you-dont-need-lodash-underscore');
 
+const mochaGlobals = {
+  describe : "readonly",
+  it : "readonly",
+  expect : "readonly",
+  agent : "writable"
+}
+
 module.exports = defineConfig([
   js.configs.recommended,
   jsdoc.configs['flat/recommended'],
@@ -19,8 +26,7 @@ module.exports = defineConfig([
     rules: {
       ...eslintPluginYouDontNeedLodashUnderscore.configs.compatible.rules,
     },
-    languageOptions: { globals: {...globals.browser, ...globals.node} }
+    languageOptions: { globals: {...globals.browser, ...globals.node, ...mochaGlobals } }
   },
   { files: ['**/*.js'], languageOptions: { sourceType: 'commonjs' } },
 ]);
-

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,6 +10,11 @@ const mochaGlobals = {
   it : "readonly",
   expect : "readonly",
   agent : "writable"
+};
+
+
+const angularGlobals= {
+  angular: "readonly",
 }
 
 module.exports = defineConfig([
@@ -26,7 +31,7 @@ module.exports = defineConfig([
     rules: {
       ...eslintPluginYouDontNeedLodashUnderscore.configs.compatible.rules,
     },
-    languageOptions: { globals: {...globals.browser, ...globals.node, ...mochaGlobals } }
+    languageOptions: { globals: {...globals.browser, ...globals.node, ...mochaGlobals, ...angularGlobals } }
   },
   { files: ['**/*.js'], languageOptions: { sourceType: 'commonjs' } },
 ]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1308,18 +1308,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@puppeteer/browsers/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@puppeteer/browsers/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -2172,9 +2160,9 @@
       }
     },
     "node_modules/bare-fs": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.2.tgz",
-      "integrity": "sha512-veTnRzkb6aPHOvSKIOy60KzURfBdUflr5VReI+NSaPL6xf+XLdONQgZgpYvUuZLVQ8dCqxpBAudaOM1+KpAUxw==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.3.tgz",
+      "integrity": "sha512-9+kwVx8QYvt3hPWnmb19tPnh38c6Nihz8Lx3t0g9+4GoIf3/fTgYwM4Z6NxgI+B9elLQA7mLE9PpqcWtOMRDiQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -4238,9 +4226,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.278",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.278.tgz",
-      "integrity": "sha512-dQ0tM1svDRQOwxnXxm+twlGTjr9Upvt8UFWAgmLsxEzFQxhbti4VwxmMjsDxVC51Zo84swW7FVCXEV+VAkhuPw==",
+      "version": "1.5.279",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.279.tgz",
+      "integrity": "sha512-0bblUU5UNdOt5G7XqGiJtpZMONma6WAfq9vsFmtn9x1+joAObr6x1chfqyxFSDCAFwFhCQDrqeAr6MYdpwJ9Hg==",
       "dev": true,
       "license": "ISC"
     },
@@ -4642,19 +4630,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint-plugin-jsdoc/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/eslint-plugin-you-dont-need-lodash-underscore": {
@@ -7757,18 +7732,6 @@
         "npm": ">=6"
       }
     },
-    "node_modules/jsonwebtoken/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/jszip": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
@@ -8478,9 +8441,9 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "11.2.4",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
-      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+      "version": "11.2.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
+      "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -10792,7 +10755,6 @@
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -11310,19 +11272,6 @@
         "node": "^20.12.0 || >=22.0.0"
       }
     },
-    "node_modules/release-it/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/remove-bom-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz",
@@ -11706,14 +11655,15 @@
       }
     },
     "node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "license": "ISC",
-      "optional": true,
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/semver-greatest-satisfied-range": {
@@ -12400,6 +12350,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-bom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha512-kwrX1y7czp1E69n2ajbG65mIo9dqvJ+8aBQXOGVxqwvNbsXdFM6Lq37dLAY3mknUwru8CfcCbfOLL/gMo+fi3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-utf8": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/strip-bom-buf": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-1.0.0.tgz",
@@ -12422,19 +12385,6 @@
       "dependencies": {
         "first-chunk-stream": "^2.0.0",
         "strip-bom": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/strip-bom-stream/node_modules/strip-bom": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-      "integrity": "sha512-kwrX1y7czp1E69n2ajbG65mIo9dqvJ+8aBQXOGVxqwvNbsXdFM6Lq37dLAY3mknUwru8CfcCbfOLL/gMo+fi3g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-utf8": "^0.2.0"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -12519,19 +12469,6 @@
         "node": ">=4.0.0"
       }
     },
-    "node_modules/superagent/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -12566,6 +12503,17 @@
       "license": "MIT",
       "optionalDependencies": {
         "semver": "^6.3.0"
+      }
+    },
+    "node_modules/sver/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/svgo": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1265,9 +1265,9 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.11.1.tgz",
-      "integrity": "sha512-YmhAxs7XPuxN0j7LJloHpfD1ylhDuFmmwMvfy/+6nBSrETT2ycL53LrhgPtR+f+GcPSybQVuQ5inWWu5MrWCpA==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.11.2.tgz",
+      "integrity": "sha512-GBY0+2lI9fDrjgb5dFL9+enKXqyOPok9PXg/69NVkjW3bikbK9RQrNrI3qccQXmDNN7ln4j/yL89Qgvj/tfqrw==",
       "license": "Apache-2.0",
       "dependencies": {
         "debug": "^4.4.3",
@@ -1587,9 +1587,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.53.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.53.1.tgz",
-      "integrity": "sha512-jr/swrr2aRmUAUjW5/zQHbMaui//vQlsZcJKijZf3M26bnmLj8LyZUpj8/Rd6uzaek06OWsqdofN/Thenm5O8A==",
+      "version": "8.54.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.54.0.tgz",
+      "integrity": "sha512-PDUI9R1BVjqu7AUDsRBbKMtwmjWcn4J3le+5LpcFgWULN3LvHC5rkc9gCVxbrsrGmO1jfPybN5s6h4Jy+OnkAA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2268,9 +2268,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.18",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.18.tgz",
-      "integrity": "sha512-e23vBV1ZLfjb9apvfPk4rHVu2ry6RIr2Wfs+O324okSidrX7pTAnEJPCh/O5BtRlr7QtZI7ktOP3vsqr7Z5XoA==",
+      "version": "2.9.19",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
+      "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -5878,9 +5878,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.1.0.tgz",
-      "integrity": "sha512-8HoIcWI5fCvG5NADj4bDav+er9B9JMj2vyL2pI8D0eismKyUvPLTSs+Ln3wqhwcp306i73iyVnEKx3F6T47TGw==",
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.2.0.tgz",
+      "integrity": "sha512-tovnCz/fEq+Ripoq+p/gN1u7l6A7wwkoBT9pRCzTHzsD/LvADIzXZdjmRymh5Ztf0DYC3Rwg5cZRYjxzBmzbWg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9219,20 +9219,20 @@
       }
     },
     "node_modules/mysql2": {
-      "version": "3.16.1",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.16.1.tgz",
-      "integrity": "sha512-b75qsDB3ieYEzMsT1uRGsztM/sy6vWPY40uPZlVVl8eefAotFCoS7jaDB5DxDNtlW5kdVGd9jptSpkvujNxI2A==",
+      "version": "3.16.2",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.16.2.tgz",
+      "integrity": "sha512-JsqBpYNy7pH20lGfPuSyRSIcCxSeAIwxWADpV64nP9KeyN3ZKpHZgjKXuBKsh7dH6FbOvf1bOgoVKjSUPXRMTw==",
       "license": "MIT",
       "dependencies": {
-        "aws-ssl-profiles": "^1.1.1",
+        "aws-ssl-profiles": "^1.1.2",
         "denque": "^2.1.0",
         "generate-function": "^2.3.1",
-        "iconv-lite": "^0.7.0",
-        "long": "^5.2.1",
-        "lru.min": "^1.0.0",
+        "iconv-lite": "^0.7.2",
+        "long": "^5.3.2",
+        "lru.min": "^1.1.3",
         "named-placeholders": "^1.1.6",
         "seq-queue": "^0.0.5",
-        "sqlstring": "^2.3.2"
+        "sqlstring": "^2.3.3"
       },
       "engines": {
         "node": ">= 8.0"
@@ -9412,9 +9412,9 @@
       "license": "MIT"
     },
     "node_modules/nodemailer": {
-      "version": "7.0.12",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.12.tgz",
-      "integrity": "sha512-H+rnK5bX2Pi/6ms3sN4/jRQvYSMltV6vqup/0SFOrxYYY/qoNvhXPlYq3e+Pm9RFJRwrMGbMIwi81M4dxpomhA==",
+      "version": "7.0.13",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.13.tgz",
+      "integrity": "sha512-PNDFSJdP+KFgdsG3ZzMXCgquO7I6McjY2vlqILjtJd0hy8wEvtugS9xKRF2NWlPNGxvLCXlTNIae4serI7dinw==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
@@ -11001,18 +11001,18 @@
       "license": "MIT"
     },
     "node_modules/puppeteer": {
-      "version": "24.36.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.36.0.tgz",
-      "integrity": "sha512-BD/VCyV/Uezvd6o7Fd1DmEJSxTzofAKplzDy6T9d4WbLTQ5A+06zY7VwO91ZlNU22vYE8sidVEsTpTrKc+EEnQ==",
+      "version": "24.36.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.36.1.tgz",
+      "integrity": "sha512-uPiDUyf7gd7Il1KnqfNUtHqntL0w1LapEw5Zsuh8oCK8GsqdxySX1PzdIHKB2Dw273gWY4MW0zC5gy3Re9XlqQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@puppeteer/browsers": "2.11.1",
+        "@puppeteer/browsers": "2.11.2",
         "chromium-bidi": "13.0.1",
         "cosmiconfig": "^9.0.0",
         "devtools-protocol": "0.0.1551306",
-        "puppeteer-core": "24.36.0",
+        "puppeteer-core": "24.36.1",
         "typed-query-selector": "^2.12.0"
       },
       "bin": {
@@ -11035,12 +11035,12 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "24.36.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.36.0.tgz",
-      "integrity": "sha512-P3Ou0MAFDCQ0dK1d9F9+8jTrg6JvXjUacgG0YkJQP4kbEnUOGokSDEMmMId5ZhXD5HwsHM202E9VwEpEjWfwxg==",
+      "version": "24.36.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.36.1.tgz",
+      "integrity": "sha512-L7ykMWc3lQf3HS7ME3PSjp7wMIjJeW6+bKfH/RSTz5l6VUDGubnrC2BKj3UvM28Y5PMDFW0xniJOZHBZPpW1dQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "2.11.1",
+        "@puppeteer/browsers": "2.11.2",
         "chromium-bidi": "13.0.1",
         "debug": "^4.4.3",
         "devtools-protocol": "0.0.1551306",

--- a/server/controllers/inventory/import/index.js
+++ b/server/controllers/inventory/import/index.js
@@ -86,10 +86,14 @@ async function importInventories(req, res) {
  */
 function hasValidHeaders(data = []) {
   const [headers] = data;
-  return 'inventory_group_name' in headers && 'inventory_code' in headers
-    && 'inventory_text' in headers && 'inventory_type' in headers
-    && 'inventory_unit' in headers && 'inventory_unit_price' in headers;
+  return Object.hasOwn(headers, 'inventory_group_name')
+      && Object.hasOwn(headers, 'inventory_code')
+      && Object.hasOwn(headers, 'inventory_text')
+      && Object.hasOwn(headers, 'inventory_type')
+      && Object.hasOwn(headers, 'inventory_unit')
+      && Object.hasOwn(headers, 'inventory_unit_price');
 }
+
 
 /**
  * @function hasValidData

--- a/server/controllers/stock/core.js
+++ b/server/controllers/stock/core.js
@@ -517,8 +517,7 @@ async function getLotsDepotWithAssignment(depotUuid, params, finalClause) {
 /**
  * @function getLotsDepot
  * @description returns lots with their real quantity in each depots
- * @param {number} depot_uuid - optional depot uuid for retrieving on depot
- * @param depotUuid
+ * @param {number} depotUuid - optional depot uuid for retrieving on depot
  * @param {object} params - A request query object
  * @param {string} finalClause - An optional final clause (GROUP BY, ...) to add to query built
  */
@@ -574,7 +573,7 @@ async function getLotsDepot(depotUuid, params, finalClause) {
       DATEDIFF(l.expiration_date, CURRENT_DATE()) AS lifetime,
       BUID(l.inventory_uuid) AS inventory_uuid,
       i.code, i.text, BUID(LB.depot_uuid) AS depot_uuid,
-      LB.date, i.is_asset, i.manufacturer_brand, i.manufacturer_model,
+      LB.date, LB.date AS entry_date, i.is_asset, i.manufacturer_brand, i.manufacturer_model,
       i.purchase_interval, i.delay, i.is_count_per_container,
       IF(ISNULL(iu.token), iu.text, CONCAT("INVENTORY.UNITS.",iu.token,".TEXT")) AS unit_type,
       ig.name AS group_name, ig.tracking_expiration, ig.tracking_consumption,
@@ -612,14 +611,14 @@ async function getLotsDepot(depotUuid, params, finalClause) {
 
   debug(`Found ${resultFromProcess.length} lots from initial query.`)
 
-  // add minumum delay
+  // add minimum delay
   resultFromProcess.forEach(row => {
     row.min_delay = params.min_delay;
   });
 
   debug(`Computing bulk CMMs for each lot.`)
 
-  // calulate the CMM and add inventory flags.
+  // calculate the CMM and add inventory flags.
   const inventoriesWithManagementData = await getBulkInventoryCMM(
     resultFromProcess,
     params.month_average_consumption,

--- a/server/controllers/stock/functions/rumer.function.js
+++ b/server/controllers/stock/functions/rumer.function.js
@@ -13,8 +13,8 @@ const DEFAULT_PARAMS = {
 };
 
 /**
- * @method getRumer
- *
+ * @param reqQuery
+ * @function getRumer
  * @description
  * This method builds the RUMER (Registre d’Utilisation des Médicaments Et Recettes) report by month
  *

--- a/server/controllers/stock/index.js
+++ b/server/controllers/stock/index.js
@@ -1,8 +1,6 @@
-/* eslint-disable camelcase */
+ 
 /**
  * @module stock
- *
- *
  * @description
  * The /stock HTTP API endpoint
  *
@@ -65,6 +63,8 @@ exports.dashboard = dashboard;
 /**
  * POST /stock/lots
  * Create a new stock lots entry
+ * @param req
+ * @param res
  */
 async function createStock(req, res) {
   const params = req.body;
@@ -178,8 +178,10 @@ async function createStock(req, res) {
 }
 
 /**
+ * @param inventoryUuids
+ * @param mvmtDate
+ * @param depotUuid
  * @function updateQuantityInStockAfterMovement
- *
  * @description
  * This function is called after each stock movement to ensure that the quantity in stock is updated in
  * the stock_movement_status table.  It takes in an array of inventory uuids, the date, and the depot's
@@ -203,7 +205,7 @@ function updateQuantityInStockAfterMovement(inventoryUuids, mvmtDate, depotUuid)
 }
 
 /**
- * @method insertNewStock
+ * @function insertNewStock
  * @param {object} session The session object
  * @param {object} params Request body params (req.body)
  */
@@ -228,7 +230,7 @@ async function insertNewStock(session, params) {
         unit_cost : lot.unit_cost,
         description : lot.description,
         expiration_date : new Date(lot.expiration_date),
-        acquisition_date : new Date(lot.acquisition_date) || null,
+        acquisition_date : lot.acquisition_date ? new Date(lot.acquisition_date) : null,
         inventory_uuid : db.bid(lot.inventory_uuid),
         serial_number : lot.serial_number,
         package_size : lot.package_size || 1,
@@ -275,6 +277,8 @@ async function insertNewStock(session, params) {
 /**
  * POST /stock/integration
  * create a new integration entry
+ * @param req
+ * @param res
  */
 async function createIntegration(req, res) {
   const documentUuid = await insertNewStock(req.session, req.body);
@@ -284,6 +288,8 @@ async function createIntegration(req, res) {
 /**
  * POST /stock/inventory_adjustment
  * Stock inventory adjustment
+ * @param req
+ * @param res
  */
 async function createInventoryAdjustment(req, res) {
   let movement = req.body;
@@ -440,6 +446,10 @@ async function createInventoryAdjustment(req, res) {
     });
 }
 
+/**
+ *
+ * @param params
+ */
 async function movementsFromMobile(params) {
   const mobileLots = params.lots;
   const [mobile] = mobileLots;
@@ -562,8 +572,9 @@ async function movementsFromMobile(params) {
 }
 
 /**
+ * @param req
+ * @param res
  * @function createMovement
- *
  * @description
  * Create a new stock movement.
  *
@@ -647,8 +658,10 @@ async function createMovement(req, res) {
 }
 
 /**
- * @method deleteMovement
- * @desc perform a stock movement deletion based on its document uuid
+ * @param req
+ * @param res
+ * @function deleteMovement
+ * @description perform a stock movement deletion based on its document uuid
  */
 async function deleteMovement(req, res) {
   const tx = db.transaction();
@@ -722,6 +735,9 @@ async function deleteMovement(req, res) {
 }
 
 /**
+ * @param document
+ * @param params
+ * @param metadata
  * @function normalMovement
  * @description there are only lines for IN or OUT
  */
@@ -782,6 +798,9 @@ async function normalMovement(document, params, metadata) {
 }
 
 /**
+ * @param document
+ * @param params
+ * @param metadata
  * @function depotMovement
  * @description movement between depots
  */
@@ -864,6 +883,8 @@ async function depotMovement(document, params, metadata) {
 /**
  * GET /stock/assetLots
  * Get the assets lots
+ * @param req
+ * @param res
  */
 async function listAssetLots(req, res) {
   const params = req.query;
@@ -874,6 +895,8 @@ async function listAssetLots(req, res) {
 /**
  * GET /stock/lots
  * this function helps to list lots
+ * @param req
+ * @param res
  */
 async function listLots(req, res) {
   const params = req.query;
@@ -884,6 +907,8 @@ async function listLots(req, res) {
 /**
  * GET /stock/lots/movements
  * returns list of stock movements
+ * @param req
+ * @param res
  */
 async function listLotsMovements(req, res) {
   const rows = await core.getLotsMovements(null, req.query);
@@ -893,6 +918,8 @@ async function listLotsMovements(req, res) {
 /**
  * GET /stock/movements
  * returns list of stock movements
+ * @param req
+ * @param res
  */
 async function listMovements(req, res) {
   const params = req.query;
@@ -908,9 +935,11 @@ async function listMovements(req, res) {
 /**
  * GET /stock/dashboard
  * returns data for stock dashboard
+ * @param req
+ * @param res
  */
 async function dashboard(req, res) {
-  // eslint-disable-next-line
+   
   const { month_average_consumption, average_consumption_algo, min_delay, enable_expired_stock_out } = req.session.stock_settings;
 
   const dbPromises = [];
@@ -1076,6 +1105,8 @@ async function dashboard(req, res) {
 /**
  * GET /stock/lots/depots/
  * returns list of each lots in each depots with their quantities
+ * @param req
+ * @param res
  */
 async function listLotsDepot(req, res) {
   const params = req.query;
@@ -1094,6 +1125,7 @@ async function listLotsDepot(req, res) {
     delete params.period;
   }
 
+
   const data = await core.getLotsDepot(null, params);
 
   // if no data is returned or if the skipTags flag is set, we don't need to do any processing
@@ -1110,7 +1142,10 @@ async function listLotsDepot(req, res) {
 }
 
 /**
- * GET /stock/lots/depots/
+ * GET /stock/lots/depotsDetailed/
+ * @param req
+ * @param res
+ * @description
  * returns list of each lots in each depots with their quantities
  */
 async function listLotsDepotDetailed(req, res) {
@@ -1216,6 +1251,8 @@ async function listLotsDepotDetailed(req, res) {
 /**
  * GET /stock/inventory/depots/
  * returns list of each inventory in a given depot with their quantities and CMM
+ * @param req
+ * @param res
  * @todo process stock alert, rupture of stock
  * @todo prevision for purchase
  */
@@ -1301,6 +1338,8 @@ async function listInventoryDepot(req, res) {
 /**
  * GET /stock/flux
  * returns list of stock flux
+ * @param req
+ * @param res
  */
 async function listStockFlux(req, res) {
   const rows = await db.exec('SELECT id, label FROM flux;');
@@ -1309,6 +1348,8 @@ async function listStockFlux(req, res) {
 
 /**
  * GET /stock/consumptions/:periodId
+ * @param req
+ * @param res
  */
 async function getStockConsumption(req, res) {
   const { params } = req;
@@ -1318,6 +1359,8 @@ async function getStockConsumption(req, res) {
 
 /**
  * GET /stock/consumptions/average/:periodId?number_of_months=...
+ * @param req
+ * @param res
  */
 async function getStockConsumptionAverage(req, res) {
   const { query, params } = req;
@@ -1327,6 +1370,8 @@ async function getStockConsumptionAverage(req, res) {
 
 /**
  * GET /stock/transfer
+ * @param req
+ * @param res
  */
 async function getStockTransfers(req, res) {
   const params = req.query;
@@ -1373,6 +1418,8 @@ async function getStockTransfers(req, res) {
 /**
  * POST /stock/aggregated_consumption
  * Stock Aggregated Consumption
+ * @param req
+ * @param res
  */
 async function createAggregatedConsumption(req, res) {
   const movement = req.body;

--- a/server/controllers/stock/index.js
+++ b/server/controllers/stock/index.js
@@ -447,8 +447,23 @@ async function createInventoryAdjustment(req, res) {
 }
 
 /**
+ * Build a stock movement payload from data submitted by a mobile client.
  *
- * @param params
+ * @param {Object} params - Parameters received from the mobile application.
+ * @param {Array<Object>} params.lots - List of lot movements provided by the mobile client.
+ * @param {string} params.lots[].uuid - Unique identifier of the mobile lot line.
+ * @param {string} params.lots[].lotUuid - UUID of the corresponding BHIMA lot.
+ * @param {string} params.lots[].description - Description of the lot or movement line.
+ * @param {number} params.lots[].quantity - Quantity moved for this lot.
+ * @param {number} params.lots[].unitCost - Unit cost associated with the lot.
+ * @param {boolean} params.lots[].isExit - Indicates whether the movement is an exit.
+ * @param {string} [params.lots[].reference] - Reference linking this movement to an initial stock exit.
+ * @param {string} params.lots[].depotUuid - UUID of the depot associated with the mobile movement.
+ * @param {number} params.lots[].fluxId - Identifier of the stock flux type.
+ * @param {string|Date} params.lots[].date - Date of the movement as provided by the mobile client.
+ *
+ * @returns {Object} A normalized stock movement object containing document/depot/lot information
+ *   suitable for persistence, or an empty object if no valid lots are found.
  */
 async function movementsFromMobile(params) {
   const mobileLots = params.lots;

--- a/server/controllers/stock/reports/stock/lots_report.js
+++ b/server/controllers/stock/reports/stock/lots_report.js
@@ -112,9 +112,11 @@ async function stockLotsReport(req, res) {
 }
 
 /**
+ * Compares two strings using locale-aware ordering for use as a sort callback.
  *
- * @param a
- * @param b
+ * @param {string} a - First string to compare.
+ * @param {string} b - Second string to compare.
+ * @returns {number} Negative if a < b, positive if a > b, zero if equal.
  */
 function compare(a, b) {
   return a.localeCompare(b);

--- a/server/controllers/stock/reports/stock/rumer.js
+++ b/server/controllers/stock/reports/stock/rumer.js
@@ -7,8 +7,9 @@ const TEMPLATE2 = './server/controllers/stock/reports/rumer_condensed.report.han
 exports.report = report;
 
 /**
- * @method report
- *
+ * @param req
+ * @param res
+ * @function report
  * @description
  * This method builds the RUMER (Registre d’Utilisation des Médicaments Et Recettes) report
  * by month JSON, PDF, or HTML file to be sent to the client.

--- a/test/integration/stock/stock.js
+++ b/test/integration/stock/stock.js
@@ -1,4 +1,3 @@
-/* global expect, agent */
 const moment = require('moment');
 const helpers = require('../helpers');
 const shared = require('./shared');
@@ -20,6 +19,7 @@ describe('test/integration/stock/stock The Stock API', () => {
   it('POST /stock/lots/movements distribute lots to patients from a depot', async () => {
     const res1 = await agent.post('/stock/lots/movements').send(shared.movementOutPatient);
     helpers.api.created(res1);
+
     // get details of the movement
     const docUuid = res1.body.uuid;
     const res2 = await agent.get(`/stock/lots/movements?document_uuid=${docUuid}`);
@@ -29,7 +29,6 @@ describe('test/integration/stock/stock The Stock API', () => {
     const res3 = await agent.get(`/stock/lots/movements?reference=${firstMvt.documentReference}`);
 
     expect(res3.body).to.deep.equal(mvtsByDocument);
-
   });
 
   // create stock movement to depot


### PR DESCRIPTION
This commit updates the SQL query associated with the `stock/lots/depots` query as recommended by #7295. This should improve performance on low-end systems.  It tries to replicate the previous behavior as closely as possible, but improve the efficiency.

Note that some items needed to be duplicated to make this work effectively, and testing with live data still needs to be performed.

Closes #7295.