### PR TITLE
chore: drop unused utilities

### DIFF
--- a/client/src/js/services/BarcodeService.js
+++ b/client/src/js/services/BarcodeService.js
@@ -26,9 +26,7 @@ function BarcodeService($http, util, Modal) {
     size        : 'lg',
     backdrop    : 'static',
     keyboard    : true,
-    resolve : {
-      options : () => options,
-    },
+    resolve : { options : () => options },
   }).result;
 
   return service;

--- a/client/src/js/services/CronService.js
+++ b/client/src/js/services/CronService.js
@@ -8,6 +8,5 @@ CronService.$inject = ['PrototypeApiService'];
  * @param Api
  */
 function CronService(Api) {
-  const service = new Api('/crons/');
-  return service;
+  return new Api('/crons/');
 }

--- a/client/src/js/services/color.js
+++ b/client/src/js/services/color.js
@@ -1,9 +1,7 @@
 angular.module('bhima.services')
   .service('ColorService', ColorService);
 
-ColorService.$inject = [
-  '$translate',
-];
+ColorService.$inject = [ '$translate', ];
 
 /**
  *

--- a/client/src/js/services/period.js
+++ b/client/src/js/services/period.js
@@ -8,6 +8,5 @@ PeriodApi.$inject = ['PrototypeApiService'];
  * @param Api
  */
 function PeriodApi(Api) {
-  const service = new Api('/periods/');
-  return service;
+  return new Api('/periods/');
 }

--- a/client/src/js/services/util.js
+++ b/client/src/js/services/util.js
@@ -98,20 +98,6 @@ function UtilService(moment) {
   service.length16 = 16;
   service.length12 = 12;
 
-  // utility function
-  service.clean = function clean(o) {
-    // clean off the $$hashKey and other angular bits and delete undefined
-    const cleaned = {};
-
-    Object.keys(o).forEach(k => {
-      if (k !== '$$hashKey' && angular.isDefined(o[k]) && o[k] !== '' && o[k] !== null) {
-        cleaned[k] = o[k];
-      }
-    });
-
-    return cleaned;
-  };
-
   // moment() provides the current date, similar to the new Date() API. This requests the difference between two dates
   service.getMomentAge = (date, duration) => {
     return duration ? moment().diff(date, duration) : moment().diff(date);
@@ -201,16 +187,6 @@ function UtilService(moment) {
     };
   };
 
-  /**
-   * @function uniquelize
-   * @param {Array} array An array in which we want to get only unique values
-   * @description return an array which contain only unique values
-   */
-  service.uniquelize = function uniquelize(array) {
-    return array.filter((value, idx, _array) => {
-      return _array.indexOf(value) === idx;
-    });
-  };
 
   service.isEmptyObject = function isEmptyObject(object) {
     return Object.keys(object).length === 0;
@@ -302,46 +278,40 @@ function UtilService(moment) {
    * @param {string} property
    * @returns {object}
    */
-  service.groupBy = (array, property) => {
-    const out = {};
-    for (let i = 0; i < array.length; i++) {
-      const item = array[i];
-      const value = item[property];
-      if (!out[value]) {
-        out[value] = [];
-      }
-      out[value].push(item);
-    }
-    return out;
-  };
+  service.groupBy = (array, property) => Object.groupBy(array, (item) => item[property]);
+
 
   /**
    * @function mimeIcon
    * @param {string} mimetype
+   * @returns {{icon: string, label: string, ext: string}}
    */
   service.mimeIcon = (mimetype) => {
-    let result = {};
-    let ext;
+    const type = (mimetype || '').toLowerCase();
 
-    if (mimetype.indexOf('image') > -1) {
-       
-      ext = (mimetype.indexOf('jpg') > -1 || mimetype.indexOf('jpeg') > -1) ? '.jpg'
-        : (mimetype.indexOf('png') > -1) ? '.png'
-          : (mimetype.indexOf('gif') > -1) ? '.gif' : '';
+    const DEFAULT_RESULT = { icon: 'fa-file-o', label: 'Fichier', ext: '' };
 
-      result = { icon : 'fa-file-image-o', label : 'Image', ext };
-    } else if (mimetype.indexOf('pdf') > -1) {
-      result = { icon : 'fa-file-pdf-o', label : 'PDF', ext : '.pdf' };
-    } else if (mimetype.indexOf('word') > -1) {
-      result = { icon : 'fa-file-word-o', label : 'MS WORD', ext : '.doc' };
-    } else if (mimetype.indexOf('sheet') > -1) {
-      result = { icon : 'fa-file-excel-o', label : 'MS EXCEL', ext : '.xls' };
-    } else if (mimetype.indexOf('presentation') > -1) {
-      result = { icon : 'fa-file-powerpoint-o', label : 'MS Power Point', ext : '.ppt' };
-    } else {
-      result = { icon : 'fa-file-o', label : 'Fichier', ext : '' };
+    const IMAGE_EXTENSIONS = [
+      { match: ['jpg', 'jpeg'], ext: '.jpg' },
+      { match: ['png'], ext: '.png' },
+      { match: ['gif'], ext: '.gif' },
+    ];
+
+    const MIME_MAP = [
+      { match: 'pdf', icon: 'fa-file-pdf-o', label: 'PDF', ext: '.pdf' },
+      { match: 'word', icon: 'fa-file-word-o', label: 'MS WORD', ext: '.doc' },
+      { match: 'sheet', icon: 'fa-file-excel-o', label: 'MS EXCEL', ext: '.xls' },
+      { match: 'presentation', icon: 'fa-file-powerpoint-o', label: 'MS Power Point', ext: '.ppt' },
+    ];
+
+    if (type.includes('image')) {
+      const found = IMAGE_EXTENSIONS.find(({ match }) => match.some((m) => type.includes(m)));
+      return { icon: 'fa-file-image-o', label: 'Image', ext: found ? found.ext : '' };
     }
 
-    return result;
+    const found = MIME_MAP.find(({ match }) => type.includes(match));
+    return found
+      ? { icon: found.icon, label: found.label, ext: found.ext }
+      : DEFAULT_RESULT;
   };
 }

--- a/client/src/modules/assets/modals/assign.modal.js
+++ b/client/src/modules/assets/modals/assign.modal.js
@@ -221,7 +221,8 @@ function AssetAssignmentModalController(
   function computeAvailableInventories(invData) {
     vm.globalAvailableLots = invData;
     vm.groupedInventories = Util.groupBy(invData, 'inventory_uuid');
-    const uniqueInventoriesUuids = Util.uniquelize(invData.map(item => item.inventory_uuid));
+
+    const uniqueInventoriesUuids = Array.from(new Set(invData.map(item => item.inventory_uuid)));
     vm.availableInventories = uniqueInventoriesUuids.map(inventoryUuid => vm.groupedInventories[inventoryUuid][0]);
     vm.availableInventories.forEach(item => {
       item.hrLabel = `[${item.code}] ${item.text}`;

--- a/test/client-unit/services/util.spec.js
+++ b/test/client-unit/services/util.spec.js
@@ -122,24 +122,6 @@ describe('test/client-unit/services/util', () => {
     expect(util.filterFormElements(form)).to.deep.equal(expected);
   });
 
-  it('#clean() should filter out all properties that have empty values or that begin with $', () => {
-    const data = {
-      $$hashKey : '8339Gh1',
-      $modelValue : 10,
-      $dirty : true,
-      name : 'Alice',
-      test : null,
-    };
-
-    const expected = {
-      $modelValue : 10,
-      $dirty : true,
-      name : 'Alice',
-    };
-    const formatedData = util.clean(data);
-    expect(formatedData).to.deep.equal(expected);
-  });
-
   it('#getMomentAge() should return a number', () => {
     const date = new Date();
     const expected = 'number';
@@ -152,13 +134,6 @@ describe('test/client-unit/services/util', () => {
     expect(defaultBirthMonth).to.not.equal(null);
   });
 
-  it('#uniquelize should turn an array into unique values', () => {
-    const data = ['name', 'gender', 'label', 'name', 'gender'];
-    const expected = ['name', 'gender', 'label'];
-    const formatedData = util.uniquelize(data);
-    expect(formatedData).to.deep.equal(expected);
-  });
-
   it('#isEmptyObject() should turn true for {}', () => {
     const data = {};
     const expected = true;
@@ -169,6 +144,13 @@ describe('test/client-unit/services/util', () => {
   it('#isEmptyObject() should turn true for []', () => {
     const data = [];
     const expected = true;
+    const formatedData = util.isEmptyObject(data);
+    expect(formatedData).to.be.equal(expected);
+  });
+
+  it('#isEmptyObject() should turn false for { x : 1 }', () => {
+    const data = { x : 1};
+    const expected = false;
     const formatedData = util.isEmptyObject(data);
     expect(formatedData).to.be.equal(expected);
   });
@@ -306,4 +288,75 @@ describe('test/client-unit/services/util', () => {
     expect(util.getUniqueBy(sample, 'notfound')).to.deep.equal([sample[0]]);
   });
 
+  it('#mimeIcon() should return image icon and .jpg ext for image/jpeg mimetype', () => {
+    const expected = { icon : 'fa-file-image-o', label : 'Image', ext : '.jpg' };
+    const result = util.mimeIcon('image/jpeg');
+    expect(result).to.deep.equal( expected);
+  });
+
+  it('#mimeIcon() should return image icon and .jpg ext for image/jpg mimetype', () => {
+    const expected = { icon : 'fa-file-image-o', label : 'Image', ext : '.jpg' };
+    const result = util.mimeIcon('image/jpg');
+    expect(result).to.deep.equal( expected);
+  });
+
+  it('#mimeIcon() should return image icon and .png ext for image/png mimetype', () => {
+    const expected = { icon : 'fa-file-image-o', label : 'Image', ext : '.png' };
+    const result = util.mimeIcon('image/png');
+    expect(result).to.deep.equal( expected);
+  });
+
+  it('#mimeIcon() should return image icon and .gif ext for image/gif mimetype', () => {
+    const expected = { icon : 'fa-file-image-o', label : 'Image', ext : '.gif' };
+    const result = util.mimeIcon('image/gif');
+    expect(result).to.deep.equal( expected);
+  });
+
+  it('#mimeIcon() should return image icon with empty ext for unrecognized image subtype', () => {
+    const expected = { icon : 'fa-file-image-o', label : 'Image', ext : '' };
+    const result = util.mimeIcon('image/svg+xml');
+    expect(result).to.deep.equal( expected);
+  });
+
+  it('#mimeIcon() should return PDF icon and .pdf ext for application/pdf mimetype', () => {
+    const expected = { icon : 'fa-file-pdf-o', label : 'PDF', ext : '.pdf' };
+    const result = util.mimeIcon('application/pdf');
+    expect(result).to.deep.equal(expected);
+  });
+
+  it('#mimeIcon() should return Word icon and .doc ext for msword mimetype', () => {
+    const expected = { icon : 'fa-file-word-o', label : 'MS WORD', ext : '.doc' };
+    const result = util.mimeIcon('application/msword');
+    expect(result).to.deep.equal(expected);
+  });
+
+  it('#mimeIcon() should return Word icon and .doc ext for openxmlformats word mimetype', () => {
+    const expected = { icon : 'fa-file-word-o', label : 'MS WORD', ext : '.doc' };
+    const result = util.mimeIcon('application/vnd.openxmlformats-officedocument.wordprocessingml.document');
+    expect(result).to.deep.equal(expected);
+  });
+
+  it('#mimeIcon() should return Excel icon and .xls ext for spreadsheet mimetype', () => {
+    const expected = { icon : 'fa-file-excel-o', label : 'MS EXCEL', ext : '.xls' };
+    const result = util.mimeIcon('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+    expect(result).to.deep.equal( expected);
+  });
+
+  it('#mimeIcon() should return PowerPoint icon and .ppt ext for presentation mimetype', () => {
+    const expected = { icon : 'fa-file-powerpoint-o', label : 'MS Power Point', ext : '.ppt' };
+    const result = util.mimeIcon('application/vnd.openxmlformats-officedocument.presentationml.presentation');
+    expect(result).to.deep.equal( expected);
+  });
+
+  it('#mimeIcon() should return generic file icon for unrecognized mimetype', () => {
+    const expected = { icon : 'fa-file-o', label : 'Fichier', ext : '' };
+    const result = util.mimeIcon('application/octet-stream');
+    expect(result).to.deep.equal(expected);
+  });
+
+  it('#mimeIcon() should be case-insensitive when matching mimetype', () => {
+    const expected = { icon : 'fa-file-pdf-o', label : 'PDF', ext : '.pdf' };
+    const result = util.mimeIcon('APPLICATION/PDF');
+    expect(result).to.deep.equal(expected);
+  });
 });


### PR DESCRIPTION
This PR drops unused utilities like uniquelize() that are only used in a single location.  It replaces them with more modern versions where possible.

It also writes more tests for the client util.js service.