### PR TITLE
fix(exchange): allow direct exchange rate entry relative to the stronger currency

### DIFF
--- a/client/src/i18n/en/exchange.json
+++ b/client/src/i18n/en/exchange.json
@@ -12,7 +12,7 @@
     "EXCHANGE_RATES" : "Exchange Rate(s)",
     "FIX_MISSING_RATES_FIRST": "You must fix missing exchange rates before proceeding!",
     "FOR" : "for",
-    "FRACTIONAL_RATE_HINT": "To enter a fractional rate, please use as many digits as possible.",
+    "FRACTIONAL_RATE_HINT": "Enter the exchange rate relative to the stronger currency.",
     "INVALID_CURRENCY_DEFINITION": "Invalid currency definition!",
     "INVOICE_DISCLAIMER" : "Exchange rate based on the latest enterprise exchange:",
     "MISSING_EXCHANGE_RATES": "The exchange for some currencies have not be defined!",

--- a/client/src/i18n/fr/exchange.json
+++ b/client/src/i18n/fr/exchange.json
@@ -12,7 +12,7 @@
     "EXCHANGE_RATES" : "le taux de change",
     "FIX_MISSING_RATES_FIRST": "Vous devez fixer les taux de change manquants avant de poursuivre !",
     "FOR" : "pour",
-    "FRACTIONAL_RATE_HINT": "Pour saisir un taux fractionnaire, veuillez utiliser autant de chiffres que possible.",
+    "FRACTIONAL_RATE_HINT": "Saisissez le taux de change par rapport à la devise la plus forte.",
     "INVALID_CURRENCY_DEFINITION": "Définition de la monnaie non valide !",
     "INVOICE_DISCLAIMER" : "Taux de Change basé sur le dernier taux de l'entreprise",
     "MISSING_EXCHANGE_RATES": "Les taux de change de certaines monnaies n'ont pas été définis !",

--- a/client/src/js/components/bhExchangeRate.js
+++ b/client/src/js/components/bhExchangeRate.js
@@ -30,13 +30,6 @@ function bhExchangeRateController(Currencies, Rates, Session, Notify) {
   $ctrl.enterprise = Session.enterprise;
   $ctrl.EXCHANGE_RATE_DISPLAY_SIZE = 6;
 
-  /*
-    $ctrl.isFirstCurencyLabel is used to check the exchange Rate
-    is lower then 1  the program display something
-    mutch better for reading
-  */
-  $ctrl.isFirstCurencyLabel = false;
-
   // load exchange rates
   /**
    *
@@ -53,15 +46,16 @@ function bhExchangeRateController(Currencies, Rates, Session, Notify) {
       })
       .then(() => {
         $ctrl.currencies.forEach((currency) => {
-          currency.rate = Rates.getCurrentRate(currency.id);
+          const rawRate = Rates.getCurrentRate(currency.id);
 
-          /*
-            Let check if the currency rate is lower the 1
-            so that we could format it in a readable way
-          */
-          if (currency.rate < 1) {
-            currency.rate = (1 / currency.rate);
-            $ctrl.isFirstCurencyLabel = true;
+          // if the rate is less than 1, the enterprise currency is weak
+          // relative to this foreign currency — display as "1 Foreign = X Enterprise"
+          if (rawRate < 1) {
+            currency.rate = Rates.round(1 / rawRate, 2);
+            currency.isWeakCurrency = true;
+          } else {
+            currency.rate = rawRate;
+            currency.isWeakCurrency = false;
           }
         });
 

--- a/client/src/modules/exchange/exchange.modal.html
+++ b/client/src/modules/exchange/exchange.modal.html
@@ -43,8 +43,14 @@
 
     <div style="margin-bottom: 0.5em;">
       <span translate>EXCHANGE.CURRENT_RATE</span>:
-      <i>{{ ModalCtrl.currentExchangeRate }} {{ ModalCtrl.rate.currency.symbol }}</i>
-      <i><span translate>FORM.INFO.PER</span> {{ModalCtrl.enterprise.currencySymbol}}</i>
+      <span ng-if="!ModalCtrl.isWeakCurrency">
+        <i>{{ ModalCtrl.currentExchangeRate }} {{ ModalCtrl.rate.currency.symbol }}</i>
+        <i><span translate>FORM.INFO.PER</span> {{ModalCtrl.enterprise.currencySymbol}}</i>
+      </span>
+      <span ng-if="ModalCtrl.isWeakCurrency">
+        <i>{{ ModalCtrl.currentExchangeRate }} {{ ModalCtrl.enterprise.currencySymbol }}</i>
+        <i><span translate>FORM.INFO.PER</span> {{ ModalCtrl.rate.currency.symbol }}</i>
+      </span>
     </div>
 
     <div class="form-group"
@@ -53,13 +59,15 @@
       <div class="row">
         <div class="col-xs-2">
           <p class="form-control-static text-right" ng-class="{ 'text-danger' : ModalForm.$submitted && ModalForm.rate.$invalid }">
-            {{ 1 | currency:ModalCtrl.enterprise.currency_id }} <b>=</b>
+            <span ng-if="!ModalCtrl.isWeakCurrency">{{ 1 | currency:ModalCtrl.enterprise.currency_id }} <b>=</b></span>
+            <span ng-if="ModalCtrl.isWeakCurrency">{{ 1 | currency:ModalCtrl.rate.currency.id }} <b>=</b></span>
           </p>
         </div>
         <div class="col-xs-10">
           <div class="input-group">
             <input class="form-control" min="0.000000000001" type="number" name="rate" ng-model="ModalCtrl.rate.rate" required>
-            <span class="input-group-addon">{{ ModalCtrl.symbol(ModalCtrl.rate.currency.id) }}</span>
+            <span ng-if="!ModalCtrl.isWeakCurrency" class="input-group-addon">{{ ModalCtrl.symbol(ModalCtrl.rate.currency.id) }}</span>
+            <span ng-if="ModalCtrl.isWeakCurrency" class="input-group-addon">{{ ModalCtrl.enterprise.currencySymbol }}</span>
           </div>
           <p><em translate>EXCHANGE.FRACTIONAL_RATE_HINT</em></p>
         </div>

--- a/client/src/modules/exchange/exchange.modal.js
+++ b/client/src/modules/exchange/exchange.modal.js
@@ -42,11 +42,16 @@ function ExchangeRateModalController(ModalInstance, Exchange, Currencies, Sessio
   vm.cancel = function cancel() { ModalInstance.dismiss(); };
 
   vm.selectCurrency = () => {
-    vm.currentExchangeRate = Exchange.getCurrentRate(vm.rate.currency.id);
+    const rawRate = Exchange.getCurrentRate(vm.rate.currency.id);
+    vm.isWeakCurrency = rawRate !== null && rawRate < 1;
+    vm.currentExchangeRate = vm.isWeakCurrency ? Exchange.round(1 / rawRate, 2) : rawRate;
   };
 
   // this turns on and off the currency select input
   vm.hasMultipleCurrencies = false;
+
+  // tracks whether the enterprise currency is weak relative to the selected foreign currency
+  vm.isWeakCurrency = false;
 
   Currencies.read()
     .then((currencies) => {
@@ -62,7 +67,9 @@ function ExchangeRateModalController(ModalInstance, Exchange, Currencies, Sessio
         vm.hasMultipleCurrencies = true;
       }
 
-      vm.currentExchangeRate = Exchange.getCurrentRate(vm.rate.currency.id);
+      const rawRate = Exchange.getCurrentRate(vm.rate.currency.id);
+      vm.isWeakCurrency = rawRate !== null && rawRate < 1;
+      vm.currentExchangeRate = vm.isWeakCurrency ? Exchange.round(1 / rawRate, 2) : rawRate;
     })
     .catch(Notify.handleError);
 
@@ -81,6 +88,12 @@ function ExchangeRateModalController(ModalInstance, Exchange, Currencies, Sessio
     // TODO clean this up with proper ui-select syntax when internet available
     const { currency } = vm.rate;
     data.currency_id = currency.id;
+
+    // if the enterprise currency is weak, the user entered the rate as
+    // "1 [Foreign] = X [Enterprise]", so convert back to internal format
+    if (vm.isWeakCurrency) {
+      data.rate = 1 / data.rate;
+    }
 
     return Exchange.create(data)
       .then(() => {

--- a/client/src/modules/templates/bhExchange.tmpl.html
+++ b/client/src/modules/templates/bhExchange.tmpl.html
@@ -32,11 +32,11 @@
     <ul class="list-unstyled">
       <li data-exchange-rate-element ng-repeat="rate in $ctrl.rates | orderBy:'-date'">
         <i class="fa fa-clock-o"></i>
-          <span ng-if="rate.rate < 0.1">
-            <b> <em> (1 / {{(1 / rate.rate) | number:0 }}) </em> {{ $ctrl.formatCurrency(rate.currency_id) }} </b>
+          <span ng-if="rate.rate < 1">
+            <b>1 {{ $ctrl.formatCurrency(rate.currency_id) }} = {{(1 / rate.rate) | number:2 }} {{ $ctrl.formatCurrency($ctrl.enterpriseCurrencyId) }}</b>
           </span>
-          <span ng-if="rate.rate >= 0.1">
-            <b>{{ rate.rate}} {{ $ctrl.formatCurrency(rate.currency_id) }} </b>
+          <span ng-if="rate.rate >= 1">
+            <b>1 {{ $ctrl.formatCurrency($ctrl.enterpriseCurrencyId) }} = {{ rate.rate}} {{ $ctrl.formatCurrency(rate.currency_id) }}</b>
           </span>
         <span translate>EXCHANGE.RATE_SET</span> <span am-time-ago="rate.date"></span>.
         <br />

--- a/client/src/modules/templates/bhExchangeRate.tmpl.html
+++ b/client/src/modules/templates/bhExchangeRate.tmpl.html
@@ -1,12 +1,12 @@
 <span >
   <span translate>FORM.LABELS.EXCHANGE_RATE</span> : 
-  <b ng-show="$ctrl.isFirstCurencyLabel">
+  <b ng-show="$ctrl.primaryExchange.isWeakCurrency">
     1{{$ctrl.primaryExchange.symbol}} = {{ $ctrl.primaryExchange.rate | limitTo:$ctrl.EXCHANGE_RATE_DISPLAY_SIZE }}
     ({{ $ctrl.enterprise.currencySymbol }})
   </b>
 
-  <b ng-show="!$ctrl.isFirstCurencyLabel">
+  <b ng-show="!$ctrl.primaryExchange.isWeakCurrency">
     1{{ $ctrl.enterprise.currencySymbol }} = {{ $ctrl.primaryExchange.rate | limitTo:$ctrl.EXCHANGE_RATE_DISPLAY_SIZE }}
-    ({{ $ctrl.primaryExchange.symbol }})</div>
+    ({{ $ctrl.primaryExchange.symbol }})
   </b>
 </span>


### PR DESCRIPTION
…rrency

When the enterprise currency is weak, users can now enter exchange rates directly relative to the strong currency (e.g. 1 USD = 920 CDF) instead of being forced to enter fractional values (e.g. 0.00108).

- Detect weak currency scenario (rate < 1) in exchange modal
- Swap input labels to show '1 Foreign = ? Enterprise' for weak currencies
- Convert user input back to internal format (1/rate) on submit
- Per-currency display logic in bhExchangeRate header component
- Human-readable rate display in exchange rate list (bhExchange)
- Updated i18n hints (en/fr)
- No changes to database schema, SQL procedures, or conversion logic