### PR TITLE
refactor(db): drop MYSQL5_PASSWORD

### DIFF
--- a/server/controllers/admin/users/index.js
+++ b/server/controllers/admin/users/index.js
@@ -1,10 +1,8 @@
 /**
- * @overview Users
- *
+ * @file Users
  * @description
  * The /users API endpoint.  This file is responsible for implementing CRUD
  * operations on the `user` table.
- *
  * @requires db
  * @requires FilterParser
  * @requires errors
@@ -36,13 +34,11 @@ exports.depotUsersSupervision = depotUsersSupervision;
 
 /**
  * @function lookupUser
- *
  * @description
  * This function looks up a user by their id in the database.  It returns the
  * full details of the user, including a list of their project and permission
  * ids.
- *
- * @param {Number} id - the id of a user in the database
+ * @param {number} id - the id of a user in the database
  * @returns {Promise} A promise object with
  */
 async function lookupUser(id) {
@@ -81,6 +77,10 @@ async function lookupUser(id) {
   return user;
 }
 
+/**
+ *
+ * @param params
+ */
 async function fetchUser(params) {
   const options = params;
   db.convert(options, ['role_uuid', 'depot_uuid']);
@@ -124,8 +124,9 @@ async function fetchUser(params) {
 }
 
 /**
+ * @param req
+ * @param res
  * @function list
- *
  * @description
  * If the client queries to /users endpoint, the API will respond with an array
  * of zero or more JSON objects, with id, username, display_name, activation state,
@@ -139,8 +140,9 @@ async function list(req, res) {
 }
 
 /**
+ * @param req
+ * @param res
  * @function detail
- *
  * @description
  * This endpoint will return a single JSON object containing the full user row
  * for the user with matching ID.  If no matching user exists, it will return a
@@ -156,6 +158,11 @@ async function detail(req, res) {
   res.status(200).json(data);
 }
 
+/**
+ *
+ * @param req
+ * @param res
+ */
 async function exists(req, res) {
   const sql = 'SELECT count(id) as nbr FROM user WHERE username = ?';
   const data = await db.one(sql, req.params.username);
@@ -163,8 +170,9 @@ async function exists(req, res) {
 }
 
 /**
- * @method create
- *
+ * @param req
+ * @param res
+ * @function create
  * @description
  * POST /users
  *
@@ -174,17 +182,17 @@ async function exists(req, res) {
  *
  * If the checks succeed, the user password is hashed and stored in the database.
  * A single JSON is returned to the client with the user id.
- *
  */
 async function create(req, res) {
   const data = req.body;
 
   let sql = `
     INSERT INTO user (username, password, email, display_name) VALUES
-    (?, MYSQL5_PASSWORD(?), ?, ?);
+    (?, ?, ?, ?);
   `;
 
-  const row = await db.exec(sql, [data.username, data.password, data.email, data.display_name]);
+  const password = db.mysql5password(data.password);
+  const row = await db.exec(sql, [data.username, password, data.email, data.display_name]);
 
   // retain the insert id
   const userId = row.insertId;
@@ -199,8 +207,9 @@ async function create(req, res) {
 }
 
 /**
- * @method update
- *
+ * @param req
+ * @param res
+ * @function update
  * @description
  * PUT /users/:id
  *
@@ -260,8 +269,9 @@ async function update(req, res) {
 }
 
 /**
+ * @param req
+ * @param res
  * @function password
- *
  * @description
  * PUT /users/:id/password
  *
@@ -271,16 +281,17 @@ async function update(req, res) {
 async function password(req, res) {
   // TODO -- strict check to see if the user is either signed in or has
   // sudo permissions.
-  const sql = `UPDATE user SET password = MYSQL5_PASSWORD(?) WHERE id = ?;`;
+  const sql = `UPDATE user SET password = ? WHERE id = ?;`;
 
-  await db.exec(sql, [req.body.password, req.params.id]);
+  await db.exec(sql, [db.mysql5password(req.body.password), req.params.id]);
   const user = await lookupUser(req.params.id);
   res.status(200).json(user);
 }
 
 /**
+ * @param req
+ * @param res
  * @function remove
- *
  * @description
  * DELETE /users/:id
  *
@@ -303,6 +314,8 @@ async function remove(req, res) {
  *
  * Creates and updates a user's depots for Management.  This works by completely deleting
  * the user's depots and then replacing them with the new depots set.
+ * @param req
+ * @param res
  */
 async function depotUsersManagment(req, res) {
   const transaction = db.transaction();
@@ -330,6 +343,8 @@ async function depotUsersManagment(req, res) {
  *
  * Creates and updates a user's depots for supervision.  This works by completely deleting
  * the user's depots and then replacing them with the new depots set.
+ * @param req
+ * @param res
  */
 async function depotUsersSupervision(req, res) {
   const transaction = db.transaction();

--- a/server/controllers/auth.js
+++ b/server/controllers/auth.js
@@ -54,6 +54,9 @@ async function loginRoute(req, res) {
  * the database all enterprise, project, and user data for easy access.
  */
 async function login(username, password, projectId) {
+  
+  const hashedPassword = db.mysql5password(password);
+
   const sql = `
     SELECT
       user.id, user.username, user.display_name, user.email, user.deactivated,
@@ -62,13 +65,13 @@ async function login(username, password, projectId) {
     JOIN project_permission JOIN project ON user.id = project_permission.user_id
       AND project.id = project_permission.project_id
     WHERE
-      user.username = ? AND user.password = MYSQL5_PASSWORD(?)
+      user.username = ? AND user.password = ?
       AND project_permission.project_id = ?;
   `;
 
   const sqlUser = `
     SELECT user.id, user.deactivated FROM user
-    WHERE user.username = ? AND user.password = MYSQL5_PASSWORD(?);
+    WHERE user.username = ? AND user.password = ?;
   `;
 
   // a role should be assigned to the user
@@ -77,13 +80,13 @@ async function login(username, password, projectId) {
     SELECT  user.id
     FROM  user_role
       JOIN user ON user.id =  user_role.user_id
-    WHERE user.username = ? AND user.password = MYSQL5_PASSWORD(?)
+    WHERE user.username = ? AND user.password = ?
   `;
 
   const [connect, user, permission] = await Promise.all([
-    db.exec(sql, [username, password, projectId]),
-    db.exec(sqlUser, [username, password]),
-    db.exec(sqlPermission, [username, password]),
+    db.exec(sql, [username, hashedPassword, projectId]),
+    db.exec(sqlUser, [username, hashedPassword]),
+    db.exec(sqlPermission, [username, hashedPassword]),
   ]);
 
   const hasAuthorization = connect.length > 0;

--- a/server/controllers/install.js
+++ b/server/controllers/install.js
@@ -112,7 +112,7 @@ function createEnterpriseProjectUser(enterprise, project, user, locationUuid) {
   const sqlEnterprise = 'INSERT INTO enterprise SET ? ';
   const sqlEnterpriseSettings = 'INSERT INTO enterprise_setting SET ?';
   const sqlProject = 'INSERT INTO project SET ? ';
-  const sqlUser = 'INSERT INTO user (username, password, display_name) VALUES (?, MYSQL5_PASSWORD(?)  , ?);';
+  const sqlUser = 'INSERT INTO user (username, password, display_name) VALUES (?, ?  , ?);';
   const sqlRole = `CALL superUserRole(${user.id})`;
   const sqlProjectPermission = 'INSERT INTO project_permission SET ? ';
 
@@ -120,7 +120,7 @@ function createEnterpriseProjectUser(enterprise, project, user, locationUuid) {
     .addQuery(sqlEnterprise, enterprise)
     .addQuery(sqlEnterpriseSettings, DEFAULTS.settings)
     .addQuery(sqlProject, project)
-    .addQuery(sqlUser, [user.username, user.password, user.display_name])
+    .addQuery(sqlUser, [user.username, db.mysql5password(user.password), user.display_name])
     .addQuery(sqlProjectPermission, { user_id : user.id, project_id : project.id })
     .addQuery(sqlRole)
     .execute();

--- a/server/lib/db/index.js
+++ b/server/lib/db/index.js
@@ -1,14 +1,14 @@
 /* eslint class-methods-use-this:off */
+const process = require('node:process');
+const crypto = require('node:crypto');
 const mysql = require('mysql2/promise');
 const uuidParse = require('uuid-parse');
 const moment = require('moment');
 const debug = require('debug')('db');
-const process = require('node:process');
 
 const Transaction = require('./transaction');
 const { uuid, isString, isDate } = require('../util');
-const BadRequest = require('../errors/BadRequest');
-const NotFound = require('../errors/NotFound');
+const { BadRequest, NotFound } = require('../errors');
 
 /**
  * @class DatabaseConnector
@@ -259,6 +259,26 @@ class DatabaseConnector {
     return mysql.format(sql.trim(), params);
   }
 
+  /**
+   * @param  plainText
+   * @function mysql5password
+   * @description
+   * Drop in replacement for MySQL 5 password hashing.  This is used to generate the
+   * user passwords until we can replace them with argon2.
+   */
+  mysql5password(plainText = '') {
+    // First SHA1 pass, as a hex string
+    const stage1 = crypto.createHash('sha1').update(plainText, 'utf8').digest('hex');
+
+    // UNHEX(stage1) -> raw bytes, then SHA1 again
+    const stage2 = crypto
+      .createHash('sha1')
+      .update(Buffer.from(stage1, 'hex'))
+      .digest('hex');
+
+    return '*' + stage2.toUpperCase();
+  }
+
   async delete(table, idKey, idValue, res, notFoundErrorMessage) {
     const sql = `DELETE FROM ${table} WHERE ${idKey} = ?;`;
 
@@ -333,6 +353,7 @@ class DatabaseConnector {
     return { rows, pager };
   }
 }
+
 
 const db = new DatabaseConnector();
 

--- a/server/models/02-functions.sql
+++ b/server/models/02-functions.sql
@@ -184,16 +184,4 @@ BEGIN
 END
 $$
 
-/**
-  MYSQL5_PASSWORD(string)
-
-  function to emulate the PASSWORD function of MySQL 5, that is not available in MySQL 8
-  TODO: use better methods to store the password
- */
-CREATE FUNCTION `MYSQL5_PASSWORD`(_pwd VARCHAR(40))
-RETURNS VARCHAR(100) DETERMINISTIC
-BEGIN
-  RETURN CONCAT('*', UPPER(SHA1(UNHEX(SHA1(_pwd)))));
-END
-$$
 DELIMITER ;

--- a/server/models/migrations/next/migrate.sql
+++ b/server/models/migrations/next/migrate.sql
@@ -29,3 +29,7 @@ CREATE TABLE `smtp_configuration` (
   `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARACTER SET = utf8mb4 DEFAULT COLLATE = utf8mb4_unicode_ci;
+
+-- author: @jniles
+-- Replace the MYSQL5_PASSWORD functionality with a nodejs alternative.
+DROP FUNCTION IF EXISTS MYSQL5_PASSWORD;

--- a/test/data-init.sql
+++ b/test/data-init.sql
@@ -6,7 +6,7 @@ INSERT INTO `project` VALUE (1,'IMA Kinshasa','KIN',1,1,0);
 
 -- create a superuser
 INSERT INTO user (id, username, password, display_name, email, deactivated) VALUE
-  (1, 'superuser', MYSQL5_PASSWORD('superuser'), 'Adminstrator', 'developper@imaworldhealth.org', 0);
+  (1, 'superuser', '*F5AB3475E4D0309381498567B7C7A270ADED2652', 'Adminstrator', 'developper@imaworldhealth.org', 0); -- password 'superuser'
 
 -- superuser permission
 INSERT INTO permission (unit_id, user_id)

--- a/test/data.sql
+++ b/test/data.sql
@@ -328,10 +328,12 @@ UPDATE enterprise SET `gain_account_id` = 267, `loss_account_id` = 134;
 
 -- create test users
 INSERT INTO user (id, username, password, display_name, email, deactivated) VALUES
-  (1, 'superuser', MYSQL5_PASSWORD('superuser'), 'Super User', 'SuperUser@test.org', 0),
-  (2, 'RegularUser', MYSQL5_PASSWORD('RegularUser'), 'Regular User', 'RegUser@test.org', 0),
-  (3, 'NoUserPermissions', MYSQL5_PASSWORD('NoUserPermissions'), 'No Permissrepertoireions', 'Invalid@test.org', 1),
-  (4, 'admin', MYSQL5_PASSWORD('1'), 'Admin User', 'admin@test.org', 1);
+  (1, 'superuser', '*F5AB3475E4D0309381498567B7C7A270ADED2652', 'Super User', 'SuperUser@test.org', 0), -- password 'superuser'
+  (2, 'RegularUser', '*6112644293BCB2CB91A4C912EEFC84E2A91D13E8', 'Regular User', 'RegUser@test.org', 0), -- password 'RegularUser'
+  (3, 'NoUserPermissions', '*9E74AE6A88D68D7C395C27A1ED6809700BB136A3', 'No Permissions', 'Invalid@test.org', 1), -- password 'NoUserPermissions'
+  (4, 'admin', '*E6CC90B878B948C35E92B003C792C46C58C4AF40', 'Admin User', 'admin@test.org', 1); -- password '1'
+
+
 
 SET @superUser = 1;
 

--- a/test/data/core.sql
+++ b/test/data/core.sql
@@ -46,10 +46,10 @@ INSERT INTO `service` (uuid, enterprise_id, project_id, name) VALUES
 SET @superUser = 1;
 
 INSERT INTO user (id, username, password, display_name, email, deactivated) VALUES
-  (@superUser, 'superuser', MYSQL5_PASSWORD('superuser'), 'Super User', 'SuperUser@test.org', 0),
-  (2, 'RegularUser', MYSQL5_PASSWORD('RegularUser'), 'Regular User', 'RegUser@test.org', 0),
-  (3, 'NoUserPermissions', MYSQL5_PASSWORD('NoUserPermissions'), 'No Permissrepertoireions', 'Invalid@test.org', 1),
-  (4, 'admin', MYSQL5_PASSWORD('1'), 'Admin User', 'admin@test.org', 1);
+  (@superUser, 'superuser', '*F5AB3475E4D0309381498567B7C7A270ADED2652', 'Super User', 'SuperUser@test.org', 0), -- password 'superuser'
+  (2, 'RegularUser', '*6112644293BCB2CB91A4C912EEFC84E2A91D13E8', 'Regular User', 'RegUser@test.org', 0), -- password 'RegularUser'
+  (3, 'NoUserPermissions', '*9E74AE6A88D68D7C395C27A1ED6809700BB136A3', 'No Permissions', 'Invalid@test.org', 1), -- password 'NoUserPermissions'
+  (4, 'admin', '*E6CC90B878B948C35E92B003C792C46C58C4AF40', 'Admin User', 'admin@test.org', 1); -- password '1'
 
 -- the super user has permission to everything user
 INSERT INTO permission (unit_id, user_id)


### PR DESCRIPTION
Replaces the `MYSQL5_PASSWORD` native SQL function with a Node.js replacement in preparation for the migration to argon2.  If you need the old functionality, it is exported from `lib/db` as `db.mysql5password(plainText)`.

The flat SQL files that used MYSQL5_PASSWORD() have been updated with the pre-hashed passwords.  The plaintext equivalent are commented alongside if needed.

It has the additional benefit of allowing testing on MySQL 9 LTS which drops the SHA1 function.

Partially addresses #1754.