### PR TITLE
Use single UUID map

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -144,9 +144,9 @@
       "license": "MIT"
     },
     "node_modules/@es-joy/jsdoccomment": {
-      "version": "0.90.0",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.90.0.tgz",
-      "integrity": "sha512-51x9KxyTAN6guZOCd+lmcDdkhgdMdP/6iMMtg9dyhCWDc3+iSUyoB7f/9WAM/yGHmGFq25Vd6bXRR7CZcB+tog==",
+      "version": "0.91.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.91.0.tgz",
+      "integrity": "sha512-vgqlMGNNhZxwDYbUNIHj3Hskb4R28iqdXx90ufHyt/NeuTQkeqjTDslAs9I0/GCAfbxP5BpH5WsL1R1fht5Lxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -154,7 +154,7 @@
         "@typescript-eslint/types": "^8.65.0",
         "comment-parser": "1.4.7",
         "esquery": "^1.7.0",
-        "jsdoc-type-pratt-parser": "~7.3.0"
+        "jsdoc-type-pratt-parser": "~8.0.0"
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
@@ -171,9 +171,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
-      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -249,9 +249,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
-      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1771,9 +1771,9 @@
       "license": "MIT"
     },
     "node_modules/acorn": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
-      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -2281,9 +2281,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.43",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
-      "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
+      "version": "2.11.5",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.5.tgz",
+      "integrity": "sha512-xJo6a6YZnwZfnyGmQKWMbVOcii7XRibjOskRh+WJ9UHQoX16xrQrcIgAMQOzfvs8XiLMx6ih/fsLPF73iY2D1A==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2422,15 +2422,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -2454,9 +2454,9 @@
       "license": "ISC"
     },
     "node_modules/browserslist": {
-      "version": "4.28.6",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
-      "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
       "dev": true,
       "funding": [
         {
@@ -2474,9 +2474,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.42",
-        "caniuse-lite": "^1.0.30001803",
-        "electron-to-chromium": "^1.5.389",
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
         "node-releases": "^2.0.51",
         "update-browserslist-db": "^1.2.3"
       },
@@ -4146,9 +4146,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.393",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.393.tgz",
-      "integrity": "sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==",
+      "version": "1.5.397",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.397.tgz",
+      "integrity": "sha512-khGTy9U9x02KEtsKM8vx5A62BsRmcOsIgDpWr1ImE32Ax8GxHGPHZf+Eu9H8zOOyHJnB0jTbseyTHbq2XCT8yw==",
       "dev": true,
       "license": "ISC"
     },
@@ -4411,9 +4411,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.7.0.tgz",
-      "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
+      "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -4423,7 +4423,7 @@
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/config-helpers": "^0.7.0",
         "@eslint/core": "^1.2.1",
         "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
@@ -4447,7 +4447,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.4",
+        "minimatch": "^10.2.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -4470,13 +4470,13 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "63.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.3.1.tgz",
-      "integrity": "sha512-yVyTPtOY2tA8EjTwUtaM3pFxj9i/3m4/FSPMv5gMnDHSSleCpzIYQLyV8KnVmEIkkPpNhDlkDQ99mTfjxgqLxA==",
+      "version": "63.3.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.3.2.tgz",
+      "integrity": "sha512-5B3oO23iqbNJC/ru7uqIY80wmY66De1Q0+5kXQGHuLrGze/rL0Zw/YktMcqgYQ+kdHmgvY1q5TpRgl3yZMLmhQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@es-joy/jsdoccomment": "~0.90.0",
+        "@es-joy/jsdoccomment": "~0.91.0",
         "@es-joy/resolve.exports": "1.2.0",
         "are-docs-informative": "^0.0.2",
         "comment-parser": "1.4.7",
@@ -4812,9 +4812,9 @@
       "license": "MIT"
     },
     "node_modules/exsolve": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.0.tgz",
-      "integrity": "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.1.tgz",
+      "integrity": "sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==",
       "dev": true,
       "license": "MIT"
     },
@@ -5132,9 +5132,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.3.tgz",
+      "integrity": "sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -7490,9 +7490,9 @@
       "license": "MIT"
     },
     "node_modules/jsdoc-type-pratt-parser": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.3.0.tgz",
-      "integrity": "sha512-DoyJXo7x/n48M3NsGOs9QnEws0ft0tV3YsSgvWMNxz2hZtz+Q6fpqUD96lVYX4a+jcEkzHeFNDJOn68TzXfbdA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-8.0.0.tgz",
+      "integrity": "sha512-uQu/fXVqVaMg6gM8/E5G5+eygVcZ1NV0Z51CvqhNa2bDWxvHMl484ETr6vph4oPyC+KUcbP/w2W2pewfCiR9aQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7994,9 +7994,9 @@
       }
     },
     "node_modules/less": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/less/-/less-4.7.0.tgz",
-      "integrity": "sha512-i7dAlT3+boO0mMh1G4cex0vz1lLAScmBbikm1VEDNv+cy0ore1CUo2UtX8m3N9QLE5WYDr4ISbiCRzHNGyFkrA==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/less/-/less-4.8.1.tgz",
+      "integrity": "sha512-jQ3lRIo1aUtiWVYXZ7mk4+V4BjCGswF3IxTLJ+4RUta8ZiHh8lhkig2G8dya2eCcyR1dYUvzuV46EkJN8PSwww==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -8390,12 +8390,16 @@
       "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/merge-descriptors": {
@@ -8514,12 +8518,12 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -8671,9 +8675,9 @@
       "license": "MIT"
     },
     "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9608,9 +9612,9 @@
       }
     },
     "node_modules/p-map": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.5.tgz",
-      "integrity": "sha512-e8vJF4XdVkzqqSHguEMz41mQO1wKwxKm5ENrUJQUu9kLDCtn83cxbyHZcszr4QC5zEA7WffRRC4gsTecC7J9oA==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.6.tgz",
+      "integrity": "sha512-I4Prw6ivkd6p8PiYR1tXASOAOBzIJwu0TB7fqaX0c/8c3QAehNYmX57EijyGGGBt3c/BIowGwV03RVBtXvHEVg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10030,9 +10034,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.23",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
-      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "version": "8.5.24",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.24.tgz",
+      "integrity": "sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==",
       "dev": true,
       "funding": [
         {
@@ -11750,9 +11754,9 @@
       "license": "MIT"
     },
     "node_modules/sax": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
-      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"

--- a/server/controllers/asset_management/shipment/reports/shipment-barcode.js
+++ b/server/controllers/asset_management/shipment/reports/shipment-barcode.js
@@ -21,9 +21,9 @@ async function getBarcode(req, res) {
 
   const sql = `
     SELECT
-      BUID(s.uuid) AS uuid, s.name, dm.text AS reference
+      BUID(s.uuid) AS uuid, s.name, dm.short_name AS reference
     FROM shipment s 
-    JOIN document_map dm ON dm.uuid = s.uuid
+    JOIN uuid_map dm ON dm.uuid = s.uuid
     WHERE s.uuid = ?;
   `;
 

--- a/server/controllers/asset_management/shipment/shipment.js
+++ b/server/controllers/asset_management/shipment/shipment.js
@@ -555,8 +555,8 @@ function find(params) {
       BUID(sh.uuid) AS uuid,
       ss.translation_key AS status,
       ss.id AS status_id,
-      dm.text AS reference,
-      dm2.text AS stock_reference,
+      dm.short_name AS reference,
+      dm2.short_name AS stock_reference,
       BUID(sh.origin_depot_uuid) AS origin_depot_uuid,
       d.text AS origin_depot,
       BUID(sh.destination_depot_uuid) AS destination_depot_uuid,
@@ -571,9 +571,9 @@ function find(params) {
     JOIN shipment_status ss ON ss.id = sh.status_id
     JOIN depot d ON d.uuid = sh.origin_depot_uuid
     JOIN depot d2 ON d2.uuid = sh.destination_depot_uuid
-    JOIN document_map dm ON dm.uuid = sh.uuid
+    JOIN uuid_map dm ON dm.uuid = sh.uuid
     JOIN user u ON u.id = sh.created_by
-    LEFT JOIN document_map dm2 ON dm2.uuid = sh.document_uuid
+    LEFT JOIN uuid_map dm2 ON dm2.uuid = sh.document_uuid
   `;
 
   // depot permission check
@@ -606,13 +606,13 @@ function findAllocatedAssets(params) {
       BUID(shi.lot_uuid) AS lot_uuid, shi.quantity_sent,
       l.label AS lot_label, i.code AS inventory_code,
       i.text AS inventory_text, i.is_asset,
-      dm.text AS reference
+      dm.short_name AS reference
     FROM shipment sh
     JOIN shipment_item shi ON shi.shipment_uuid = sh.uuid
     JOIN lot l ON l.uuid = shi.lot_uuid
     JOIN inventory i ON i.uuid = l.inventory_uuid
     JOIN depot d ON d.uuid = sh.origin_depot_uuid
-    LEFT JOIN document_map dm ON dm.uuid = sh.uuid
+    LEFT JOIN uuid_map dm ON dm.uuid = sh.uuid
   `;
 
   const query = filters.applyQuery(sql);
@@ -627,8 +627,8 @@ async function lookup(identifier) {
       ss.translation_key AS status,
       ss.id AS status_id,
       ss.name AS status_name,
-      dm.text AS reference,
-      dm2.text AS stock_reference,
+      dm.short_name AS reference,
+      dm2.short_name AS stock_reference,
       d.text AS origin_depot,
       BUID(sh.origin_depot_uuid) AS origin_depot_uuid,
       d2.text AS destination_depot,
@@ -651,10 +651,10 @@ async function lookup(identifier) {
     JOIN inventory_unit iu ON iu.id = inv.unit_id
     JOIN depot d ON d.uuid = sh.origin_depot_uuid
     JOIN depot d2 ON d2.uuid = sh.destination_depot_uuid
-    JOIN document_map dm ON dm.uuid = sh.uuid
+    JOIN uuid_map dm ON dm.uuid = sh.uuid
     JOIN user u ON u.id = sh.created_by
     LEFT JOIN shipment_container sc ON sc.uuid = shi.container_uuid
-    LEFT JOIN document_map dm2 ON dm2.uuid = sh.document_uuid
+    LEFT JOIN uuid_map dm2 ON dm2.uuid = sh.document_uuid
     WHERE sh.uuid = ?
   `;
 
@@ -691,8 +691,8 @@ async function lookupSingle(identifier) {
       ss.translation_key AS status,
       ss.id AS status_id,
       ss.name AS status_name,
-      dm.text AS reference,
-      dm2.text AS stock_reference,
+      dm.short_name AS reference,
+      dm2.short_name AS stock_reference,
       d.text AS origin_depot,
       BUID(sh.origin_depot_uuid) AS origin_depot_uuid,
       d2.text AS destination_depot,
@@ -707,9 +707,9 @@ async function lookupSingle(identifier) {
     JOIN shipment_status ss ON ss.id = sh.status_id
     JOIN depot d ON d.uuid = sh.origin_depot_uuid
     JOIN depot d2 ON d2.uuid = sh.destination_depot_uuid
-    JOIN document_map dm ON dm.uuid = sh.uuid
+    JOIN uuid_map dm ON dm.uuid = sh.uuid
     JOIN user u ON u.id = sh.created_by
-    LEFT JOIN document_map dm2 ON dm2.uuid = sh.document_uuid
+    LEFT JOIN uuid_map dm2 ON dm2.uuid = sh.document_uuid
     WHERE sh.uuid = ?
   `;
 
@@ -759,7 +759,7 @@ async function getPackingList(identifier) {
       i.manufacturer_brand AS brand, i.manufacturer_model AS model,
       IF(ISNULL(iu.token), iu.text, CONCAT("INVENTORY.UNITS.",iu.token,".TEXT")) AS unit_type,
       sc.label AS container_label,
-      dm.text AS reference
+      dm.short_name AS reference
     FROM shipment sh
     JOIN shipment_status ss ON ss.id = sh.status_id
     JOIN shipment_item shi ON shi.shipment_uuid = sh.uuid
@@ -769,7 +769,7 @@ async function getPackingList(identifier) {
     JOIN stock_value sv ON sv.inventory_uuid = i.uuid
     JOIN user u ON u.id = sh.created_by
     LEFT JOIN shipment_container sc ON sc.uuid = shi.container_uuid
-    JOIN document_map dm ON dm.uuid = sh.uuid
+    JOIN uuid_map dm ON dm.uuid = sh.uuid
     WHERE sh.uuid = ?
     ORDER BY container_label, inventory_label, lot_label
   `;

--- a/server/controllers/asset_management/shipment/shipment.js
+++ b/server/controllers/asset_management/shipment/shipment.js
@@ -466,6 +466,10 @@ exports.findAllocatedAssets = async (req, res) => {
   res.status(200).json(result);
 };
 
+/**
+ *
+ * @param parameters
+ */
 function getShipmentFilters(parameters) {
   // clone the parameters
   const params = { ...parameters };
@@ -494,7 +498,7 @@ function getShipmentFilters(parameters) {
   filters.equals('group_uuid', 'uuid', 'ig');
   filters.equals('text', 'text', 'i');
   filters.equals('label', 'label', 'l');
-  filters.equals('reference', 'text', 'dm');
+  filters.equals('reference', 'short_name', 'dm');
   filters.equals('is_asset', 'is_asset', 'i');
   filters.equals('project_id', 'project_id', 'sh');
 
@@ -548,6 +552,10 @@ function getShipmentFilters(parameters) {
   return filters;
 }
 
+/**
+ *
+ * @param params
+ */
 function find(params) {
   const filters = getShipmentFilters(params);
   const sql = `
@@ -598,6 +606,10 @@ function find(params) {
   return db.exec(query, queryParameters);
 }
 
+/**
+ *
+ * @param params
+ */
 function findAllocatedAssets(params) {
   const filters = getShipmentFilters(params);
   const sql = `
@@ -620,6 +632,10 @@ function findAllocatedAssets(params) {
   return db.exec(query, queryParameters);
 }
 
+/**
+ *
+ * @param identifier
+ */
 async function lookup(identifier) {
   const sql = `
     SELECT
@@ -684,6 +700,10 @@ async function lookup(identifier) {
   return shipment;
 }
 
+/**
+ *
+ * @param identifier
+ */
 async function lookupSingle(identifier) {
   const sql = `
     SELECT
@@ -716,6 +736,10 @@ async function lookupSingle(identifier) {
   return db.one(sql, [db.bid(identifier)]);
 }
 
+/**
+ *
+ * @param shipmentUuid
+ */
 async function isShipmentExists(shipmentUuid) {
   if (!shipmentUuid) { return false; }
 
@@ -724,6 +748,13 @@ async function isShipmentExists(shipmentUuid) {
   return !!result;
 }
 
+/**
+ *
+ * @param tx
+ * @param shipmentUuid
+ * @param note
+ * @param userId
+ */
 function addTrackingLogMessage(tx, shipmentUuid, note, userId) {
   if (!shipmentUuid) {
     // In regtests we may not have the shipment uuid, so skip this
@@ -738,6 +769,10 @@ function addTrackingLogMessage(tx, shipmentUuid, note, userId) {
   tx.addQuery('INSERT INTO shipment_tracking SET ?;', [logInfo]);
 }
 
+/**
+ *
+ * @param identifier
+ */
 async function getPackingList(identifier) {
   const sql = `
     SELECT
@@ -777,6 +812,10 @@ async function getPackingList(identifier) {
   return db.exec(sql, [db.bid(identifier)]);
 }
 
+/**
+ *
+ * @param shipmentUuid
+ */
 async function getShipmentInfo(shipmentUuid) {
   const sql = `
     SELECT BUID(s.uuid) uuid, s.date, s.note, u.display_name
@@ -789,6 +828,10 @@ async function getShipmentInfo(shipmentUuid) {
   return db.exec(sql, [db.bid(shipmentUuid)]);
 }
 
+/**
+ *
+ * @param identifier
+ */
 async function deleteShipment(identifier) {
   const [shipmentStatus] = await db.exec(
     'SELECT status_id FROM shipment WHERE uuid = ?',
@@ -812,7 +855,7 @@ async function deleteShipment(identifier) {
 /**
  * @function getStep
  * @param {string} statusName
- * @desc returns the step according the shipment status
+ * @description returns the step according the shipment status
  * AT_DEPOT => Step 1
  * READY_TO_SHIP => Step 2
  * IN_TRANSIT => Step 3

--- a/server/controllers/finance/accounts/transactions.js
+++ b/server/controllers/finance/accounts/transactions.js
@@ -160,7 +160,7 @@ async function getAccountTransactions(options, openingBalance = 0) {
  *
  * Constructs a single SQL statement (plus parameters) that:
  * 1) Builds a combined ledger from general_ledger and (optionally) posting_journal
- * 2) Joins the document_map
+ * 2) Joins the uuid_map
  * 3) Sums results grouped by record_uuid
  * 4) Converts amounts using a rate
  * 5) Computes a running total (cumsum) using a window function
@@ -198,7 +198,7 @@ function buildLedgerSQL(options, openingBalance = 0) {
       trans_id,
       description,
       trans_date,
-      document_map.text AS document_reference,
+      uuid_map.text AS document_reference,
       created_at,
       transaction_type_id,
       MAX(currency_id) AS currency_id,
@@ -215,7 +215,7 @@ function buildLedgerSQL(options, openingBalance = 0) {
         )
       ) AS rate
     FROM ${unionSQL}
-    LEFT JOIN document_map ON ledger.record_uuid = document_map.uuid
+    LEFT JOIN uuid_map ON ledger.record_uuid = uuid_map.uuid
   `;
 
   // Apply grouping and ordering from FilterParser

--- a/server/controllers/finance/accounts/transactions.js
+++ b/server/controllers/finance/accounts/transactions.js
@@ -198,7 +198,7 @@ function buildLedgerSQL(options, openingBalance = 0) {
       trans_id,
       description,
       trans_date,
-      uuid_map.text AS document_reference,
+      uuid_map.short_name AS document_reference,
       created_at,
       transaction_type_id,
       MAX(currency_id) AS currency_id,

--- a/server/controllers/finance/allocationCostCenter/getDistributed.js
+++ b/server/controllers/finance/allocationCostCenter/getDistributed.js
@@ -1,12 +1,17 @@
 /**
-* Distribution Cost Center Controller
-*
-* This function searches all the distributions of the costs and profits made, in order to allow possible updates.
-*/
+ * Distribution Cost Center Controller
+ *
+ * This function searches all the distributions of the costs and profits made, in order to allow possible updates.
+ */
 const fiscal = require('../fiscal');
 const db = require('../../../lib/db');
 const FilterParser = require('../../../lib/filter');
 
+/**
+ *
+ * @param req
+ * @param res
+ */
 async function getDistributed(req, res) {
   const options = req.query;
 
@@ -36,7 +41,7 @@ async function getDistributed(req, res) {
       fc.date_distribution, fc.user_id, gl.project_id, gl.fiscal_year_id, gl.period_id, gl.trans_date,
       gl.description, gl.transaction_type_id, BUID(gl.record_uuid) AS record_uuid, gl.entity_uuid,
       BUID(gl.reference_uuid) AS reference_uuid, ac.number AS account_number, ac.label AS account_label,
-      aux.label AS cost_center_label, pri.label AS principal_label, dm1.text AS hrRecord, dm2.text AS hrReference,
+      aux.label AS cost_center_label, pri.label AS principal_label, dm1.short_name AS hrRecord, dm2.short_name AS hrReference,
       u.display_name AS user_name
       FROM cost_center_allocation AS fc
       JOIN general_ledger AS gl ON gl.uuid = fc.row_uuid
@@ -44,8 +49,8 @@ async function getDistributed(req, res) {
       JOIN cost_center AS aux ON aux.id = fc.auxiliary_cost_center_id
       JOIN cost_center AS pri ON pri.id = fc.principal_cost_center_id
       JOIN user AS u ON u.id = fc.user_id
-      LEFT JOIN document_map dm1 ON dm1.uuid = gl.record_uuid
-      LEFT JOIN document_map dm2 ON dm2.uuid = gl.reference_uuid
+      LEFT JOIN uuid_map dm1 ON dm1.uuid = gl.record_uuid
+      LEFT JOIN uuid_map dm2 ON dm2.uuid = gl.reference_uuid
     `;
 
   filters.dateFrom('custom_period_start', 'trans_date', 'gl');

--- a/server/controllers/finance/cash.js
+++ b/server/controllers/finance/cash.js
@@ -150,8 +150,8 @@ function find(options) {
 
   filters.fullText('description');
 
-  filters.equals('reference', 'text', 'dm');
-  filters.equals('patientReference', 'text', 'em');
+  filters.equals('reference', 'short_name', 'dm');
+  filters.equals('patientReference', 'short_name', 'em');
 
   // @TODO Support ordering query (reference support for limit)?
   filters.setOrder('ORDER BY cash.date DESC');

--- a/server/controllers/finance/cash.js
+++ b/server/controllers/finance/cash.js
@@ -49,24 +49,24 @@ async function lookup(uuid) {
   const bid = db.bid(uuid);
 
   const cashRecordSql = `
-    SELECT BUID(cash.uuid) as uuid, cash.project_id, dm.text AS reference,
-      d.text as debtorName, em.text as debtorReference,
+    SELECT BUID(cash.uuid) as uuid, cash.project_id, dm.short_name AS reference,
+      d.text as debtorName, em.short_name as debtorReference,
       cash.date, cash.created_at, BUID(cash.debtor_uuid) AS debtor_uuid, cash.currency_id, cash.amount,
       cash.description, cash.cashbox_id, cash.is_caution, cash.user_id, cash.edited, cash.posted
     FROM cash JOIN project ON cash.project_id = project.id
-      JOIN document_map dm ON cash.uuid = dm.uuid
+      JOIN uuid_map dm ON cash.uuid = dm.uuid
       JOIN debtor d ON d.uuid = cash.debtor_uuid
-      JOIN entity_map em On d.uuid = em.uuid
+      JOIN uuid_map em On d.uuid = em.uuid
     WHERE cash.uuid = ?;
   `;
 
   const cashItemsRecordSql = `
     SELECT BUID(ci.uuid) AS uuid, ci.amount, BUID(ci.invoice_uuid) AS invoice_uuid,
-      s.name AS serviceName, dm.text AS reference
+      s.name AS serviceName, dm.short_name AS reference
     FROM cash_item AS ci
       JOIN invoice AS i ON ci.invoice_uuid = i.uuid
       JOIN project AS p ON i.project_id = p.id
-      JOIN document_map dm ON i.uuid = dm.uuid
+      JOIN uuid_map dm ON i.uuid = dm.uuid
       LEFT JOIN service AS s ON i.service_uuid = s.uuid
     WHERE ci.cash_uuid = ?
     ORDER BY i.date ASC;
@@ -118,17 +118,17 @@ function find(options) {
   const filters = new FilterParser(options, { tableAlias : 'cash' });
 
   const sql = `
-    SELECT BUID(cash.uuid) as uuid, cash.project_id, dm.text as reference,
+    SELECT BUID(cash.uuid) as uuid, cash.project_id, dm.short_name as reference,
       cash.date, cash.created_at,  BUID(cash.debtor_uuid) AS debtor_uuid, cash.currency_id,
       cash.amount, cash.description, cash.cashbox_id, cash.is_caution, cash.user_id,
       cash.reversed, d.text AS debtor_name, cb.label AS cashbox_label, u.display_name,
-      p.display_name AS patientName, em.text AS patientReference, cash.edited, cash.created_at
+      p.display_name AS patientName, em.short_name AS patientReference, cash.edited, cash.created_at
     FROM cash
-      JOIN document_map dm ON dm.uuid = cash.uuid
+      JOIN uuid_map dm ON dm.uuid = cash.uuid
       JOIN project ON cash.project_id = project.id
       JOIN debtor d ON d.uuid = cash.debtor_uuid
       JOIN patient p on p.debtor_uuid = d.uuid
-      JOIN entity_map em ON em.uuid = p.uuid
+      JOIN uuid_map em ON em.uuid = p.uuid
       JOIN cash_box cb ON cb.id = cash.cashbox_id
       JOIN user u ON u.id = cash.user_id
   `;
@@ -278,7 +278,7 @@ function safelyDeleteCashPayment(uuid) {
   `;
 
   const DELETE_DOCUMENT_MAP = `
-    DELETE FROM document_map WHERE uuid = ?;
+    DELETE FROM uuid_map WHERE uuid = ?;
   `;
 
   return shared.isRemovableTransaction(uuid)

--- a/server/controllers/finance/creditors.js
+++ b/server/controllers/finance/creditors.js
@@ -30,16 +30,16 @@ async function list(req, res) {
 
   const sql = `
     SELECT BUID(c.uuid) as uuid, c.text, cg.name, BUID(c.group_uuid) as group_uuid,
-      a.id AS account_id, a.number, em.text as hrEntity
+      a.id AS account_id, a.number, em.short_name as hrEntity
     FROM creditor AS c
     JOIN creditor_group AS cg
     JOIN account AS a ON c.group_uuid = cg.uuid AND cg.account_id = a.id
-    LEFT JOIN entity_map me ON em.uuid = c.uuid
+    LEFT JOIN uuid_map me ON em.uuid = c.uuid
   `;
 
   filters.equals('uuid');
   filters.equals('creditor_uuid');
-  filters.custom('hrEntity', 'em.text = ?');
+  filters.custom('hrEntity', 'em.short_name = ?');
 
   const query = filters.applyQuery(sql);
   const parameters = filters.parameters();
@@ -157,20 +157,20 @@ async function getFinancialActivity(creditorUuid, dateFrom, dateTo) {
       SUM(balance) OVER (ORDER BY trans_date ASC, trans_id) AS cumsum
     FROM (
       SELECT p.trans_id, p.entity_uuid, p.description, p.record_uuid, p.trans_date,
-        SUM(p.debit_equiv) AS debit, SUM(p.credit_equiv) AS credit, dm.text AS document,
+        SUM(p.debit_equiv) AS debit, SUM(p.credit_equiv) AS credit, dm.short_name AS document,
         SUM(p.credit_equiv) - SUM(p.debit_equiv) AS balance, 0 AS posted
       FROM posting_journal AS p
-        LEFT JOIN document_map AS dm ON dm.uuid = p.record_uuid
+        LEFT JOIN uuid_map AS dm ON dm.uuid = p.record_uuid
       WHERE p.entity_uuid = ? ${filterBydatePosting}
       GROUP BY p.record_uuid
 
       UNION ALL
 
       SELECT g.trans_id, g.entity_uuid, g.description, g.record_uuid, g.trans_date,
-        SUM(g.debit_equiv) AS debit, SUM(g.credit_equiv) AS credit, dm.text AS document,
+        SUM(g.debit_equiv) AS debit, SUM(g.credit_equiv) AS credit, dm.short_name AS document,
         SUM(g.credit_equiv) - SUM(g.debit_equiv) AS balance, 1 AS posted
       FROM general_ledger AS g
-        LEFT JOIN document_map AS dm ON dm.uuid = g.record_uuid
+        LEFT JOIN uuid_map AS dm ON dm.uuid = g.record_uuid
       WHERE g.entity_uuid = ? ${filterBydateLegder}
       GROUP BY g.record_uuid
     )z ORDER BY trans_date ASC, trans_id;

--- a/server/controllers/finance/debtors/groups/index.js
+++ b/server/controllers/finance/debtors/groups/index.js
@@ -296,7 +296,7 @@ function loadInvoices(params) {
   let sqlInvoices = `
     SELECT BUID(i.uuid) as uuid, CONCAT_WS('.', '${identifiers.INVOICE.key}', project.abbr, i.reference) AS reference,
       SUM(debit) AS debit, SUM(credit) AS credit, SUM(debit - credit) AS balance, BUID(entity_uuid) AS entity_uuid,
-      i.date, uuid_map.text AS entityReference
+      i.date, uuid_map.short_name AS entityReference
     FROM (
       SELECT record_uuid AS uuid, trans_date AS date, debit_equiv AS debit, credit_equiv AS credit,
         entity_uuid, invoice.reference, invoice.project_id

--- a/server/controllers/finance/debtors/groups/index.js
+++ b/server/controllers/finance/debtors/groups/index.js
@@ -296,7 +296,7 @@ function loadInvoices(params) {
   let sqlInvoices = `
     SELECT BUID(i.uuid) as uuid, CONCAT_WS('.', '${identifiers.INVOICE.key}', project.abbr, i.reference) AS reference,
       SUM(debit) AS debit, SUM(credit) AS credit, SUM(debit - credit) AS balance, BUID(entity_uuid) AS entity_uuid,
-      i.date, entity_map.text AS entityReference
+      i.date, uuid_map.text AS entityReference
     FROM (
       SELECT record_uuid AS uuid, trans_date AS date, debit_equiv AS debit, credit_equiv AS credit,
         entity_uuid, invoice.reference, invoice.project_id
@@ -325,7 +325,7 @@ function loadInvoices(params) {
       WHERE entity_uuid IN (?) AND invoice.reversed <> 1
     ) AS i
     JOIN project ON i.project_id = project.id
-    JOIN entity_map ON i.entity_uuid = entity_map.uuid
+    JOIN uuid_map ON i.entity_uuid = uuid_map.uuid
     GROUP BY i.uuid
   `;
 

--- a/server/controllers/finance/debtors/index.js
+++ b/server/controllers/finance/debtors/index.js
@@ -40,13 +40,13 @@ async function list(req, res) {
 
   const sql = `
     SELECT BUID(d.uuid) AS uuid, BUID(d.group_uuid) AS group_uuid,
-      d.text, em.text as hrEntity
-    FROM debtor d JOIN entity_map em ON em.uuid = d.uuid
+      d.text, em.short_name as hrEntity
+    FROM debtor d JOIN uuid_map em ON em.uuid = d.uuid
   `;
 
   filters.equals('uuid');
   filters.equals('group_uuid');
-  filters.custom('hrEntity', 'em.text = ?');
+  filters.custom('hrEntity', 'em.short_name = ?');
 
   const query = filters.applyQuery(sql);
   const parameters = filters.parameters();
@@ -246,7 +246,7 @@ function invoiceBalances(debtorUuid, uuids, options = {}) {
 
     SELECT
       BUID(b.invoice_uuid) AS uuid,
-      dm.text AS reference,
+      dm.short_name AS reference,
       b.credit,
       b.debit,
       b.balance,
@@ -258,7 +258,7 @@ function invoiceBalances(debtorUuid, uuids, options = {}) {
       ON invoice.uuid = b.invoice_uuid
     JOIN project
       ON project.id = invoice.project_id
-    LEFT JOIN document_map dm
+    LEFT JOIN uuid_map dm
       ON dm.uuid = b.invoice_uuid
     ${orderBy};`;
 
@@ -325,7 +325,7 @@ async function getFinancialActivity(debtorUuid, excludeCautionLinks = false) {
     SUM(balance) OVER (ORDER BY trans_date ASC, trans_id) AS cumsum
     FROM (
       SELECT p.trans_id, p.entity_uuid, p.description, p.record_uuid, p.trans_date,
-        SUM(p.debit_equiv) AS debit, SUM(p.credit_equiv) AS credit, dm.text AS document,
+        SUM(p.debit_equiv) AS debit, SUM(p.credit_equiv) AS credit, dm.short_name AS document,
         SUM(p.debit_equiv) - SUM(p.credit_equiv) AS balance, 0 AS posted, created_at
       FROM (
         SELECT trans_id, entity_uuid, description, record_uuid, trans_date,
@@ -334,13 +334,13 @@ async function getFinancialActivity(debtorUuid, excludeCautionLinks = false) {
         WHERE entity_uuid = ? ${excludeCautionLinks ? excludeCautionLinkStatement : ''}
         ORDER BY CHAR_LENGTH(description) DESC
       ) AS p
-        LEFT JOIN document_map AS dm ON dm.uuid = p.record_uuid
+        LEFT JOIN uuid_map AS dm ON dm.uuid = p.record_uuid
       GROUP BY p.record_uuid
 
       UNION ALL
 
       SELECT g.trans_id, g.entity_uuid, g.description, g.record_uuid, g.trans_date,
-        SUM(g.debit_equiv) AS debit, SUM(g.credit_equiv) AS credit, dm.text AS document,
+        SUM(g.debit_equiv) AS debit, SUM(g.credit_equiv) AS credit, dm.short_name AS document,
         SUM(g.debit_equiv) - SUM(g.credit_equiv) AS balance, 0 AS posted, created_at
       FROM (
         SELECT trans_id, entity_uuid, description, record_uuid, trans_date,
@@ -349,7 +349,7 @@ async function getFinancialActivity(debtorUuid, excludeCautionLinks = false) {
         WHERE entity_uuid = ? ${excludeCautionLinks ? excludeCautionLinkStatement : ''}
         ORDER BY CHAR_LENGTH(description) DESC
       ) AS g
-        LEFT JOIN document_map AS dm ON dm.uuid = g.record_uuid
+        LEFT JOIN uuid_map AS dm ON dm.uuid = g.record_uuid
       GROUP BY g.record_uuid
     )z ORDER BY trans_date ASC, trans_id ASC;
   `;

--- a/server/controllers/finance/invoice/lookupConsumableInvoice.js
+++ b/server/controllers/finance/invoice/lookupConsumableInvoice.js
@@ -2,8 +2,9 @@ const db = require('../../../lib/db');
 const FilterParser = require('../../../lib/filter');
 
 /**
+ * @param req
+ * @param res
  * @function lookupConsumableInvoicePatient
- *
  * @description
  * This function returns an invoice details and all consumable inventories
  * related to this invoice.
@@ -20,7 +21,7 @@ async function lookupConsumableInvoicePatient(req, res) {
   const filters = new FilterParser(params);
 
   filters.equals('patientUuid', 'uuid', 'patient');
-  filters.equals('invoiceReference', 'text', 'dm');
+  filters.equals('invoiceReference', 'short_name', 'dm');
   filters.equals('invoiceUuid', 'uuid', 'invoice');
 
   const invoiceDetailQuery = `

--- a/server/controllers/finance/invoice/lookupConsumableInvoice.js
+++ b/server/controllers/finance/invoice/lookupConsumableInvoice.js
@@ -25,7 +25,7 @@ async function lookupConsumableInvoicePatient(req, res) {
 
   const invoiceDetailQuery = `
       SELECT
-        BUID(invoice.uuid) as uuid, dm.text AS reference,
+        BUID(invoice.uuid) as uuid, dm.short_name AS reference,
         invoice.description, BUID(invoice.debtor_uuid) AS debtor_uuid,
         patient.display_name AS debtor_name, BUID(patient.uuid) as patient_uuid,
         invoice.user_id, invoice.date, user.display_name, invoice.service_uuid,
@@ -34,7 +34,7 @@ async function lookupConsumableInvoicePatient(req, res) {
       LEFT JOIN patient ON patient.debtor_uuid = invoice.debtor_uuid
       JOIN service ON invoice.service_uuid = service.uuid
       JOIN user ON user.id = invoice.user_id
-      JOIN document_map AS dm ON dm.uuid = invoice.uuid`;
+      JOIN uuid_map AS dm ON dm.uuid = invoice.uuid`;
 
   const invoiceItemsQuery = `
       SELECT

--- a/server/controllers/finance/journal/index.js
+++ b/server/controllers/finance/journal/index.js
@@ -237,9 +237,9 @@ function buildTransactionQuery(options, posted) {
   }
 
   filters.equals('comment');
-  filters.equals('hrEntity', 'text', 'em');
-  filters.equals('hrRecord', 'text', 'dm1');
-  filters.equals('hrReference', 'text', 'dm2');
+  filters.equals('hrEntity', 'short_name', 'em');
+  filters.equals('hrRecord', 'short_name', 'dm1');
+  filters.equals('hrReference', 'short_name', 'dm2');
   filters.equals('entity_uuid');
   filters.equals('stockReference', 'reference_uuid', 'p');
   filters.custom('currency_id', 'c.id=?');
@@ -481,8 +481,7 @@ async function editTransaction(req, res) {
  */
 function transformColumns(rows, newRecord, transactionToEdit, setFiscalData) {
   const ACCOUNT_NUMBER_QUERY = 'SELECT id FROM account WHERE number = ?';
-  const ENTITY_QUERY = 'SELECT uuid FROM uuid_map WHERE text = ?';
-  const REFERENCE_QUERY = 'SELECT uuid FROM uuid_map  WHERE text = ?';
+  const UUID_QUERY = 'SELECT uuid FROM uuid_map WHERE short_name = ?';
   const EXCHANGE_RATE_QUERY = `
     SELECT ? * IF(enterprise.currency_id = ?, 1, GetExchangeRate(enterprise.id, ?, ?)) AS amount FROM enterprise
     JOIN project ON enterprise.id = project.enterprise_id WHERE project.id = ?;
@@ -542,7 +541,7 @@ function transformColumns(rows, newRecord, transactionToEdit, setFiscalData) {
 
     if (row.hrEntity) {
       // reverse barcode lookup entity
-      databaseRequests.push(ENTITY_QUERY);
+      databaseRequests.push(UUID_QUERY);
       databaseValues.push([row.hrEntity]);
 
       assignments.push(result => {
@@ -559,7 +558,7 @@ function transformColumns(rows, newRecord, transactionToEdit, setFiscalData) {
 
     if (row.hrReference) {
       // reverse barcode lookup entity
-      databaseRequests.push(REFERENCE_QUERY);
+      databaseRequests.push(UUID_QUERY);
       databaseValues.push([row.hrReference]);
 
       assignments.push(result => {

--- a/server/controllers/finance/journal/index.js
+++ b/server/controllers/finance/journal/index.js
@@ -1,11 +1,9 @@
-/** The /journal HTTP API endpoint
- *
+/**
+ * The /journal HTTP API endpoint
  * @module finance/journal/
- *
  * @description
  * This module is responsible for handling CRUD operations
  * against the `posting journal` table.
- *
  * @requires lodash
  * @requires lib/db
  * @requires lib/util
@@ -50,6 +48,11 @@ exports.findJournalLog = findJournalLog;
 
 const isUndefined = (value) => typeof value === 'undefined';
 
+/**
+ *
+ * @param req
+ * @param res
+ */
 async function log(req, res) {
   const options = req.query;
   const { query, parameters } = findJournalLog(options);
@@ -61,6 +64,10 @@ async function log(req, res) {
   res.status(200).json(data);
 }
 
+/**
+ *
+ * @param options
+ */
 function findJournalLog(options) {
   db.convert(options, ['record_uuid']);
   const filters = new FilterParser(options, { tableAlias : 'th' });
@@ -74,10 +81,10 @@ function findJournalLog(options) {
       th.value AS value,
       th.action,
       u.display_name,
-      dm.text as hrRecord
+      dm.short_name as hrRecord
     FROM transaction_history th
     JOIN user u ON u.id = th.user_id
-    LEFT JOIN document_map dm ON dm.uuid = th.record_uuid
+    LEFT JOIN uuid_map dm ON dm.uuid = th.record_uuid
   `;
 
   filters.fullText('description', 'value');
@@ -100,8 +107,8 @@ function findJournalLog(options) {
 
 /**
  * Looks up a transaction by record_uuid.
- *
- * @param {String} record_uuid - the record uuid
+ * @param {string} record_uuid - the record uuid
+ * @param recordUuid
  * @returns {Promise} object - a promise resolving to the part of transaction object.
  */
 async function lookupTransaction(recordUuid) {
@@ -132,6 +139,11 @@ async function lookupTransaction(recordUuid) {
 // 2. select all from the general ledger including all joins, conditions etc.
 // 3. UNION ALL between both complete sets of data
 // 4. Apply date order
+/**
+ *
+ * @param options
+ * @param includeNonPosted
+ */
 function naiveTransactionSearch(options, includeNonPosted) {
   // hack to ensure only the correct amount of rows are returned - this should be improved
   // in the more efficient method of selection
@@ -159,6 +171,11 @@ function naiveTransactionSearch(options, includeNonPosted) {
 
 // if posted ONLY return posted transactions
 // if not posted ONLY return non-posted transactions
+/**
+ *
+ * @param options
+ * @param posted
+ */
 function buildTransactionQuery(options, posted) {
   db.convert(options, [
     'uuid', 'record_uuid', 'uuids', 'record_uuids', 'reference_uuid', 'entity_uuid', 'stockReference',
@@ -177,10 +194,10 @@ function buildTransactionQuery(options, posted) {
   const sql = `
     SELECT BUID(p.uuid) AS uuid, ${posted} as posted, p.project_id, p.fiscal_year_id, p.period_id,
       p.trans_id, p.trans_date, BUID(p.record_uuid) AS record_uuid,
-      dm1.text AS hrRecord, p.description, p.account_id, p.debit, p.credit,
+      dm1.short_name AS hrRecord, p.description, p.account_id, p.debit, p.credit,
       p.debit_equiv, p.credit_equiv, p.currency_id, c.name AS currencyName,
-      BUID(p.entity_uuid) AS entity_uuid, em.text AS hrEntity,
-      BUID(p.reference_uuid) AS reference_uuid, dm2.text AS hrReference,
+      BUID(p.entity_uuid) AS entity_uuid, em.short_name AS hrEntity,
+      BUID(p.reference_uuid) AS reference_uuid, dm2.short_name AS hrReference,
       p.comment, p.transaction_type_id, p.user_id, pro.abbr,
       pro.name AS project_name, tp.text AS transaction_type_text,
       a.number AS account_number, a.type_id AS account_type_id, a.label AS account_label,
@@ -193,9 +210,9 @@ function buildTransactionQuery(options, posted) {
       JOIN user u ON u.id = p.user_id
       JOIN currency c ON c.id = p.currency_id
       LEFT JOIN cost_center cc ON cc.id = p.cost_center_id
-      LEFT JOIN entity_map em ON em.uuid = p.entity_uuid
-      LEFT JOIN document_map dm1 ON dm1.uuid = p.record_uuid
-      LEFT JOIN document_map dm2 ON dm2.uuid = p.reference_uuid
+      LEFT JOIN uuid_map em ON em.uuid = p.entity_uuid
+      LEFT JOIN uuid_map dm1 ON dm1.uuid = p.record_uuid
+      LEFT JOIN uuid_map dm2 ON dm2.uuid = p.reference_uuid
   `;
 
   filters.period('period', 'trans_date');
@@ -248,8 +265,8 @@ function buildTransactionQuery(options, posted) {
 }
 
 /**
+ * @param options
  * @function find
- *
  * @description
  * This function filters the posting journal by query parameters passed in via
  * the options object.  If no query parameters are provided, the method will
@@ -267,6 +284,11 @@ function find(options) {
   return naiveTransactionSearch(options, false);
 }
 
+/**
+ *
+ * @param rows
+ * @param includeNonPosted
+ */
 function postProcessFullTransactions(rows, includeNonPosted) {
   // get a list of unique record uuids
   const records = rows
@@ -277,8 +299,9 @@ function postProcessFullTransactions(rows, includeNonPosted) {
 }
 
 /**
- * @method list
- *
+ * @param req
+ * @param res
+ * @function list
  * @description
  * This function simply uses the find() method to filter the posting journal and
  * (optionally) the general ledger. If the "showFullTransactions" option is
@@ -307,6 +330,8 @@ async function list(req, res) {
 /**
  * GET /journal/:record_uuid
  * send back a set of lines which have the same record_uuid the which provided by the user
+ * @param req
+ * @param res
  */
 async function getTransaction(req, res) {
   const transaction = await lookupTransaction(req.params.record_uuid);
@@ -315,6 +340,11 @@ async function getTransaction(req, res) {
 
 // @TODO(sfount) move edit transaction code to separate server controller - split editing process
 //               up into smaller self contained methods
+/**
+ *
+ * @param req
+ * @param res
+ */
 async function editTransaction(req, res) {
   const REMOVE_JOURNAL_ROW = 'DELETE FROM posting_journal WHERE uuid = ?;';
   const UPDATE_JOURNAL_ROW = 'UPDATE posting_journal SET ? WHERE uuid = ?;';
@@ -442,10 +472,17 @@ async function editTransaction(req, res) {
 // converts all valid posting journal editable columns into data representations
 // returns valid errors for incorrect data
 // @TODO Many requests are made vs. getting one look up table and using that - this can be greatly optimised
+/**
+ *
+ * @param rows
+ * @param newRecord
+ * @param transactionToEdit
+ * @param setFiscalData
+ */
 function transformColumns(rows, newRecord, transactionToEdit, setFiscalData) {
   const ACCOUNT_NUMBER_QUERY = 'SELECT id FROM account WHERE number = ?';
-  const ENTITY_QUERY = 'SELECT uuid FROM entity_map WHERE text = ?';
-  const REFERENCE_QUERY = 'SELECT uuid FROM document_map  WHERE text = ?';
+  const ENTITY_QUERY = 'SELECT uuid FROM uuid_map WHERE text = ?';
+  const REFERENCE_QUERY = 'SELECT uuid FROM uuid_map  WHERE text = ?';
   const EXCHANGE_RATE_QUERY = `
     SELECT ? * IF(enterprise.currency_id = ?, 1, GetExchangeRate(enterprise.id, ?, ?)) AS amount FROM enterprise
     JOIN project ON enterprise.id = project.enterprise_id WHERE project.id = ?;
@@ -469,8 +506,6 @@ function transformColumns(rows, newRecord, transactionToEdit, setFiscalData) {
   const databaseRequests = [];
   const databaseValues = [];
   const assignments = [];
-
-  let promises = [];
 
   // this works on both the object provided from changes and the array from new
   // rows - that might be a hack
@@ -640,7 +675,7 @@ function transformColumns(rows, newRecord, transactionToEdit, setFiscalData) {
     }
   });
 
-  promises = databaseRequests.map(
+  const promises = databaseRequests.map(
     (request, index) => db.exec(request, databaseValues[index])
       .then(results => assignments[index](results)),
   );
@@ -650,8 +685,9 @@ function transformColumns(rows, newRecord, transactionToEdit, setFiscalData) {
 }
 
 /**
- * @method reverse
- *
+ * @param req
+ * @param res
+ * @function reverse
  * @description
  * This is a generic wrapper for reversing any transaction in the posting
  * journal or general ledger.
@@ -667,8 +703,10 @@ async function reverse(req, res) {
 }
 
 /**
- * @method reverseTransaction
- *
+ * @param recordUuid
+ * @param userId
+ * @param reverseDescription
+ * @function reverseTransaction
  * @description
  * Reverses a transaction in the database by creating a reversing voucher.
  */
@@ -709,14 +747,14 @@ async function reverseTransaction(recordUuid, userId, reverseDescription) {
 }
 
 /**
- * @method count
+ * @param req
+ * @param res
+ * @function count
  *
  *
  * GET /journal/count
- *
  * @description
  * Returns the number of transactions in the posting journal.
- *
  */
 async function count(req, res) {
   const sql = `
@@ -729,8 +767,9 @@ async function count(req, res) {
 }
 
 /**
+ * @param oldRows
+ * @param changedRows
  * @function getTransactionDate
- *
  * @description
  * This function computes the date of the transaction from the submitted data.
  * It will prefer changed rows over the underlying transaction, if the user changed the trans_date.
@@ -748,8 +787,9 @@ function getTransactionDate(oldRows, changedRows = {}) {
 }
 
 /**
+ * @param req
+ * @param res
  * @function getTransactionEditHistory
- *
  * @description
  * A lightweight function to scan the transaction_history and check if
  * a transaction has previously been edited.  If so, it pulls out the user

--- a/server/controllers/finance/journal/index.js
+++ b/server/controllers/finance/journal/index.js
@@ -481,6 +481,7 @@ async function editTransaction(req, res) {
  */
 function transformColumns(rows, newRecord, transactionToEdit, setFiscalData) {
   const ACCOUNT_NUMBER_QUERY = 'SELECT id FROM account WHERE number = ?';
+  const ENTITY_UUID_QUERY = 'SELECT uuid FROM uuid_map WHERE short_name = ? AND type = "entity"';
   const UUID_QUERY = 'SELECT uuid FROM uuid_map WHERE short_name = ?';
   const EXCHANGE_RATE_QUERY = `
     SELECT ? * IF(enterprise.currency_id = ?, 1, GetExchangeRate(enterprise.id, ?, ?)) AS amount FROM enterprise
@@ -541,7 +542,7 @@ function transformColumns(rows, newRecord, transactionToEdit, setFiscalData) {
 
     if (row.hrEntity) {
       // reverse barcode lookup entity
-      databaseRequests.push(UUID_QUERY);
+      databaseRequests.push(ENTITY_UUID_QUERY);
       databaseValues.push([row.hrEntity]);
 
       assignments.push(result => {

--- a/server/controllers/finance/patientInvoice.js
+++ b/server/controllers/finance/patientInvoice.js
@@ -250,16 +250,16 @@ function find(options) {
   const sql = `
     SELECT BUID(invoice.uuid) as uuid, invoice.project_id, invoice.date,
       patient.display_name as patientName, invoice.cost, invoice.description,
-      BUID(invoice.debtor_uuid) as debtor_uuid, dm.text AS reference,
-      em.text AS patientReference, service.name as serviceName, proj.name AS project_name,
+      BUID(invoice.debtor_uuid) as debtor_uuid, dm.short_name AS reference,
+      em.short_name AS patientReference, service.name as serviceName, proj.name AS project_name,
       user.display_name, invoice.user_id, invoice.reversed, invoice.edited, invoice.posted,
       invoice.created_at
     FROM invoice
     JOIN patient FORCE INDEX(debtor_uuid) ON invoice.debtor_uuid = patient.debtor_uuid
     ${debtorJoin}
     JOIN project AS proj ON proj.id = invoice.project_id
-    JOIN entity_map AS em ON em.uuid = patient.uuid
-    JOIN document_map AS dm ON dm.uuid = invoice.uuid
+    JOIN uuid_map AS em ON em.uuid = patient.uuid
+    JOIN uuid_map AS dm ON dm.uuid = invoice.uuid
     JOIN service ON service.uuid = invoice.service_uuid
     JOIN user ON user.id = invoice.user_id
   `;
@@ -312,10 +312,10 @@ function find(options) {
 function lookupInvoiceCreditNote(invoiceUuid) {
   const buid = db.bid(invoiceUuid);
   const sql = `
-    SELECT BUID(v.uuid) AS uuid, v.date, dm.text AS reference,
+    SELECT BUID(v.uuid) AS uuid, v.date, dm.short_name AS reference,
       v.currency_id, v.amount, v.description, v.reference_uuid, u.display_name
     FROM voucher v
-    JOIN document_map dm ON v.uuid = dm.uuid
+    JOIN uuid_map dm ON v.uuid = dm.uuid
     JOIN project p ON p.id = v.project_id
     JOIN user u ON u.id = v.user_id
     JOIN invoice i ON i.uuid = v.reference_uuid
@@ -346,7 +346,7 @@ function safelyDeleteInvoice(guid) {
   `;
 
   const DELETE_DOCUMENT_MAP = `
-    DELETE FROM document_map WHERE uuid = ?;
+    DELETE FROM uuid_map WHERE uuid = ?;
   `;
 
   return shared.isRemovableTransaction(guid)

--- a/server/controllers/finance/patientInvoice.js
+++ b/server/controllers/finance/patientInvoice.js
@@ -277,8 +277,8 @@ function find(options) {
 
   filters.fullText('description');
 
-  filters.equals('reference', 'text', 'dm');
-  filters.equals('patientReference', 'text', 'em');
+  filters.equals('reference', 'short_name', 'dm');
+  filters.equals('patientReference', 'short_name', 'em');
 
   filters.custom(
     'cash_uuid',

--- a/server/controllers/finance/purchases.js
+++ b/server/controllers/finance/purchases.js
@@ -490,7 +490,7 @@ function find(options) {
       LEFT JOIN entity AS ent ON ent.uuid = p.responsible
   `;
 
-  filters.equals('reference', 'text', 'dm');
+  filters.equals('reference', 'short_name', 'dm');
   filters.setOrder('ORDER BY p.date DESC');
 
   const query = filters.applyQuery(sql);
@@ -824,7 +824,7 @@ function findDetailed(options) {
     LEFT JOIN stock_movement AS mov ON (mov.lot_uuid = l.uuid AND mov.entity_uuid = p.uuid)
   `;
 
-  filters.equals('reference', 'text', 'dm');
+  filters.equals('reference', 'short_name', 'dm');
   filters.setGroup('GROUP BY p.uuid, it.inventory_uuid');
   filters.setOrder('ORDER BY p.date DESC');
 

--- a/server/controllers/finance/purchases.js
+++ b/server/controllers/finance/purchases.js
@@ -112,7 +112,7 @@ function lookupPurchaseOrder(uid) {
   let record;
 
   let sql = `
-    SELECT BUID(p.uuid) AS uuid, dm.text as reference,
+    SELECT BUID(p.uuid) AS uuid, dm.short_name as reference,
       p.cost, p.shipping_handling, p.date, s.display_name AS supplier, p.user_id,
       BUID(p.supplier_uuid) as supplier_uuid, p.currency_id,
       p.note, u.display_name AS author,
@@ -141,7 +141,7 @@ function lookupPurchaseOrder(uid) {
       s.address_1, s.email, s.phone,
       curr.format_key, curr.symbol
     FROM purchase AS p
-      JOIN document_map dm ON p.uuid = dm.uuid
+      JOIN uuid_map dm ON p.uuid = dm.uuid
       JOIN project ON p.project_id = project.id
       JOIN supplier AS s ON s.uuid = p.supplier_uuid
       JOIN project AS pr ON p.project_id = pr.id
@@ -475,14 +475,14 @@ function find(options) {
   filters.equals('supplier_uuid', 'uuid', 's');
 
   const sql = `
-    SELECT BUID(p.uuid) AS uuid, dm.text as reference,
+    SELECT BUID(p.uuid) AS uuid, dm.short_name as reference,
         p.cost, p.shipping_handling, p.date, s.display_name  AS supplier,
         p.user_id, p.note,
         BUID(p.supplier_uuid) as supplier_uuid, u.display_name AS author,
         p.info_purchase_number, p.info_prf_number, p.currency_id, p.status_id,
         ps.text AS status, ent.display_name AS responsible, p.created_at
       FROM purchase AS p
-      JOIN document_map dm ON p.uuid = dm.uuid
+      JOIN uuid_map dm ON p.uuid = dm.uuid
       JOIN supplier AS s ON s.uuid = p.supplier_uuid
       JOIN project AS pr ON p.project_id = pr.id
       JOIN user AS u ON u.id = p.user_id
@@ -617,12 +617,12 @@ async function purchaseBalance(req, res) {
   const sql = `
     SELECT
       s.display_name AS supplier_name, u.display_name AS user_name, BUID(p.uuid) AS uuid,
-      dm.text AS reference, p.date, BUID(pi.inventory_uuid) AS inventory_uuid,
+      dm.short_name AS reference, p.date, BUID(pi.inventory_uuid) AS inventory_uuid,
       pi.quantity, pi.unit_price, p.shipping_handling, p.currency_id,
       IFNULL(distributed.quantity, 0) AS distributed_quantity,
       (pi.quantity - IFNULL(distributed.quantity, 0)) AS balance
     FROM purchase p
-    JOIN document_map dm ON dm.uuid = p.uuid
+    JOIN uuid_map dm ON dm.uuid = p.uuid
     JOIN purchase_item pi ON pi.purchase_uuid = p.uuid
     JOIN project proj ON proj.id = p.project_id
     JOIN supplier s ON s.uuid = p.supplier_uuid
@@ -802,7 +802,7 @@ function findDetailed(options) {
   filters.equals('info_prf_number');
 
   const sql = `
-    SELECT BUID(p.uuid) AS uuid, dm.text as reference,
+    SELECT BUID(p.uuid) AS uuid, dm.short_name as reference,
       p.cost, p.shipping_handling, p.date, s.display_name  AS supplier,
       p.user_id, p.note, inv.text AS inventory_text, it.quantity, it.unit_price AS inventory_purchase_price,
       it.total, it.package_size, (it.quantity / it.package_size) AS number_packages,
@@ -813,7 +813,7 @@ function findDetailed(options) {
       SUM(IFNULL(mov.quantity, 0)) AS quantity_delivered, (it.quantity - SUM(mov.quantity)) AS balance
     FROM purchase AS p
     JOIN purchase_item AS it ON it.purchase_uuid = p.uuid
-    JOIN document_map dm ON p.uuid = dm.uuid
+    JOIN uuid_map dm ON p.uuid = dm.uuid
     JOIN supplier AS s ON s.uuid = p.supplier_uuid
     JOIN project AS pr ON p.project_id = pr.id
     JOIN inventory AS inv ON inv.uuid = it.inventory_uuid

--- a/server/controllers/finance/reports/budget_analytical/index.js
+++ b/server/controllers/finance/reports/budget_analytical/index.js
@@ -13,8 +13,9 @@ const BUDGET_REPORT_TEMPLATE = './server/controllers/finance/reports/budget_anal
 exports.report = report;
 
 /**
+ * @param req
+ * @param res
  * @function report
- *
  * @description
  * Renders the analytical budget report.
  */
@@ -30,8 +31,6 @@ async function report(req, res) {
 
   const ACCOUNT_TYPES_INCOME = 4;
   const ACCOUNT_TYPES_EXPENSE = 5;
-
-  let totalCash = 0;
 
   let totalBudgetIncome = 0;
   let totalRealisationIncome = 0;
@@ -86,19 +85,19 @@ async function report(req, res) {
 
     if (params.transactionTypes) {
       /**
-         * Determination of transaction types to exclude for fund inflows
-         * that are not considered as revenue
-         */
+       * Determination of transaction types to exclude for fund inflows
+       * that are not considered as revenue
+       */
       transactionTypes = util.convertToNumericArray(params.transactionTypes);
 
     }
 
     if (params.transactionTypesSubsidies) {
       /**
-         * Determination of transactions for operating subsidies,
-         * subsidies are included in the calculation of overall revenue
-         * but excluded when determining local revenue
-         */
+       * Determination of transactions for operating subsidies,
+       * subsidies are included in the calculation of overall revenue
+       * but excluded when determining local revenue
+       */
       transactionTypesSubsidies = util.convertToNumericArray(params.transactionTypesSubsidies);
     }
 
@@ -114,8 +113,8 @@ async function report(req, res) {
       `;
 
     /**
-       * Retrieving accounts linked to the selected cashbox or cashboxes
-       */
+     * Retrieving accounts linked to the selected cashbox or cashboxes
+     */
     const cashboxes = await db.exec(query, [[cashboxesIds]]);
 
     const cashAccountIds = cashboxes.map(cashbox => cashbox.account_id);
@@ -135,12 +134,12 @@ async function report(req, res) {
       `;
 
     /**
-       * accountsReferenceType: A large array of objects containing
-       * 0: Elements of the account reference type
-       * 1: Account references corresponding to the budget analysis
-       * 2: All account numbers by their account references
-       * 3: All accounts to exclude, respectively by account reference
-       */
+     * accountsReferenceType: A large array of objects containing
+     * 0: Elements of the account reference type
+     * 1: Account references corresponding to the budget analysis
+     * 2: All account numbers by their account references
+     * 3: All accounts to exclude, respectively by account reference
+     */
     const accountsReferenceType = await ReferencesCompute.getAccountsConfigurationReferences(
       [BUDGET_ANALYSIS_REFERENCE_TYPE_ID],
     );
@@ -151,9 +150,9 @@ async function report(req, res) {
     configurationReferences = await db.exec(sqlReferences, [BUDGET_ANALYSIS_REFERENCE_TYPE_ID]);
 
     /**
-       * Here, the account references corresponding to the budget analysis are formatted
-       * and placed into the arrays accounts_number_formated and accounts_id_formated
-       */
+     * Here, the account references corresponding to the budget analysis are formatted
+     * and placed into the arrays accounts_number_formated and accounts_id_formated
+     */
     configurationReferences = configurationReferences.map(item => ({
       ...item,
       accounts_number_formated : item.accounts_number
@@ -194,10 +193,10 @@ async function report(req, res) {
       `;
 
     /**
-       * Here, all accounts belonging to the excluded account references are listed.
-       * The account numbers as well as the account IDs are placed into the arrays
-       * accounts_number_formated and accounts_id_formated
-       */
+     * Here, all accounts belonging to the excluded account references are listed.
+     * The account numbers as well as the account IDs are placed into the arrays
+     * accounts_number_formated and accounts_id_formated
+     */
     configurationReferencesException = await db.exec(sqlReferencesException, [BUDGET_ANALYSIS_REFERENCE_TYPE_ID]);
 
     configurationReferencesException = configurationReferencesException.map(item => ({
@@ -216,9 +215,9 @@ async function report(req, res) {
     let filterExcludeTransactionType = ``;
 
     /**
-       * Here, clauses are formatted to be injected into SQL queries
-       * in order to account for the transaction types to exclude
-       */
+     * Here, clauses are formatted to be injected into SQL queries
+     * in order to account for the transaction types to exclude
+     */
     if (transactionTypes.length) {
       filterTransactionType = ` AND aggr.transaction_type_id NOT IN (${transactionTypes})`;
       filterExcludeTransactionType = ` AND gl.transaction_type_id NOT IN (${transactionTypes})`;
@@ -227,9 +226,9 @@ async function report(req, res) {
     let filterTransactionTypesSubsidies = ``;
 
     /**
-       * Here, clauses are formatted to be injected into SQL queries
-       * to exclude transaction types corresponding to operating subsidies
-       */
+     * Here, clauses are formatted to be injected into SQL queries
+     * to exclude transaction types corresponding to operating subsidies
+     */
     if (transactionTypesSubsidies.length) {
       filterTransactionTypesSubsidies = ` AND gl.transaction_type_id NOT IN (${transactionTypesSubsidies})`;
     }
@@ -279,8 +278,8 @@ async function report(req, res) {
     ];
 
     /**
-       * Retrieving the revenue obtained with the selected cashbox
-       */
+     * Retrieving the revenue obtained with the selected cashbox
+     */
     const cashflowIncome = await db.exec(sqlCashflowIncome, paramsLocalIncomeFilter);
 
     cashflowIncome.forEach(income => {
@@ -292,9 +291,9 @@ async function report(req, res) {
     });
 
     /**
-       * Configuration with index 4 corresponds to the fifth account reference configuration
-       * to capture revenue from other sources such as bank accounts
-       */
+     * Configuration with index 4 corresponds to the fifth account reference configuration
+     * to capture revenue from other sources such as bank accounts
+     */
     if (configurationReferences[CONFIG_REF_REVENUE_OTHER_SOURCES]) {
       const otherIncome = configurationReferences[CONFIG_REF_REVENUE_OTHER_SOURCES];
 
@@ -305,7 +304,7 @@ async function report(req, res) {
           tt.text, tt.type, v.reversed
           FROM general_ledger AS gl
           JOIN voucher AS v ON v.uuid = gl.record_uuid
-          JOIN document_map AS map ON map.uuid = v.uuid
+          JOIN uuid_map AS map ON map.uuid = v.uuid
           JOIN account AS a ON a.id = gl.account_id
           JOIN transaction_type AS tt ON tt.id = gl.transaction_type_id
           WHERE
@@ -319,10 +318,10 @@ async function report(req, res) {
       const referencesOtherIncome = await db.exec(sqlOtherIncome, [fiscalYearId, [otherIncome.accounts_id_formated]]);
 
       /**
-         * This is the value corresponding to the sum of other revenues. To obtain this value,
-         * it is essential to exclude operating subsidies, corrections
-         * of entries, and miscellaneous operations
-         */
+       * This is the value corresponding to the sum of other revenues. To obtain this value,
+       * it is essential to exclude operating subsidies, corrections
+       * of entries, and miscellaneous operations
+       */
       balanceOtherIncome = referencesOtherIncome[0].debit_equiv;
     }
   }
@@ -483,10 +482,10 @@ async function report(req, res) {
 
   configurationReferences.forEach((item, index) => {
     /**
-       * Here, we search for how to calculate the values corresponding to each of the account references.
-       * These values are obtained from tabFiscalIncomeData and they only concern the first 4
-       * configurations of the budget analysis, which is why we limit ourselves to index 4
-       */
+     * Here, we search for how to calculate the values corresponding to each of the account references.
+     * These values are obtained from tabFiscalIncomeData and they only concern the first 4
+     * configurations of the budget analysis, which is why we limit ourselves to index 4
+     */
     if (index < 4) {
       item.value_account_number = item.accounts_number_formated.reduce((total, accountNumber) => {
         const matchingIncome = tabFiscalIncomeData.find(income => income.number === accountNumber);
@@ -506,9 +505,9 @@ async function report(req, res) {
   });
 
   /**
-     * Here, we iterate through both arrays configurationReferences and configurationReferencesException
-     * in order to subtract the corresponding value from the exceptions array:
-     */
+   * Here, we iterate through both arrays configurationReferences and configurationReferencesException
+   * in order to subtract the corresponding value from the exceptions array:
+   */
   configurationReferences.forEach(item => {
     const getException = configurationReferencesException.find(elt => elt.abbr === item.abbr);
     if (getException) {
@@ -532,9 +531,9 @@ async function report(req, res) {
     operatingSubsidiesReferences = configurationReferences[CONFIG_REF_OPERATING_SUBSIDIES].value_account_number;
 
     /**
-       * Here, we calculate the result without the accounts, which would represent the result
-       * without subsidies and Financial revenues
-       */
+     * Here, we calculate the result without the accounts, which would represent the result
+     * without subsidies and Financial revenues
+     */
     realisationOperatingRevenue = (operatingRevenue.value_account_number || 0) - totalRealisationExpense;
 
     /** Here, we evaluate the result without operating subsidies */
@@ -546,9 +545,9 @@ async function report(req, res) {
   localCashRevenues += balanceOtherIncome;
 
   /**
-     * Total Cash is the sum of local revenue + operating subsidies
-     */
-  totalCash = localCashRevenues + operatingSubsidiesReferences;
+   * Total Cash is the sum of local revenue + operating subsidies
+   */
+  const totalCash = localCashRevenues + operatingSubsidiesReferences;
   const soldeTotalFinancement = totalCash - totalRealisationExpense;
 
   const data = {

--- a/server/controllers/finance/reports/budget_analytical/index.js
+++ b/server/controllers/finance/reports/budget_analytical/index.js
@@ -298,7 +298,7 @@ async function report(req, res) {
       const otherIncome = configurationReferences[CONFIG_REF_REVENUE_OTHER_SOURCES];
 
       const sqlOtherIncome = `
-          SELECT map.text AS referenceVoucher, gl.trans_id, gl.trans_date, a.id AS account_id,
+          SELECT map.short_name AS referenceVoucher, gl.trans_id, gl.trans_date, a.id AS account_id,
           a.number AS account_number, a.label AS account_label, gl.transaction_type_id,
           gl.description, SUM(gl.debit_equiv) AS debit_equiv,
           tt.text, tt.type, v.reversed

--- a/server/controllers/finance/reports/cashflow/index.js
+++ b/server/controllers/finance/reports/cashflow/index.js
@@ -131,9 +131,9 @@ async function reportByService(req, res) {
   // FIXME(jniles): this should use the dates for a faster query.
   debug(`looking up the cash payments.`);
   const payments = await db.exec(`
-      SELECT c.uuid, c.amount, dm.text as reference, em.text as patientReference, d.text as patientName
-      FROM cash c JOIN  document_map dm ON c.uuid = dm.uuid
-        JOIN entity_map em ON c.debtor_uuid = em.uuid
+      SELECT c.uuid, c.amount, dm.short_name as reference, em.short_name as patientReference, d.text as patientName
+      FROM cash c JOIN  uuid_map dm ON c.uuid = dm.uuid
+        JOIN uuid_map em ON c.debtor_uuid = em.uuid
         JOIN debtor d ON c.debtor_uuid = d.uuid
       WHERE c.uuid IN (?);
     `, [cashUuids]);

--- a/server/controllers/finance/reports/client_debts/index.js
+++ b/server/controllers/finance/reports/client_debts/index.js
@@ -29,16 +29,16 @@ async function report(req, res) {
   const rpt = new ReportManager(TEMPLATE, metadata, qs);
 
   const entitiesSQL = `
-      SELECT BUID(debtor.uuid) as uuid, em.text AS reference,
+      SELECT BUID(debtor.uuid) as uuid, em.short_name AS reference,
         (SELECT patient.display_name FROM patient WHERE patient.debtor_uuid = debtor.uuid) AS display_name,
         (SELECT e.creditor_uuid FROM employee e
           JOIN patient p ON e.patient_uuid = p.uuid
           WHERE p.debtor_uuid = debtor.uuid
         ) AS is_employee
-        FROM debtor JOIN entity_map em
+        FROM debtor JOIN uuid_map em
         ON debtor.uuid = em.uuid
       WHERE debtor.group_uuid = ?
-      ORDER BY display_name, em.text;
+      ORDER BY display_name, em.short_name;
     `;
   const clientQuery = `
       SELECT BUID(uuid) AS uuid, name, account_id, account.number, account.label
@@ -130,7 +130,7 @@ async function report(req, res) {
  */
 function getDebtsSupportedByEmployees(groupUuid) {
   const sql = `
-    SELECT BUID(entity_uuid) AS uuid, em.text AS reference, p.display_name,
+    SELECT BUID(entity_uuid) AS uuid, em.short_name AS reference, p.display_name,
       IFNULL(SUM(ledger.debit), 0) AS debit, IFNULL(SUM(ledger.credit), 0) AS credit,
       IFNULL(SUM(ledger.debit) - SUM(ledger.credit), 0) AS balance
     FROM (
@@ -152,7 +152,7 @@ function getDebtsSupportedByEmployees(groupUuid) {
       ) AND transaction_type_id = ${SUPPORT_TRANSACTION_TYPE}
       GROUP BY entity_uuid
     ) AS ledger
-    JOIN entity_map em ON ledger.entity_uuid = em.uuid
+    JOIN uuid_map em ON ledger.entity_uuid = em.uuid
     JOIN employee e ON ledger.entity_uuid = e.creditor_uuid
     JOIN patient p ON e.patient_uuid = p.uuid
     GROUP BY ledger.entity_uuid

--- a/server/controllers/finance/reports/client_support/index.js
+++ b/server/controllers/finance/reports/client_support/index.js
@@ -34,7 +34,7 @@ async function report(req, res) {
 
   const employeeSupportQuery = `
       SELECT
-        em.text AS reference, a.label, dg.name, p.display_name,
+        em.short_name AS reference, a.label, dg.name, p.display_name,
         SUM(i.credit_equiv - i.debit_equiv) AS balance,
         CONCAT(z.display_name, ' (', z.reference, ')') AS employee_name,
         z.balance AS employee_support, z.label AS employee_account
@@ -43,17 +43,17 @@ async function report(req, res) {
       JOIN debtor d ON d.uuid = i.entity_uuid
       JOIN debtor_group dg ON dg.uuid = d.group_uuid
       JOIN patient p ON p.debtor_uuid = d.uuid
-      JOIN entity_map em ON em.uuid = p.uuid
+      JOIN uuid_map em ON em.uuid = p.uuid
       JOIN (
         SELECT
           gl.record_uuid, a.label, p.display_name,
-          (gl.debit_equiv - gl.credit_equiv) AS balance, em.text AS reference
+          (gl.debit_equiv - gl.credit_equiv) AS balance, em.short_name AS reference
         FROM general_ledger gl
         JOIN account a ON a.id = gl.account_id
         JOIN creditor c ON c.uuid = gl.entity_uuid
         JOIN employee e ON e.creditor_uuid = c.uuid
         JOIN patient p ON p.uuid = e.patient_uuid
-        JOIN entity_map em ON em.uuid = e.creditor_uuid
+        JOIN uuid_map em ON em.uuid = e.creditor_uuid
         WHERE (gl.trans_date BETWEEN ? AND ?) AND gl.transaction_type_id = ${SUPPORT_TRANSACTION_TYPE}
       ) z ON z.record_uuid = i.record_uuid
     `;

--- a/server/controllers/finance/reports/debtors/openDebtors.js
+++ b/server/controllers/finance/reports/debtors/openDebtors.js
@@ -143,7 +143,7 @@ function buildDebtQuery(showDetailedView, source, dateCondition, ordering) {
 
   // Include all balance and debtor information by default
   const query = `
-    SELECT patient.display_name, uuid_map.text as reference,
+    SELECT patient.display_name, uuid_map.short_name as reference,
       SUM(debit_equiv - credit_equiv) as balance ${complexParameters}
     FROM ${source}
     JOIN patient on entity_uuid = patient.debtor_uuid

--- a/server/controllers/finance/reports/debtors/openDebtors.js
+++ b/server/controllers/finance/reports/debtors/openDebtors.js
@@ -143,11 +143,11 @@ function buildDebtQuery(showDetailedView, source, dateCondition, ordering) {
 
   // Include all balance and debtor information by default
   const query = `
-    SELECT patient.display_name, entity_map.text as reference,
+    SELECT patient.display_name, uuid_map.text as reference,
       SUM(debit_equiv - credit_equiv) as balance ${complexParameters}
     FROM ${source}
     JOIN patient on entity_uuid = patient.debtor_uuid
-    LEFT JOIN entity_map on entity_map.uuid = entity_uuid
+    LEFT JOIN uuid_map on uuid_map.uuid = entity_uuid
     ${complexJoin}
     WHERE entity_uuid IS NOT NULL
     ${dateCondition}

--- a/server/controllers/finance/reports/debtors/summaryReport.js
+++ b/server/controllers/finance/reports/debtors/summaryReport.js
@@ -38,7 +38,7 @@ async function summaryReport(req, res) {
   const inventoryGroupIndexMap = {};
 
   const invoiceSql = `
-      SELECT BUID(i.uuid) AS invoice_uuid, i.date, dm.text AS invRef, ent.text AS debtorRef,
+      SELECT BUID(i.uuid) AS invoice_uuid, i.date, dm.short_name AS invRef, ent.text AS debtorRef,
         d.text, SUM(it.transaction_price) AS amount, i.cost as total, BUID(i.debtor_uuid) AS debtor_uuid,
         invg.name as inventoryGroupName, BUID(invg.uuid) as inventoryGroupUuid, inv.text as inventoryName,
         BUID(i.service_uuid) AS service_uuid, s.name as serviceName
@@ -48,8 +48,8 @@ async function summaryReport(req, res) {
       JOIN inventory_group invg ON invg.uuid = inv.group_uuid
       JOIN debtor d ON d.uuid = i.debtor_uuid
       JOIN debtor_group dg ON dg.uuid = d.group_uuid
-      JOIN entity_map ent ON ent.uuid = d.uuid
-      JOIN document_map dm ON dm.uuid = i.uuid
+      JOIN uuid_map ent ON ent.uuid = d.uuid
+      JOIN uuid_map dm ON dm.uuid = i.uuid
       JOIN service s ON s.uuid  =  i.service_uuid
       WHERE dg.uuid = ? AND (i.date BETWEEN ? AND ?) AND i.reversed = 0
       GROUP BY invg.uuid, i.uuid

--- a/server/controllers/finance/reports/financial.all_employees.js
+++ b/server/controllers/finance/reports/financial.all_employees.js
@@ -103,7 +103,7 @@ async function build(req, res) {
           JOIN creditor AS cr ON cr.uuid = pj.entity_uuid
           JOIN employee AS emp ON emp.creditor_uuid = cr.uuid
           JOIN patient AS p ON p.uuid = emp.patient_uuid
-          JOIN entity_map AS map ON map.uuid = emp.creditor_uuid
+          JOIN uuid_map AS map ON map.uuid = emp.creditor_uuid
           ${filterBydatePosting}
           UNION ALL
           SELECT gl.trans_id, gl.debit_equiv AS debit, gl.credit_equiv AS credit, gl.account_id,
@@ -114,7 +114,7 @@ async function build(req, res) {
           JOIN creditor AS cr ON cr.uuid = gl.entity_uuid
           JOIN employee AS emp ON emp.creditor_uuid = cr.uuid
           JOIN patient AS p ON p.uuid = emp.patient_uuid
-          JOIN entity_map AS map ON map.uuid = emp.creditor_uuid
+          JOIN uuid_map AS map ON map.uuid = emp.creditor_uuid
           ${filterBydateLegder}
         ) AS aggr
         GROUP BY aggr.employee_uuid, aggr.account_id
@@ -136,7 +136,7 @@ async function build(req, res) {
           JOIN creditor AS cr ON cr.uuid = pj.entity_uuid
           JOIN employee AS emp ON emp.creditor_uuid = cr.uuid
           JOIN patient AS p ON p.uuid = emp.patient_uuid
-          JOIN entity_map AS map ON map.uuid = emp.creditor_uuid
+          JOIN uuid_map AS map ON map.uuid = emp.creditor_uuid
           ${filterBydatePosting}
           UNION ALL
           SELECT gl.trans_id, gl.debit_equiv AS debit, gl.credit_equiv AS credit, gl.account_id,
@@ -147,7 +147,7 @@ async function build(req, res) {
           JOIN creditor AS cr ON cr.uuid = gl.entity_uuid
           JOIN employee AS emp ON emp.creditor_uuid = cr.uuid
           JOIN patient AS p ON p.uuid = emp.patient_uuid
-          JOIN entity_map AS map ON map.uuid = emp.creditor_uuid
+          JOIN uuid_map AS map ON map.uuid = emp.creditor_uuid
           ${filterBydateLegder}
         ) AS aggr
         GROUP BY aggr.employee_uuid

--- a/server/controllers/finance/reports/financial.all_employees.js
+++ b/server/controllers/finance/reports/financial.all_employees.js
@@ -1,9 +1,7 @@
 /**
- * @overview server/controllers/finance/reports/financial.employee.js
- *
+ * @file server/controllers/finance/reports/financial.employee.js
  * @description
  * This file contains code to create a PDF report for financial activities of an employee
- *
  * @requires Employee
  * @requires ReportManager
  */
@@ -21,8 +19,9 @@ const PDF_OPTIONS = {
 };
 
 /**
- * @method build
- *
+ * @param req
+ * @param res
+ * @function build
  * @description
  * This method builds the report of financial activities of an Employee.
  *
@@ -97,7 +96,7 @@ async function build(req, res) {
         FROM (
           SELECT pj.trans_id, pj.debit_equiv AS debit, pj.credit_equiv AS credit, pj.account_id,
           a.number, UPPER(a.label) AS label, p.display_name AS employee_name, emp.uuid AS employee_uuid,
-          emp.code, map.text AS reference
+          emp.code, map.short_name AS reference
           FROM posting_journal AS pj
           JOIN account AS a ON a.id = pj.account_id
           JOIN creditor AS cr ON cr.uuid = pj.entity_uuid
@@ -108,7 +107,7 @@ async function build(req, res) {
           UNION ALL
           SELECT gl.trans_id, gl.debit_equiv AS debit, gl.credit_equiv AS credit, gl.account_id,
           a.number, UPPER(a.label) AS label, p.display_name AS employee_name, emp.uuid AS employee_uuid,
-          emp.code, map.text AS reference
+          emp.code, map.short_name AS reference
           FROM general_ledger AS gl
           JOIN account AS a ON a.id = gl.account_id
           JOIN creditor AS cr ON cr.uuid = gl.entity_uuid
@@ -130,7 +129,7 @@ async function build(req, res) {
         FROM (
           SELECT pj.trans_id, pj.debit_equiv AS debit, pj.credit_equiv AS credit, pj.account_id,
           a.number, UPPER(a.label) AS label, p.display_name AS employee_name, emp.uuid AS employee_uuid,
-          emp.code, map.text AS reference
+          emp.code, map.short_name AS reference
           FROM posting_journal AS pj
           JOIN account AS a ON a.id = pj.account_id
           JOIN creditor AS cr ON cr.uuid = pj.entity_uuid
@@ -141,7 +140,7 @@ async function build(req, res) {
           UNION ALL
           SELECT gl.trans_id, gl.debit_equiv AS debit, gl.credit_equiv AS credit, gl.account_id,
           a.number, UPPER(a.label) AS label, p.display_name AS employee_name, emp.uuid AS employee_uuid,
-          emp.code, map.text AS reference
+          emp.code, map.short_name AS reference
           FROM general_ledger AS gl
           JOIN account AS a ON a.id = gl.account_id
           JOIN creditor AS cr ON cr.uuid = gl.entity_uuid

--- a/server/controllers/finance/reports/invoiced_received_stock/index.js
+++ b/server/controllers/finance/reports/invoiced_received_stock/index.js
@@ -33,7 +33,7 @@ async function report(req, res) {
       FROM invoice AS iv
       JOIN debtor AS d ON d.uuid = iv.debtor_uuid
       JOIN patient AS p ON p.debtor_uuid = d.uuid
-      JOIN document_map AS map ON map.uuid = iv.uuid
+      JOIN uuid_map AS map ON map.uuid = iv.uuid
       WHERE p.uuid = ? AND (DATE(iv.date) >= DATE(?) AND DATE(iv.date) <= DATE(?))
       ORDER BY iv.date DESC
     `;
@@ -52,7 +52,7 @@ async function report(req, res) {
         FROM invoice_item AS item
         JOIN inventory AS inv ON inv.uuid = item.inventory_uuid
         JOIN invoice AS iv ON iv.uuid = item.invoice_uuid
-        JOIN document_map AS map ON map.uuid = iv.uuid
+        JOIN uuid_map AS map ON map.uuid = iv.uuid
         JOIN patient AS p ON p.debtor_uuid = iv.debtor_uuid
         WHERE p.uuid = ? AND (DATE(iv.date) >= DATE(?) AND DATE(iv.date) <= DATE(?))
         AND inv.consumable = 1
@@ -65,7 +65,7 @@ async function report(req, res) {
         JOIN lot AS l ON l.uuid = sm.lot_uuid
         JOIN inventory AS inv ON inv.uuid = l.inventory_uuid
         JOIN invoice AS iv ON iv.uuid = sm.invoice_uuid
-        JOIN document_map AS map ON map.uuid = iv.uuid
+        JOIN uuid_map AS map ON map.uuid = iv.uuid
         WHERE sm.invoice_uuid IS NOT NULL AND
         p.uuid = ? AND (DATE(sm.date) >= DATE(?) AND DATE(sm.date) <= DATE(?))
         AND sm.is_exit = 1
@@ -79,7 +79,7 @@ async function report(req, res) {
       SELECT DISTINCT(mov.document_uuid) AS document_uuid, map.text AS document, mov.date
       FROM patient AS p
         JOIN stock_movement AS mov ON mov.entity_uuid = p.uuid
-        JOIN document_map AS map ON map.uuid = mov.document_uuid
+        JOIN uuid_map AS map ON map.uuid = mov.document_uuid
       WHERE p.uuid = ? AND (DATE(mov.date) >= DATE(?) AND DATE(mov.date) <= DATE(?)) AND mov.invoice_uuid IS NULL
       ORDER BY mov.date DESC;
     `;
@@ -92,7 +92,7 @@ async function report(req, res) {
         JOIN stock_movement AS mov ON mov.entity_uuid = p.uuid
         JOIN lot AS l ON l.uuid = mov.lot_uuid
         JOIN inventory AS iv ON iv.uuid = l.inventory_uuid
-        JOIN document_map AS map ON map.uuid = mov.document_uuid
+        JOIN uuid_map AS map ON map.uuid = mov.document_uuid
       WHERE p.uuid = ? AND (DATE(mov.date) >= DATE(?) AND DATE(mov.date) <= DATE(?))
         AND mov.is_exit = 1 AND mov.invoice_uuid IS NULL
       ORDER BY iv.text ASC;

--- a/server/controllers/finance/reports/invoiced_received_stock/index.js
+++ b/server/controllers/finance/reports/invoiced_received_stock/index.js
@@ -15,8 +15,9 @@ const DEFAULT_PARAMS = {
 };
 
 /**
+ * @param req
+ * @param res
  * @function report
- *
  * @description
  * This report makes it possible to attach the items billed to a patient on
  * the articulated items consumed or distributed to the Patient.
@@ -29,11 +30,11 @@ async function report(req, res) {
   const data = { period : { dateFrom, dateTo } };
 
   const sqlInvoice = `
-      SELECT iv.uuid, map.text, iv.date
+      SELECT iv.uuid, map.short_name AS text, iv.date
       FROM invoice AS iv
-      JOIN debtor AS d ON d.uuid = iv.debtor_uuid
-      JOIN patient AS p ON p.debtor_uuid = d.uuid
-      JOIN uuid_map AS map ON map.uuid = iv.uuid
+        JOIN debtor AS d ON d.uuid = iv.debtor_uuid
+        JOIN patient AS p ON p.debtor_uuid = d.uuid
+        JOIN uuid_map AS map ON map.uuid = iv.uuid
       WHERE p.uuid = ? AND (DATE(iv.date) >= DATE(?) AND DATE(iv.date) <= DATE(?))
       ORDER BY iv.date DESC
     `;
@@ -44,7 +45,7 @@ async function report(req, res) {
       BUID(aggr.invoice_uuid) AS invoice_uuid, aggr.invoice_date,
       SUM(aggr.quantity_distributed) AS quantity_distributed, SUM(aggr.cost_distributed) AS cost_distributed
       FROM (
-        SELECT map.text AS reference, inv.uuid AS inventory_uuid, inv.text AS inventory_text, item.quantity,
+        SELECT map.short_name AS reference, inv.uuid AS inventory_uuid, inv.text AS inventory_text, item.quantity,
           item.inventory_price AS price_invoiced,
           iv.uuid AS invoice_uuid, iv.date AS invoice_date,
           0 AS quantity_distributed,
@@ -57,7 +58,7 @@ async function report(req, res) {
         WHERE p.uuid = ? AND (DATE(iv.date) >= DATE(?) AND DATE(iv.date) <= DATE(?))
         AND inv.consumable = 1
       UNION ALL
-        SELECT map.text AS reference, inv.uuid AS inventory_uuid, inv.text AS inventory_text,
+        SELECT map.short_name AS reference, inv.uuid AS inventory_uuid, inv.text AS inventory_text,
         0 AS quantity, 0 AS price_invoiced, sm.invoice_uuid, sm.date,
         SUM(sm.quantity) AS quantity_distributed, sm.unit_cost AS cost_distributed
         FROM stock_movement AS sm
@@ -76,7 +77,7 @@ async function report(req, res) {
     `;
 
   const sqlNoInvoiceAttributionAggregat = `
-      SELECT DISTINCT(mov.document_uuid) AS document_uuid, map.text AS document, mov.date
+      SELECT DISTINCT(mov.document_uuid) AS document_uuid, map.short_name AS document, mov.date
       FROM patient AS p
         JOIN stock_movement AS mov ON mov.entity_uuid = p.uuid
         JOIN uuid_map AS map ON map.uuid = mov.document_uuid
@@ -86,7 +87,7 @@ async function report(req, res) {
 
   const sqlNoInvoiceAttribution = `
       SELECT
-        BUID(p.uuid) AS patientUuid, mov.document_uuid, mov.quantity, mov.unit_cost, map.text AS document,
+        BUID(p.uuid) AS patientUuid, mov.document_uuid, mov.quantity, mov.unit_cost, map.short_name AS document,
         iv.text AS inventory_text, (mov.quantity * mov.unit_cost) AS total_cost, mov.date
       FROM patient AS p
         JOIN stock_movement AS mov ON mov.entity_uuid = p.uuid

--- a/server/controllers/finance/reports/unpaid_invoice_payments/index.js
+++ b/server/controllers/finance/reports/unpaid_invoice_payments/index.js
@@ -120,14 +120,14 @@ async function getUnbalancedInvoices(options) {
       )
     SELECT
       BUID(ivc.uuid) AS invoice_uuid,
-      em.text AS debtorReference,
+      em.short_name AS debtorReference,
       d.text AS debtorName,
       BUID(d.uuid) AS debtorUuid,
       (b.total_debit * ?) AS debit,
       (b.total_credit * ?) AS credit,
       (b.balance * ?) AS balance,
       ivc.date AS creation_date,
-      dm.text AS reference,
+      dm.short_name AS reference,
       ivc.project_id,
       p.name AS projectName,
       dg.name AS debtorGroupName,
@@ -140,8 +140,8 @@ async function getUnbalancedInvoices(options) {
       JOIN debtor d ON d.uuid = ivc.debtor_uuid
       JOIN debtor_group dg ON dg.uuid = d.group_uuid
       JOIN project p ON p.id = ivc.project_id
-      LEFT JOIN document_map dm ON dm.uuid = b.invoice_uuid
-      LEFT JOIN entity_map em ON em.uuid = d.uuid
+      LEFT JOIN uuid_map dm ON dm.uuid = b.invoice_uuid
+      LEFT JOIN uuid_map em ON em.uuid = d.uuid
     ORDER BY ivc.date;
 `;
 
@@ -191,8 +191,8 @@ async function getUnbalancedInvoices(options) {
   const debtorNames = (debtorUuids.length === 0)
     ? []
     : await db.exec(`
-    SELECT BUID(debtor.uuid) AS uuid, em.text as reference, debtor.text, p.dob
-    FROM debtor JOIN entity_map em ON debtor.uuid = em.uuid
+    SELECT BUID(debtor.uuid) AS uuid, em.short_name as reference, debtor.text, p.dob
+    FROM debtor JOIN uuid_map em ON debtor.uuid = em.uuid
     LEFT JOIN patient p ON p.debtor_uuid = debtor.uuid
     WHERE debtor.uuid IN (?);
   `, [debtorUuids]);

--- a/server/controllers/finance/reports/vouchers/index.js
+++ b/server/controllers/finance/reports/vouchers/index.js
@@ -106,9 +106,9 @@ async function report(req, res) {
 
 function findCreditNotedReference(uuid) {
   const sql = `
-    SELECT dm.text as reference
+    SELECT dm.short_name as reference
     FROM voucher v
-    JOIN  document_map dm ON v.uuid = dm.uuid
+    JOIN  uuid_map dm ON v.uuid = dm.uuid
     WHERE v.reference_uuid = ?
   `;
 

--- a/server/controllers/finance/shared.js
+++ b/server/controllers/finance/shared.js
@@ -30,12 +30,12 @@ exports.lookupFinancialEntityByUuid = async (req, res) => {
   const uuid = db.bid(req.params.uuid);
 
   const debtorSQL = `
-    SELECT em.uuid, em.text, d.text as hrLabel FROM entity_map em JOIN debtor d ON em.uuid = d.uuid
+    SELECT em.uuid, em.short_name, d.text as hrLabel FROM uuid_map em JOIN debtor d ON em.uuid = d.uuid
     WHERE em.uuid = ?
   `;
 
   const creditorSQL = `
-    SELECT em.uuid, em.text, c.text as hrLabel FROM entity_map em JOIN creditor c ON em.uuid = c.uuid
+    SELECT em.uuid, em.short_name, c.text as hrLabel FROM uuid_map em JOIN creditor c ON em.uuid = c.uuid
     WHERE em.uuid = ?
   `;
 
@@ -83,11 +83,11 @@ exports.lookupFinancialEntity = async (req, res) => {
   const filters = new FilterParser(options);
 
   const debtorSQL = `
-    SELECT em.uuid, em.text, d.text as hrLabel FROM entity_map em JOIN debtor d ON em.uuid = d.uuid
+    SELECT em.uuid, em.short_name, d.text as hrLabel FROM uuid_map em JOIN debtor d ON em.uuid = d.uuid
   `;
 
   const creditorSQL = `
-    SELECT em.uuid, em.text, c.text as hrLabel FROM entity_map em JOIN creditor c ON em.uuid = c.uuid
+    SELECT em.uuid, em.short_name, c.text as hrLabel FROM uuid_map em JOIN creditor c ON em.uuid = c.uuid
   `;
 
   filters.equals('uuid', 'uuid', 'em');
@@ -112,8 +112,8 @@ function getQueryForTable(table, options) {
   db.convert(options, ['uuid']);
 
   const sql = `
-    SELECT BUID(dm.uuid) AS uuid, dm.text, t.description, t.date
-    FROM document_map dm JOIN ${table} t ON dm.uuid = t.uuid
+    SELECT BUID(dm.uuid) AS uuid, dm.short_name, t.description, t.date
+    FROM uuid_map dm JOIN ${table} t ON dm.uuid = t.uuid
   `;
 
   filters.equals('uuid', 'uuid', 't');
@@ -158,7 +158,7 @@ exports.lookupFinancialRecord = async (req, res) => {
  */
 function getRecordUuidByText(hrRecord) {
   const sql = `
-    SELECT uuid FROM document_map WHERE text = ?;
+    SELECT uuid FROM uuid_map WHERE text = ?;
   `;
 
   return db.one(sql, hrRecord);
@@ -172,7 +172,7 @@ function getRecordUuidByText(hrRecord) {
  */
 function getRecordUuidByTextBulk(hrRecords) {
   const sql = `
-    SELECT uuid, text FROM document_map WHERE text IN (?);
+    SELECT uuid, text FROM uuid_map WHERE text IN (?);
   `;
 
   return db.exec(sql, [hrRecords]);
@@ -188,9 +188,9 @@ function getRecordUuidByTextBulk(hrRecords) {
  */
 function getEntityUuidByText(hrEntity) {
   const sql = `
-    SELECT em.uuid FROM entity_map em JOIN debtor ON em.uuid = debtor.uuid WHERE em.text = ?
+    SELECT em.uuid FROM uuid_map em JOIN debtor ON em.uuid = debtor.uuid WHERE em.short_name = ?
     UNION
-    SELECT em.uuid FROM entity_map em JOIN creditor ON em.uuid = creditor.uuid WHERE em.text = ?;
+    SELECT em.uuid FROM uuid_map em JOIN creditor ON em.uuid = creditor.uuid WHERE em.short_name = ?;
   `;
 
   return db.one(sql, [hrEntity, hrEntity]);
@@ -206,9 +206,9 @@ function getEntityUuidByText(hrEntity) {
  */
 function getEntityUuidByTextBulk(hrEntities) {
   const sql = `
-    SELECT em.uuid FROM entity_map em JOIN debtor ON em.uuid = debtor.uuid WHERE em.text IN (?)
+    SELECT em.uuid FROM uuid_map em JOIN debtor ON em.uuid = debtor.uuid WHERE em.short_name IN (?)
     UNION
-    SELECT em.uuid FROM entity_map em JOIN creditor ON em.uuid = creditor.uuid WHERE em.text IN (?);
+    SELECT em.uuid FROM uuid_map em JOIN creditor ON em.uuid = creditor.uuid WHERE em.short_name IN (?);
   `;
 
   return db.exec(sql, [hrEntities, hrEntities]);
@@ -222,7 +222,7 @@ function getEntityUuidByTextBulk(hrEntities) {
  */
 function getRecordTextByUuid(uuid) {
   const sql = `
-    SELECT text FROM document_map WHERE uuid = ?;
+    SELECT text FROM uuid_map WHERE uuid = ?;
   `;
 
   return db.one(sql, db.bid(uuid));
@@ -232,12 +232,12 @@ function getRecordTextByUuid(uuid) {
  * @function getEntityTextByUuid
  *
  * @description
- * This function returns an entity's human readable text from the entity_map
+ * This function returns an entity's human readable text from the uuid_map
  * table.
  */
 function getEntityTextByUuid(uuid) {
   const sql = `
-    SELECT text FROM entity_map WHERE uuid = ?;
+    SELECT text FROM uuid_map WHERE uuid = ?;
   `;
 
   return db.one(sql, db.bid(uuid));
@@ -255,15 +255,15 @@ function getEntityTextByUuid(uuid) {
 function getTransactionReferences(transactionUuid) {
   const sql = `
     SELECT DISTINCT uuid, text FROM (
-      SELECT dm.uuid, dm.text
-      FROM posting_journal AS j JOIN document_map AS dm ON
+      SELECT dm.uuid, dm.short_name
+      FROM posting_journal AS j JOIN uuid_map AS dm ON
         j.reference_uuid = dm.uuid
       WHERE j.reference_uuid = ?
 
       UNION ALL
 
-      SELECT dm.uuid, dm.text
-      FROM general_ledger AS g JOIN document_map AS dm ON
+      SELECT dm.uuid, dm.short_name
+      FROM general_ledger AS g JOIN uuid_map AS dm ON
         g.reference_uuid = dm.uuid
       WHERE g.reference_uuid = ?
     )c;
@@ -286,9 +286,9 @@ function getTransactionRecords(uuid) {
         trans_date, debit_equiv, credit_equiv, currency_id,
         BUID(reference_uuid) AS reference_uuid,
         BUID(entity_uuid) AS entity_uuid, 0 AS posted,
-        document_map.text AS identifier
-      FROM posting_journal AS j JOIN document_map ON
-        j.record_uuid = document_map.uuid
+        uuid_map.text AS identifier
+      FROM posting_journal AS j JOIN uuid_map ON
+        j.record_uuid = uuid_map.uuid
       WHERE record_uuid = ?
 
       UNION ALL
@@ -297,9 +297,9 @@ function getTransactionRecords(uuid) {
         trans_date, debit_equiv, credit_equiv, currency_id,
         BUID(reference_uuid) AS reference_uuid,
         BUID(entity_uuid) AS entity_uuid, 1 AS posted,
-        document_map.text AS identifier
-      FROM general_ledger AS j JOIN document_map ON
-        j.record_uuid = document_map.uuid
+        uuid_map.text AS identifier
+      FROM general_ledger AS j JOIN uuid_map ON
+        j.record_uuid = uuid_map.uuid
       WHERE record_uuid = ?
   `;
 

--- a/server/controllers/finance/shared.js
+++ b/server/controllers/finance/shared.js
@@ -1,10 +1,8 @@
 /**
- * @overview shared.js
- *
+ * @file shared.js
  * @description
  * This module contains helper functions for operating on transactions.  These
  * helper functions do things like like
- *
  * @requires lib/db
  * @requires lib/errors/BadRequest
  */
@@ -40,9 +38,9 @@ exports.lookupFinancialEntityByUuid = async (req, res) => {
   `;
 
   const combinedSQL = `
-    SELECT BUID(uuid) as uuid, text, hrLabel FROM (
+    SELECT BUID(uuid) as uuid, short_name, hrLabel FROM (
       ${debtorSQL} UNION ${creditorSQL}
-    )z ORDER BY text LIMIT 1;
+    )z ORDER BY short_name LIMIT 1;
   `;
 
   const record = await db.one(combinedSQL, [uuid, uuid]);
@@ -67,8 +65,9 @@ exports.lookupFinancialRecordByUuid = async (req, res) => {
 };
 
 /**
+ * @param req
+ * @param res
  * @function lookupFinancialEntity
- *
  * @description
  * An HTTP interface to lookup financial entities (debtors/creditors) in the database.
  */
@@ -91,22 +90,28 @@ exports.lookupFinancialEntity = async (req, res) => {
   `;
 
   filters.equals('uuid', 'uuid', 'em');
-  filters.fullText('text', 'text', 'em');
+  filters.fullText('text', 'short_name', 'em');
+  filters.fullText('text', 'long_name', 'em');
 
   const debtorQuery = filters.applyQuery(debtorSQL);
   const creditorQuery = filters.applyQuery(creditorSQL);
   const parameters = filters.parameters();
 
   const query = `
-    SELECT BUID(uuid) as uuid, text, hrLabel FROM (
+    SELECT BUID(uuid) as uuid, short_name, hrLabel FROM (
       ${debtorQuery} UNION ${creditorQuery}
-    )z ORDER BY text LIMIT ${limit};
+    )z ORDER BY short_name LIMIT ${limit};
   `;
 
   const rows = await db.exec(query, [...parameters, ...parameters]);
   res.status(200).json(rows);
 };
 
+/**
+ *
+ * @param table
+ * @param options
+ */
 function getQueryForTable(table, options) {
   const filters = new FilterParser(options);
   db.convert(options, ['uuid']);
@@ -117,7 +122,8 @@ function getQueryForTable(table, options) {
   `;
 
   filters.equals('uuid', 'uuid', 't');
-  filters.fullText('text');
+  filters.fullText('text', 'short_name', 'dm');
+  filters.fullText('text', 'long_name', 'dm');
   filters.setOrder('ORDER BY t.date DESC');
 
   const query = filters.applyQuery(sql);
@@ -127,8 +133,9 @@ function getQueryForTable(table, options) {
 }
 
 /**
+ * @param req
+ * @param res
  * @function lookupFinancialRecord
- *
  * @description
  * An HTTP interface to lookup financial records (cash/voucher/invoices) in the database.
  */
@@ -150,37 +157,37 @@ exports.lookupFinancialRecord = async (req, res) => {
 };
 
 /**
+ * @param hrRecord
  * @function getRecordUuidByText
- *
  * @description
  * This function gets a record uuid by its human readable text.  It is useful for creating vouchers
  * or editing records in the journal.
  */
 function getRecordUuidByText(hrRecord) {
   const sql = `
-    SELECT uuid FROM uuid_map WHERE text = ?;
+    SELECT uuid FROM uuid_map WHERE short_name = ?;
   `;
 
   return db.one(sql, hrRecord);
 }
 
 /**
+ * @param hrRecords
  * @function getRecordUuidByTextBulk
- *
  * @description
  * This function returns the record uuids associated with an array of human readble document identifiers.
  */
 function getRecordUuidByTextBulk(hrRecords) {
   const sql = `
-    SELECT uuid, text FROM uuid_map WHERE text IN (?);
+    SELECT uuid, short_name FROM uuid_map WHERE short_name IN (?);
   `;
 
   return db.exec(sql, [hrRecords]);
 }
 
 /**
+ * @param hrEntity
  * @function getEntityUuidByText
- *
  * @description
  * This function gets an entity uuid by its human readable text.  It is useful for creating vouchers
  * or editing records in the journal where entities are specified by their text by users and later
@@ -197,8 +204,8 @@ function getEntityUuidByText(hrEntity) {
 }
 
 /**
+ * @param hrEntities
  * @function getEntityUuidByTextBulk
- *
  * @description
  * This function gets multiple entity uuids by their human readable text.  It is useful for creating vouchers
  * or editing records in the journal where entities are specified by their text by users and later
@@ -215,29 +222,29 @@ function getEntityUuidByTextBulk(hrEntities) {
 }
 
 /**
+ * @param uuid
  * @function getRecordTextByUuid
- *
  * @description
  * This function returns a record's human readable text string by its uuid.
  */
 function getRecordTextByUuid(uuid) {
   const sql = `
-    SELECT text FROM uuid_map WHERE uuid = ?;
+    SELECT short_name FROM uuid_map WHERE uuid = ?;
   `;
 
   return db.one(sql, db.bid(uuid));
 }
 
 /**
+ * @param uuid
  * @function getEntityTextByUuid
- *
  * @description
  * This function returns an entity's human readable text from the uuid_map
  * table.
  */
 function getEntityTextByUuid(uuid) {
   const sql = `
-    SELECT text FROM uuid_map WHERE uuid = ?;
+    SELECT short_name FROM uuid_map WHERE uuid = ?;
   `;
 
   return db.one(sql, db.bid(uuid));
@@ -245,16 +252,14 @@ function getEntityTextByUuid(uuid) {
 
 /**
  * @function getTransactionReferences
- *
  * @description
  * This function will find the uuids of any transactions that reference the
  * provided transaction's uuid.
- *
- * @param {String} transactionUuid - the record_uuid of the transaction
+ * @param {string} transactionUuid - the record_uuid of the transaction
  */
 function getTransactionReferences(transactionUuid) {
   const sql = `
-    SELECT DISTINCT uuid, text FROM (
+    SELECT DISTINCT uuid, short_name FROM (
       SELECT dm.uuid, dm.short_name
       FROM posting_journal AS j JOIN uuid_map AS dm ON
         j.reference_uuid = dm.uuid
@@ -275,8 +280,8 @@ function getTransactionReferences(transactionUuid) {
 }
 
 /**
+ * @param uuid
  * @function getTransactionRecords
- *
  * @description
  * Returns the transaction from the posting journal and general_ledger.
  */
@@ -286,7 +291,7 @@ function getTransactionRecords(uuid) {
         trans_date, debit_equiv, credit_equiv, currency_id,
         BUID(reference_uuid) AS reference_uuid,
         BUID(entity_uuid) AS entity_uuid, 0 AS posted,
-        uuid_map.text AS identifier
+        uuid_map.short_name AS identifier
       FROM posting_journal AS j JOIN uuid_map ON
         j.record_uuid = uuid_map.uuid
       WHERE record_uuid = ?
@@ -297,7 +302,7 @@ function getTransactionRecords(uuid) {
         trans_date, debit_equiv, credit_equiv, currency_id,
         BUID(reference_uuid) AS reference_uuid,
         BUID(entity_uuid) AS entity_uuid, 1 AS posted,
-        uuid_map.text AS identifier
+        uuid_map.short_name AS identifier
       FROM general_ledger AS j JOIN uuid_map ON
         j.record_uuid = uuid_map.uuid
       WHERE record_uuid = ?
@@ -307,8 +312,8 @@ function getTransactionRecords(uuid) {
 }
 
 /**
+ * @param uuid
  * @function isRemovableTransaction
- *
  * @description
  * Checks to see if the transaction meets the criteria for removing. A transaction cannot
  * be removed if it is:

--- a/server/controllers/finance/transactions.js
+++ b/server/controllers/finance/transactions.js
@@ -1,9 +1,7 @@
 /**
- * @overview transactions.js
- *
+ * @file transactions.js
  * @description
  * This module contains the DELETE route for transactions.
- *
  * @requires lib/db
  * @requires controllers/finance/shared
  * @requires controllers/finance/cash
@@ -38,6 +36,10 @@ exports.deleteTransaction = deleteTransaction;
 exports.commentTransactions = commentTransactions;
 
 // expects a buffer and makes it into a nicely formatted UUID
+/**
+ *
+ * @param uuid
+ */
 function formatUuid(uuid) {
   const str = uuid.toString('hex');
   return `${str.slice(0, 8)}-${str.slice(8, 12)}-${str.slice(12, 16)}-${str.slice(16, 20)}-${str.slice(20)}`;
@@ -45,13 +47,10 @@ function formatUuid(uuid) {
 
 /**
  * @function parseDocumentMapString
- *
  * @description
  * This function parses the document map identifier and returns the safe
  * deletion method associated with this document.
- *
- * @param {String} text - the text of the document map
- *
+ * @param {string} text - the text of the document map
  * @returns {Function} the safe deletion method associated with the module
  */
 function parseDocumentMapString(text) {
@@ -60,13 +59,13 @@ function parseDocumentMapString(text) {
 }
 
 /**
+ * @param text
+ * @param actions
  * @functio isUserAuthorized
- *
  * @description
  * This function checks if the user is authorized to delete the record from their "actions"
  * set by their user role.
- *
- * @returns {Boolean} true if the user is authorized, false if not.
+ * @returns {boolean} true if the user is authorized, false if not.
  */
 function isUserAuthorized(text, actions) {
   const key = text.split('.').shift();
@@ -80,8 +79,9 @@ function isUserAuthorized(text, actions) {
 }
 
 /**
+ * @param req
+ * @param res
  * @function deleteRoute
- *
  * @description
  * This function is the HTTP handler for the delete transactions route.
  *
@@ -97,6 +97,10 @@ async function deleteRoute(req, res) {
   res.sendStatus(201);
 }
 
+/**
+ *
+ * @param txnRecord
+ */
 function formatTransactionRecord(txnRecord) {
   return txnRecord.map(row => {
     const parsed = { ...row };
@@ -114,17 +118,23 @@ function formatTransactionRecord(txnRecord) {
   });
 }
 
+/**
+ *
+ * @param uuid
+ * @param actions
+ * @param userId
+ */
 async function deleteTransaction(uuid, actions, userId) {
   const documentMap = await shared.getRecordTextByUuid(uuid);
 
-  debug(`#delete() resolved transaction ${uuid} to ${documentMap.text}.`);
+  debug(`#delete() resolved transaction ${uuid} to ${documentMap.short_name}.`);
 
   // route to do the correct safe deletion method.
-  const safeDeleteFn = parseDocumentMapString(documentMap.text);
+  const safeDeleteFn = parseDocumentMapString(documentMap.short_name);
 
-  if (!isUserAuthorized(documentMap.text, actions)) {
-    debug(`#delete() user is not autorized to remove ${documentMap.text}!`);
-    throw new Unauthorized(`User is not authorized to remove ${documentMap.text}.`);
+  if (!isUserAuthorized(documentMap.short_name, actions)) {
+    debug(`#delete() user is not autorized to remove ${documentMap.short_name}!`);
+    throw new Unauthorized(`User is not authorized to remove ${documentMap.short_name}.`);
   }
 
   const transactionRecord = await db.exec(`
@@ -154,15 +164,14 @@ async function deleteTransaction(uuid, actions, userId) {
 
 /**
  * PUT /transactions/comments
- *
  * @function commentTransactions
- *
  * @description
  * This function will put a comment on rows in both the posting journal and
  * general ledger.  To remove the comment, you should just send an empty
  * comment.
- *
  * @param {object} params - { uuids: [...], comment: '' }
+ * @param req
+ * @param res
  */
 async function commentTransactions(req, res) {
   const { uuids, comment } = req.body.params;

--- a/server/controllers/finance/transactions.js
+++ b/server/controllers/finance/transactions.js
@@ -128,9 +128,9 @@ async function deleteTransaction(uuid, actions, userId) {
   }
 
   const transactionRecord = await db.exec(`
-    SELECT pj.*, dm.text as hrRecord
+    SELECT pj.*, dm.short_name as hrRecord
     FROM posting_journal pj
-    JOIN document_map dm ON dm.uuid = pj.record_uuid
+    JOIN uuid_map dm ON dm.uuid = pj.record_uuid
     WHERE pj.record_uuid = ?
   `, [db.bid(uuid)]);
 

--- a/server/controllers/finance/vouchers.js
+++ b/server/controllers/finance/vouchers.js
@@ -1,11 +1,8 @@
 /**
  * The /vouchers HTTP API endpoint
- *
  * @module finance/vouchers
- *
  * @description This module is responsible for handling CRUD operations
  * against the `voucher` table.
- *
  * @requires lodash
  * @requires lib/util
  * @requires lib/db
@@ -39,9 +36,9 @@ exports.totalAmountByCurrency = totalAmountByCurrency;
 
 /**
  * GET /vouchers
- *
- * @method list
- *
+ * @param req
+ * @param res
+ * @function list
  * @description
  * Lists all the vouchers in the database.  Uses the FilterParser to ensure
  * that searching is supported.
@@ -54,9 +51,9 @@ async function list(req, res) {
 
 /**
  * GET /vouchers/:uuid
- *
- * @method detail
- *
+ * @param req
+ * @param res
+ * @function detail
  * @description
  * This HTTP interface returns a single voucher in detail
  */
@@ -66,8 +63,8 @@ async function detail(req, res) {
 }
 
 /**
+ * @param vUuid
  * @function lookupVoucher
- *
  * @description
  * Gets a single voucher (and associated details) by its uuid.
  */
@@ -87,13 +84,13 @@ async function lookupVoucher(vUuid) {
   // For get Creditor name
   const itemSql = `
     SELECT BUID(vi.uuid) AS uuid, vi.debit, vi.credit, vi.account_id, a.number, a.label,
-      BUID(vi.document_uuid) as document_uuid, uuid_map.text AS document_reference,
-      BUID(entity_uuid) AS entity_uuid, uuid_map.text AS entity_reference, vi.description,
+      BUID(vi.document_uuid) as document_uuid, dm.short_name AS document_reference,
+      BUID(entity_uuid) AS entity_uuid, em.short_name AS entity_reference, vi.description,
       CONCAT('/ ', c.text) AS creditorName
     FROM voucher_item vi
     JOIN account a ON a.id = vi.account_id
-    LEFT JOIN uuid_map ON uuid_map.uuid = vi.entity_uuid
-    LEFT JOIN uuid_map ON uuid_map.uuid = vi.document_uuid
+    LEFT JOIN uuid_map em ON em.uuid = vi.entity_uuid
+    LEFT JOIN uuid_map dm ON dm.uuid = vi.document_uuid
     LEFT JOIN employee emp ON emp.creditor_uuid = vi.entity_uuid
     LEFT JOIN creditor c ON c.uuid = emp.creditor_uuid
     WHERE vi.voucher_uuid = ?
@@ -118,6 +115,10 @@ const REFERENCE_SQL = `
     WHERE voucher_item.document_uuid = ? OR voucher.reference_uuid = ?
   )`;
 
+/**
+ *
+ * @param options
+ */
 function find(options) {
   db.convert(options, ['uuid', 'reference_uuid', 'entity_uuid', 'cash_uuid', 'invoice_uuid', 'stockReference']);
 
@@ -152,7 +153,7 @@ function find(options) {
   filters.equals('edited');
   filters.equals('currency_id');
 
-  filters.equals('reference', 'text', 'dm');
+  filters.equals('reference', 'short_name', 'dm');
 
   filters.fullText('description');
 
@@ -203,6 +204,10 @@ function find(options) {
   return db.exec(query, parameters);
 }
 
+/**
+ *
+ * @param options
+ */
 function totalAmountByCurrency(options) {
   db.convert(options, ['uuid', 'reference_uuid', 'entity_uuid', 'cash_uuid', 'invoice_uuid']);
 
@@ -230,7 +235,7 @@ function totalAmountByCurrency(options) {
   filters.equals('user_id');
   filters.equals('edited');
 
-  filters.equals('reference', 'text', 'dm');
+  filters.equals('reference', 'short_name', 'dm');
 
   filters.fullText('description');
 
@@ -255,8 +260,9 @@ function totalAmountByCurrency(options) {
 
 /**
  * POST /vouchers
- *
- * @method create
+ * @param req
+ * @param res
+ * @function create
  */
 async function create(req, res) {
   const { voucher } = req.body;
@@ -265,6 +271,12 @@ async function create(req, res) {
   res.status(201).json({ uuid : result.uuid });
 }
 
+/**
+ *
+ * @param voucherDetails
+ * @param userId
+ * @param projectId
+ */
 async function createVoucher(voucherDetails, userId, projectId) {
   const items = voucherDetails.items || [];
 
@@ -300,7 +312,7 @@ async function createVoucher(voucherDetails, userId, projectId) {
   const referencedEntities = [...new Set(items.map(item => item.hrEntity))];
   if (referencedEntities.length) {
     const hrEntities = await shared.getEntityUuidByTextBulk(referencedEntities);
-    hrEntityMap = _.keyBy(hrEntities, 'text');
+    hrEntityMap = _.keyBy(hrEntities, 'short_name');
   }
 
   // link human readable records/documents to their corresponding uuids
@@ -308,9 +320,14 @@ async function createVoucher(voucherDetails, userId, projectId) {
   const referencedRecords = [...new Set(items.map(item => item.hrRecord))];
   if (referencedRecords.length) {
     const hrRecords = await shared.getRecordUuidByTextBulk(referencedRecords);
-    hrRecordMap = _.keyBy(hrRecords, 'text');
+    hrRecordMap = _.keyBy(hrRecords, 'short_name');
   }
 
+  /**
+   *
+   * @param map
+   * @param key
+   */
   function getMapUuid(map, key) {
     if (map[key] && map[key].uuid) {
       return map[key].uuid;
@@ -397,8 +414,8 @@ async function createVoucher(voucherDetails, userId, projectId) {
 }
 
 /**
+ * @param guid
  * @function safelyDeleteVoucher
- *
  * @description
  * This function deletes a voucher from the system.  The method first checks
  * that a transaction can be deleted using the shared transaction library.

--- a/server/controllers/finance/vouchers.js
+++ b/server/controllers/finance/vouchers.js
@@ -75,11 +75,11 @@ async function lookupVoucher(vUuid) {
   const sql = `
     SELECT BUID(v.uuid) as uuid, v.date, v.created_at, v.project_id, v.currency_id, v.amount,
       v.description, v.user_id, v.type_id,  u.display_name, transaction_type.text,
-      dm.text AS reference, reversed, v.posted
+      dm.short_name AS reference, reversed, v.posted
     FROM voucher v
     JOIN project p ON p.id = v.project_id
     JOIN user u ON u.id = v.user_id
-    JOIN document_map dm ON dm.uuid = v.uuid
+    JOIN uuid_map dm ON dm.uuid = v.uuid
     LEFT JOIN transaction_type ON v.type_id = transaction_type.id
     WHERE v.uuid = ?;
   `;
@@ -87,13 +87,13 @@ async function lookupVoucher(vUuid) {
   // For get Creditor name
   const itemSql = `
     SELECT BUID(vi.uuid) AS uuid, vi.debit, vi.credit, vi.account_id, a.number, a.label,
-      BUID(vi.document_uuid) as document_uuid, document_map.text AS document_reference,
-      BUID(entity_uuid) AS entity_uuid, entity_map.text AS entity_reference, vi.description,
+      BUID(vi.document_uuid) as document_uuid, uuid_map.text AS document_reference,
+      BUID(entity_uuid) AS entity_uuid, uuid_map.text AS entity_reference, vi.description,
       CONCAT('/ ', c.text) AS creditorName
     FROM voucher_item vi
     JOIN account a ON a.id = vi.account_id
-    LEFT JOIN entity_map ON entity_map.uuid = vi.entity_uuid
-    LEFT JOIN document_map ON document_map.uuid = vi.document_uuid
+    LEFT JOIN uuid_map ON uuid_map.uuid = vi.entity_uuid
+    LEFT JOIN uuid_map ON uuid_map.uuid = vi.document_uuid
     LEFT JOIN employee emp ON emp.creditor_uuid = vi.entity_uuid
     LEFT JOIN creditor c ON c.uuid = emp.creditor_uuid
     WHERE vi.voucher_uuid = ?
@@ -132,12 +132,12 @@ function find(options) {
     SELECT
       BUID(v.uuid) as uuid, v.date, v.project_id, v.currency_id, v.amount,
       v.description, v.user_id, v.type_id, u.display_name, transaction_type.text,
-      dm.text AS reference, v.edited, BUID(v.reference_uuid) AS reference_uuid,
+      dm.short_name AS reference, v.edited, BUID(v.reference_uuid) AS reference_uuid,
       p.name AS project_name, v.reversed, v.created_at
     FROM voucher v
     JOIN project p ON p.id = v.project_id
     JOIN user u ON u.id = v.user_id
-    LEFT JOIN document_map dm ON v.uuid = dm.uuid
+    LEFT JOIN uuid_map dm ON v.uuid = dm.uuid
     LEFT JOIN transaction_type ON v.type_id = transaction_type.id
   `;
 
@@ -177,7 +177,7 @@ function find(options) {
   if (options.reversed === '2') {
     // get all the uuids of all records matching the current search criteria
     const innerSQL = `
-      SELECT v.uuid, v.reference_uuid, v.type_id, v.reversed FROM voucher v JOIN document_map dm ON v.uuid = dm.uuid
+      SELECT v.uuid, v.reference_uuid, v.type_id, v.reversed FROM voucher v JOIN uuid_map dm ON v.uuid = dm.uuid
     `;
 
     // apply the query to the innerQuery, ignoring the LIMIT statement
@@ -195,7 +195,7 @@ function find(options) {
   }
 
   // @TODO Support ordering query (reference support for limit)?
-  filters.setOrder('ORDER BY v.date DESC, dm.text DESC');
+  filters.setOrder('ORDER BY v.date DESC, dm.short_name DESC');
 
   const query = filters.applyQuery(sql);
   const parameters = filters.parameters();
@@ -216,9 +216,9 @@ function totalAmountByCurrency(options) {
 
   const sql = `
   SELECT c.id as currencyId, c.symbol as currencySymbol, SUM(v.amount) as totalAmount,
-    COUNT(c.symbol) AS numVouchers, dm.text as reference
+    COUNT(c.symbol) AS numVouchers, dm.short_name as reference
   FROM voucher v
-    JOIN document_map dm ON v.uuid = dm.uuid
+    JOIN uuid_map dm ON v.uuid = dm.uuid
     JOIN currency c ON v.currency_id = c.id
   `;
 
@@ -416,7 +416,7 @@ async function safelyDeleteVoucher(guid) {
   `;
 
   const DELETE_DOCUMENT_MAP = `
-    DELETE FROM document_map WHERE uuid = ?;
+    DELETE FROM uuid_map WHERE uuid = ?;
   `;
 
   // NOTE(@jniles) - this is a naive way of undoing reversals.  If no value is

--- a/server/controllers/medical/patients/index.js
+++ b/server/controllers/medical/patients/index.js
@@ -290,7 +290,7 @@ async function updatePatientDebCred(patientUuid) {
 
   const updateCreditor = `UPDATE creditor SET ? WHERE creditor.uuid = ?`;
   const updateDebtor = `UPDATE debtor SET ? WHERE debtor.uuid = ?`;
-  const updateEntityMap = `UPDATE uuid_map SET text = ? WHERE uuid = ?;`;
+  const updateEntityMap = `UPDATE uuid_map SET short_name = ?, long_name = ? WHERE uuid = ?;`;
 
   const transaction = db.transaction();
 
@@ -303,9 +303,9 @@ async function updatePatientDebCred(patientUuid) {
 
   // update entity map tables
   transaction
-    .addQuery(updateEntityMap, [patient.patientReference, patient.debtor_uuid])
-    .addQuery(updateEntityMap, [patient.patientReference, patient.creditor_uuid])
-    .addQuery(updateEntityMap, [patient.patientReference, buid]);
+    .addQuery(updateEntityMap, [patient.patientReference, debtorText, patient.debtor_uuid])
+    .addQuery(updateEntityMap, [patient.patientReference, creditorText, patient.creditor_uuid])
+    .addQuery(updateEntityMap, [patient.patientReference, patient.display_name, buid]);
 
   return transaction.execute();
 }
@@ -771,7 +771,7 @@ function find(options) {
   filters.equals('sex');
   filters.equals('hospital_no');
   filters.equals('user_id');
-  filters.equals('reference', 'text', 'em');
+  filters.equals('reference', 'short_name', 'em');
 
   filters.setOrder('ORDER BY p.registration_date DESC');
 
@@ -1001,7 +1001,7 @@ async function getStockMovements(req, res) {
 function stockMovementByPatient(patientUuid) {
   const sql = `
       SELECT BUID(sm.document_uuid) AS document_uuid,
-      dmi.text AS invoiceReference,
+      dmi.short_name AS invoiceReference,
       BUID(sm.depot_uuid) AS depot_uuid, MAX(d.text) as depot_name,
       SUM(sm.quantity * sm.unit_cost) AS value,
       MAX(sm.date) AS date, MAX(dm.short_name) AS hrReference
@@ -1024,7 +1024,7 @@ function stockMovementByPatient(patientUuid) {
  */
 function stockConsumedPerPatient(patientUuid) {
   const sql = `
-    SELECT sm.document_uuid, sm.depot_uuid, sm.date, map.text AS reference_text,
+    SELECT sm.document_uuid, sm.depot_uuid, sm.date, map.short_name AS reference_text,
     iv.text AS inventory_text, sm.quantity, sm.unit_cost,
     (sm.unit_cost * sm.quantity) AS total,
     l.label AS lotLabel, un.text AS inventoryUnit

--- a/server/controllers/medical/patients/index.js
+++ b/server/controllers/medical/patients/index.js
@@ -205,7 +205,7 @@ async function lookupPatient(patientUuid) {
     SELECT BUID(p.uuid) as uuid, p.project_id, BUID(p.debtor_uuid) AS debtor_uuid, p.display_name, p.hospital_no,
       p.sex, p.registration_date, p.email, p.phone, p.dob, p.dob_unknown_date,
       p.health_zone, p.health_area, BUID(p.origin_location_id) as origin_location_id,
-      BUID(p.current_location_id) as current_location_id, em.text AS reference,
+      BUID(p.current_location_id) as current_location_id, em.short_name AS reference,
       p.title, p.address_1, p.address_2, p.father_name, p.mother_name,
       p.religion, p.marital_status, p.profession, p.employer, p.spouse,
       p.spouse_profession, p.spouse_employer, p.notes, p.avatar, proj.abbr, d.text,
@@ -219,7 +219,7 @@ async function lookupPatient(patientUuid) {
       JOIN debtor_group AS dg ON d.group_uuid = dg.uuid
       JOIN user AS u ON p.user_id = u.id
       JOIN account AS a ON a.id = dg.account_id
-      JOIN entity_map AS em ON p.uuid = em.uuid
+      JOIN uuid_map AS em ON p.uuid = em.uuid
       LEFT JOIN employee AS emp ON emp.patient_uuid = p.uuid
     WHERE p.uuid = ?;
   `;
@@ -268,10 +268,10 @@ async function updatePatientDebCred(patientUuid) {
 
   const sql = `
     SELECT BUID(debtor.uuid) AS debtorUuid, BUID(employee.creditor_uuid) AS creditorUuid,
-      patient.display_name, em.text as patientReference
+      patient.display_name, em.short_name as patientReference
     FROM debtor
       JOIN patient ON patient.debtor_uuid = debtor.uuid
-      JOIN entity_map em ON em.uuid = patient.uuid
+      JOIN uuid_map em ON em.uuid = patient.uuid
       LEFT JOIN employee ON employee.patient_uuid = patient.uuid
     WHERE patient.uuid = ?
   `;
@@ -290,7 +290,7 @@ async function updatePatientDebCred(patientUuid) {
 
   const updateCreditor = `UPDATE creditor SET ? WHERE creditor.uuid = ?`;
   const updateDebtor = `UPDATE debtor SET ? WHERE debtor.uuid = ?`;
-  const updateEntityMap = `UPDATE entity_map SET text = ? WHERE uuid = ?;`;
+  const updateEntityMap = `UPDATE uuid_map SET text = ? WHERE uuid = ?;`;
 
   const transaction = db.transaction();
 
@@ -325,13 +325,13 @@ function lookupByDebtorUuid(debtorUuid) {
   const sql = `
     SELECT BUID(p.uuid) as uuid, p.project_id, BUID(p.debtor_uuid) AS debtor_uuid, p.display_name,
       p.hospital_no, p.sex, p.registration_date, p.email, p.phone, p.dob,
-      BUID(p.origin_location_id) as origin_location_id, p.title, p.address_1, p.address_2, em.text as reference,
+      BUID(p.origin_location_id) as origin_location_id, p.title, p.address_1, p.address_2, em.short_name as reference,
       proj.name AS proj_name, p.father_name, p.mother_name, p.religion, p.marital_status, p.profession,
       p.employer, p.spouse, p.spouse_profession, p.spouse_employer, p.notes, p.avatar, proj.abbr, d.text,
       dg.account_id, BUID(dg.price_list_uuid) AS price_list_uuid, dg.is_convention, BUID(dg.uuid) as debtor_group_uuid,
       dg.locked, dg.name as debtor_group_name, u.username, a.number
     FROM patient AS p
-    JOIN project AS proj JOIN debtor AS d JOIN debtor_group AS dg JOIN user AS u JOIN account AS a JOIN entity_map AS em
+    JOIN project AS proj JOIN debtor AS d JOIN debtor_group AS dg JOIN user AS u JOIN account AS a JOIN uuid_map AS em
       ON p.debtor_uuid = d.uuid AND d.group_uuid = dg.uuid
       AND p.project_id = proj.id
       AND p.user_id = u.id
@@ -805,7 +805,7 @@ function patientEntityQuery(detailed) {
   // build the main part of the SQL query
   const sql = `
     SELECT
-      BUID(p.uuid) AS uuid, p.project_id, em.text AS reference, p.display_name, BUID(p.debtor_uuid) as debtor_uuid,
+      BUID(p.uuid) AS uuid, p.project_id, em.short_name AS reference, p.display_name, BUID(p.debtor_uuid) as debtor_uuid,
       p.sex, p.dob, p.dob_unknown_date, p.registration_date, BUID(d.group_uuid) as debtor_group_uuid, p.hospital_no,
       p.health_zone, p.health_area, u.display_name as userName, originVillage.name as originVillageName, dg.color,
       originSector.name as originSectorName, dg.name AS debtorGroupName, proj.name AS project_name, p.created_at,
@@ -818,7 +818,7 @@ function patientEntityQuery(detailed) {
       JOIN sector AS originSector ON originVillage.sector_uuid = originSector.uuid
       JOIN province AS originProvince ON originProvince.uuid = originSector.province_uuid
       JOIN user AS u ON p.user_id = u.id
-      JOIN entity_map AS em ON p.uuid = em.uuid
+      JOIN uuid_map AS em ON p.uuid = em.uuid
   `;
 
   return sql;
@@ -1004,12 +1004,12 @@ function stockMovementByPatient(patientUuid) {
       dmi.text AS invoiceReference,
       BUID(sm.depot_uuid) AS depot_uuid, MAX(d.text) as depot_name,
       SUM(sm.quantity * sm.unit_cost) AS value,
-      MAX(sm.date) AS date, MAX(dm.text) AS hrReference
+      MAX(sm.date) AS date, MAX(dm.short_name) AS hrReference
     FROM stock_movement AS sm
       JOIN depot AS d ON d.uuid = sm.depot_uuid
       JOIN patient AS p ON p.uuid = sm.entity_uuid
-      JOIN document_map AS dm ON dm.uuid = sm.document_uuid
-      LEFT JOIN document_map AS dmi ON dmi.uuid = sm.invoice_uuid
+      JOIN uuid_map AS dm ON dm.uuid = sm.document_uuid
+      LEFT JOIN uuid_map AS dmi ON dmi.uuid = sm.invoice_uuid
     WHERE sm.entity_uuid = ?
     GROUP BY sm.document_uuid
     ORDER BY sm.date DESC
@@ -1034,7 +1034,7 @@ function stockConsumedPerPatient(patientUuid) {
       JOIN inventory_unit AS un ON un.id = iv.unit_id
       JOIN depot AS d ON d.uuid = sm.depot_uuid
       JOIN patient AS p ON p.uuid = sm.entity_uuid
-      JOIN document_map AS map ON map.uuid = sm.document_uuid
+      JOIN uuid_map AS map ON map.uuid = sm.document_uuid
     WHERE sm.entity_uuid = ?
     ORDER BY sm.date, sm.reference desc, iv.text asc;
   `;

--- a/server/controllers/medical/patients/merge.js
+++ b/server/controllers/medical/patients/merge.js
@@ -34,8 +34,8 @@ router.get('/duplicates', async (req, res) => {
   const limit = parseInt(req.query.limit, 10) || 25;
   const duplicateSQL = `
     SELECT COUNT(p.uuid) AS num_patients, p.display_name,
-    GROUP_CONCAT(CONCAT(BUID(p.uuid), ':', em.text)) AS others
-    FROM patient p LEFT JOIN entity_map em ON p.uuid = em.uuid
+    GROUP_CONCAT(CONCAT(BUID(p.uuid), ':', em.short_name)) AS others
+    FROM patient p LEFT JOIN uuid_map em ON p.uuid = em.uuid
     GROUP BY LOWER(p.display_name) HAVING COUNT(p.uuid) > ?
     ORDER BY COUNT(p.uuid) DESC
     LIMIT ?;
@@ -119,7 +119,7 @@ router.post('/', async (req, res) => {
     DELETE FROM patient WHERE uuid IN (?);
   `;
   const removeOtherEntityMap = `
-    DELETE FROM entity_map WHERE uuid IN (?);
+    DELETE FROM uuid_map WHERE uuid IN (?);
   `;
 
   const patient = await db.one(getSelectedDebtorUuid, [selectedPatientUuid]);

--- a/server/controllers/medical/patients/visits.js
+++ b/server/controllers/medical/patients/visits.js
@@ -35,7 +35,7 @@ const COLUMNS = `
   ISNULL(patient_visit.end_date) AS is_open, icd10.label as start_diagnosis_label, icd10.code as start_diagnosis_code,
   patient_visit.hospitalized,
   z.bed_label, z.room_label, z.ward_name,
-  patient.display_name, patient.hospital_no, patient.sex, em.text AS reference,
+  patient.display_name, patient.hospital_no, patient.sex, em.short_name AS reference,
   s.name AS service_name,
   dt.label AS discharge_label,
   inside_health_zone, is_new_case, is_refered, is_pregnant, BUID(last_service_uuid) AS last_service_uuid,
@@ -63,7 +63,7 @@ const TABLES = `
   patient_visit
   JOIN service s ON s.uuid = patient_visit.last_service_uuid
   JOIN patient ON patient.uuid = patient_visit.patient_uuid
-  JOIN entity_map em ON em.uuid = patient.uuid
+  JOIN uuid_map em ON em.uuid = patient.uuid
   JOIN user ON patient_visit.user_id = user.id
   LEFT JOIN ${LAST_BED_LOCATION}
   LEFT JOIN discharge_type dt ON dt.id = patient_visit.discharge_type_id
@@ -94,7 +94,7 @@ function find(options) {
   filters.dateTo('custom_period_end', 'start_date', 'patient_visit');
 
   filters.fullText('display_name', 'display_name', 'patient');
-  filters.custom('reference', 'em.text = ?');
+  filters.custom('reference', 'em.short_name = ?');
   filters.equals('hospital_no');
   filters.equals('user_id', 'user_id', 'patient_visit');
 

--- a/server/controllers/payroll/employees/index.js
+++ b/server/controllers/payroll/employees/index.js
@@ -112,7 +112,7 @@ function lookupEmployee(uid) {
       patient.phone, patient.email, patient.address_1 AS adresse, BUID(employee.patient_uuid) AS patient_uuid,
       employee.bank, employee.bank_account, employee.title_employee_id, title_employee.title_txt,
       employee.individual_salary, grade.code AS code_grade, BUID(debtor.uuid) as debtor_uuid,
-      debtor.text AS debtor_text, BUID(debtor.group_uuid) as debtor_group_uuid, entity_map.text AS reference,
+      debtor.text AS debtor_text, BUID(debtor.group_uuid) as debtor_group_uuid, uuid_map.text AS reference,
       BUID(creditor.uuid) as creditor_uuid, creditor.text AS creditor_text,
       BUID(creditor.group_uuid) as creditor_group_uuid, creditor_group.account_id,
       BUID(current_location_id) as current_location_id, BUID(origin_location_id) as origin_location_id
@@ -124,7 +124,7 @@ function lookupEmployee(uid) {
       JOIN creditor ON employee.creditor_uuid = creditor.uuid
       JOIN creditor_group ON creditor_group.uuid = creditor.group_uuid
       LEFT JOIN service ON service.uuid = employee.service_uuid
-      LEFT JOIN entity_map ON entity_map.uuid = employee.creditor_uuid
+      LEFT JOIN uuid_map ON uuid_map.uuid = employee.creditor_uuid
       LEFT JOIN title_employee ON title_employee.id = employee.title_employee_id
     WHERE employee.uuid = ?;
   `;
@@ -428,7 +428,7 @@ function find(options) {
       BUID(creditor.group_uuid) as creditor_group_uuid, creditor_group.account_id,
       BUID(current_location_id) as current_location_id, BUID(origin_location_id) as origin_location_id,
       service.name as service_name, cc.label AS cost_center, cc.id AS cost_center_id,
-      entity_map.text as reference
+      uuid_map.text as reference
     FROM employee
      JOIN grade ON employee.grade_uuid = grade.uuid
      LEFT JOIN fonction ON employee.fonction_id = fonction.id
@@ -439,7 +439,7 @@ function find(options) {
      LEFT JOIN service ON service.uuid = employee.service_uuid
      LEFT JOIN service_cost_center AS scc ON scc.service_uuid = service.uuid
      LEFT JOIN cost_center AS cc ON cc.id = scc.cost_center_id
-     LEFT JOIN entity_map ON entity_map.uuid = employee.creditor_uuid
+     LEFT JOIN uuid_map ON uuid_map.uuid = employee.creditor_uuid
      LEFT JOIN title_employee ON title_employee.id = employee.title_employee_id
   `;
 
@@ -454,7 +454,7 @@ function find(options) {
   filters.equals('grade_uuid', 'grade_uuid', 'employee');
   filters.equals('is_medical', 'is_medical', 'title_employee');
   filters.equals('locked', 'locked', 'employee');
-  filters.equals('reference', 'text', 'entity_map');
+  filters.equals('reference', 'text', 'uuid_map');
   filters.equals('service_uuid', 'service_uuid', 'employee');
   filters.equals('sex', 'sex', 'patient');
   filters.equals('title_employee_id', 'title_employee_id', 'employee');

--- a/server/controllers/payroll/employees/index.js
+++ b/server/controllers/payroll/employees/index.js
@@ -112,7 +112,7 @@ function lookupEmployee(uid) {
       patient.phone, patient.email, patient.address_1 AS adresse, BUID(employee.patient_uuid) AS patient_uuid,
       employee.bank, employee.bank_account, employee.title_employee_id, title_employee.title_txt,
       employee.individual_salary, grade.code AS code_grade, BUID(debtor.uuid) as debtor_uuid,
-      debtor.text AS debtor_text, BUID(debtor.group_uuid) as debtor_group_uuid, uuid_map.text AS reference,
+      debtor.text AS debtor_text, BUID(debtor.group_uuid) as debtor_group_uuid, uuid_map.short_name AS reference,
       BUID(creditor.uuid) as creditor_uuid, creditor.text AS creditor_text,
       BUID(creditor.group_uuid) as creditor_group_uuid, creditor_group.account_id,
       BUID(current_location_id) as current_location_id, BUID(origin_location_id) as origin_location_id
@@ -428,7 +428,7 @@ function find(options) {
       BUID(creditor.group_uuid) as creditor_group_uuid, creditor_group.account_id,
       BUID(current_location_id) as current_location_id, BUID(origin_location_id) as origin_location_id,
       service.name as service_name, cc.label AS cost_center, cc.id AS cost_center_id,
-      uuid_map.text as reference
+      uuid_map.short_name as reference
     FROM employee
      JOIN grade ON employee.grade_uuid = grade.uuid
      LEFT JOIN fonction ON employee.fonction_id = fonction.id

--- a/server/controllers/payroll/multiplePayroll/find.js
+++ b/server/controllers/payroll/multiplePayroll/find.js
@@ -35,7 +35,7 @@ function find(options) {
       payroll.hrreference, payroll.cost_center_id, payroll.service_name, 
       IF (payroll.net_salary < 0, 1, 0) AS negativeValue
     FROM(
-      SELECT employee.uuid AS employee_uuid, employee.reference, em.text AS hrreference, employee.code,
+      SELECT employee.uuid AS employee_uuid, employee.reference, em.short_name AS hrreference, employee.code,
         employee.hiring_date, employee.nb_enfant,employee.individual_salary, creditor_group.account_id,
         BUID(employee.creditor_uuid) AS creditor_uuid, fonction.fonction_txt as function_name,
         UPPER(patient.display_name) AS display_name, patient.sex, BUID(payment.uuid) AS payment_uuid,
@@ -45,7 +45,7 @@ function find(options) {
         payment.status_id, payment_status.text AS status, cost_center.id AS cost_center_id,
         service.name AS service_name
         FROM employee
-          JOIN entity_map em ON employee.creditor_uuid = em.uuid
+          JOIN uuid_map em ON employee.creditor_uuid = em.uuid
           JOIN creditor ON creditor.uuid = employee.creditor_uuid
           JOIN creditor_group ON creditor_group.uuid = creditor.group_uuid
           JOIN patient ON patient.uuid = employee.patient_uuid
@@ -61,7 +61,7 @@ function find(options) {
           LEFT JOIN service ON service.uuid = employee.service_uuid
         WHERE payment.payroll_configuration_id = '${options.payroll_configuration_id}'
       UNION
-        SELECT employee.uuid AS employee_uuid,  employee.reference, em.text AS hrreference, employee.code,
+        SELECT employee.uuid AS employee_uuid,  employee.reference, em.short_name AS hrreference, employee.code,
           employee.hiring_date, employee.nb_enfant, employee.individual_salary, creditor_group.account_id,
         BUID(employee.creditor_uuid) AS creditor_uuid, fonction.fonction_txt as function_name,
         UPPER(patient.display_name) AS display_name,
@@ -72,7 +72,7 @@ function find(options) {
         'PAYROLL_STATUS.WAITING_FOR_CONFIGURATION' AS status, cost_center.id AS cost_center_id,
         service.name AS service_name
         FROM employee
-          JOIN entity_map em ON employee.creditor_uuid = em.uuid
+          JOIN uuid_map em ON employee.creditor_uuid = em.uuid
           JOIN creditor ON creditor.uuid = employee.creditor_uuid
           JOIN creditor_group ON creditor_group.uuid = creditor.group_uuid
           JOIN patient ON patient.uuid = employee.patient_uuid

--- a/server/controllers/payroll/multiplePayrollIndice/index.js
+++ b/server/controllers/payroll/multiplePayrollIndice/index.js
@@ -78,7 +78,7 @@ async function lookUp(options) {
       JOIN grade gr ON gr.uuid = emp.grade_uuid
       LEFT JOIN service ON emp.service_uuid = service.uuid
       JOIN patient pt ON pt.uuid = emp.patient_uuid
-      JOIN entity_map map ON map.uuid = emp.creditor_uuid
+      JOIN uuid_map map ON map.uuid = emp.creditor_uuid
     WHERE pc.id = ?
       ${employeeUuid ? ' AND emp.uuid = ?' : ''}
     ORDER BY pt.display_name ASC

--- a/server/controllers/payroll/multiplePayrollIndice/index.js
+++ b/server/controllers/payroll/multiplePayrollIndice/index.js
@@ -11,12 +11,22 @@ exports.parameters = require('./parameters.config');
 exports.reports = require('./report');
 
 // retrieve indice's value for employee(s)
+/**
+ *
+ * @param req
+ * @param res
+ */
 async function read(req, res) {
   const rows = await lookUp(req.query);
   res.status(200).json(rows);
 }
 
 // specifying indice's value for an employee
+/**
+ *
+ * @param req
+ * @param res
+ */
 async function create(req, res) {
   const currencyId = req.body.currency_id;
   const payrollConfigurationId = req.body.payroll_configuration_id;
@@ -64,13 +74,17 @@ async function create(req, res) {
 }
 
 // retrieve indice's value for employee(s)
+/**
+ *
+ * @param options
+ */
 async function lookUp(options) {
   const payConfigId = options.payroll_configuration_id;
   const employeeUuid = options.employee_uuid;
 
   const employeeSql = `
-    SELECT BUID(emp.uuid) AS uuid,UPPER(pt.display_name) AS display_name, pt.sex, service.name as service_name,
-    BUID(emp.grade_uuid) AS grade_uuid, map.text AS employee_reference
+    SELECT BUID(emp.uuid) AS uuid, UPPER(pt.display_name) AS display_name, pt.sex, service.name as service_name,
+    BUID(emp.grade_uuid) AS grade_uuid, map.short_name AS employee_reference
     FROM payroll_configuration pc
       JOIN config_employee ce ON ce.id = pc.config_employee_id
       JOIN config_employee_item cei ON cei.config_employee_id = ce.id

--- a/server/controllers/payroll/multiplePayrollIndice/parameters.config.js
+++ b/server/controllers/payroll/multiplePayrollIndice/parameters.config.js
@@ -1,6 +1,5 @@
 /**
- * @method find
- *
+ * @function find
  * @description
  * This method will apply filters from the options object passed in to
  * filter.
@@ -15,6 +14,11 @@ const { uuid } = require('../../../lib/util');
 const i18n = require('../../../lib/helpers/translate');
 
 // get staffing indice parameters
+/**
+ *
+ * @param req
+ * @param res
+ */
 async function detail(req, res) {
   const sql = `
     SELECT BUID(uuid) as uuid, pay_envelope, pension_fund, working_days, payroll_configuration_id
@@ -27,6 +31,11 @@ async function detail(req, res) {
 }
 
 // settup staffing indice parameters
+/**
+ *
+ * @param req
+ * @param res
+ */
 async function create(req, res) {
   const data = req.body;
   const { lang } = data;
@@ -448,6 +457,10 @@ async function create(req, res) {
   res.sendStatus(201);
 }
 
+/**
+ *
+ * @param payrollConfigurationId
+ */
 function stagePaymentIndice(payrollConfigurationId) {
   const sqlGetStagePaymentIndice = `
     SELECT BUID(spi.employee_uuid) AS employee_uuid, rub.id AS rubric_id, rub.label,
@@ -521,7 +534,6 @@ function stagePaymentIndice(payrollConfigurationId) {
  * Import Payroll Configuration for a payroll configuration
  *
  * POST /multiple_payroll_indice/upload/:payroll_config_id'
- *
  * @param {object} req - the request object
  * @param {object} res - the response object
  */
@@ -559,7 +571,7 @@ async function importConfig(req, res) {
 
   const sqlGetEmployees = `
       SELECT BUID(emp.uuid) AS employee_uuid, pat.display_name AS employee_display_name,
-      cemp.label, cemp.id, pc.id payroll_configuration_id, map.text AS employee_reference
+      cemp.label, cemp.id, pc.id payroll_configuration_id, map.short_name AS employee_reference
       FROM employee AS emp
       JOIN patient AS pat ON pat.uuid = emp.patient_uuid
       JOIN uuid_map map ON map.uuid = emp.creditor_uuid

--- a/server/controllers/payroll/multiplePayrollIndice/parameters.config.js
+++ b/server/controllers/payroll/multiplePayrollIndice/parameters.config.js
@@ -562,7 +562,7 @@ async function importConfig(req, res) {
       cemp.label, cemp.id, pc.id payroll_configuration_id, map.text AS employee_reference
       FROM employee AS emp
       JOIN patient AS pat ON pat.uuid = emp.patient_uuid
-      JOIN entity_map map ON map.uuid = emp.creditor_uuid
+      JOIN uuid_map map ON map.uuid = emp.creditor_uuid
       JOIN config_employee_item AS cei ON cei.employee_uuid = emp.uuid
       JOIN config_employee AS cemp ON cemp.id = cei.config_employee_id
       JOIN payroll_configuration AS pc ON pc.config_employee_id = cemp.id

--- a/server/controllers/stock/core.js
+++ b/server/controllers/stock/core.js
@@ -111,7 +111,7 @@ function getLotFilters(parameters, tableAlias = 'm') {
   filters.equals('period_id', 'period_id', tableAlias);
   filters.equals('is_exit', 'is_exit', tableAlias);
   filters.equals('flux_id', 'flux_id', tableAlias, true);
-  filters.equals('reference', 'text', 'dm');
+  filters.equals('reference', 'short_name', 'dm');
   filters.equals('service_uuid', 'uuid', 'serv');
   filters.equals('invoice_uuid', 'invoice_uuid', tableAlias);
   filters.equals('purchase_uuid', 'entity_uuid', tableAlias);
@@ -134,7 +134,7 @@ function getLotFilters(parameters, tableAlias = 'm') {
     'voucherReference',
     `document_uuid = (
       SELECT DISTINCT vi.document_uuid FROM voucher_item AS vi
-      WHERE vi.voucher_uuid = (SELECT uuid FROM uuid_map WHERE uuid_map.text = ?)
+      WHERE vi.voucher_uuid = (SELECT uuid FROM uuid_map WHERE uuid_map.short_name = ?)
     )`,
   );
 
@@ -153,7 +153,7 @@ function getLotFilters(parameters, tableAlias = 'm') {
   // an "IN" filter because the patient could have a patient_uuid or debtor_uuid specified.
   filters.custom(
     'patientReference',
-    'entity_uuid IN (SELECT uuid FROM uuid_map WHERE text = ?)',
+    'entity_uuid IN (SELECT uuid FROM uuid_map WHERE short_name = ?)',
   );
 
   filters.period('defaultPeriod', 'date', tableAlias);
@@ -557,12 +557,12 @@ async function getLotsDepot(depotUuid, params, finalClause) {
   // an "IN" filter because the patient could have a patient_uuid or debtor_uuid specified.
   innerFilters.custom(
     'patientReference',
-    'entity_uuid IN (SELECT uuid FROM uuid_map WHERE text = ?)',
+    'entity_uuid IN (SELECT uuid FROM uuid_map WHERE short_name = ?)',
   );
 
   // NOTE(@jniles): we may want to include inventory and uuid_map joins in the
   // inner filters for speed in the future, since these may be commonly looked up.
-  // innerFilters.equals('reference', 'text', 'dm');
+  // innerFilters.equals('reference', 'short_name', 'dm');
 
   const lotBalancesSQL = `
     SELECT 
@@ -813,7 +813,7 @@ async function getLotsMovements(depotUuid, params) {
       i.code, i.text,
       BUID(m.depot_uuid) AS depot_uuid, m.is_exit, m.date, BUID(m.document_uuid) AS document_uuid,
       m.flux_id, BUID(m.entity_uuid) AS entity_uuid, m.unit_cost,
-      f.label AS flux_label, i.delay, BUID(m.invoice_uuid) AS invoice_uuid, idm.text AS invoice_reference,
+      f.label AS flux_label, i.delay, BUID(m.invoice_uuid) AS invoice_uuid, idm.short_name AS invoice_reference,
       IF(ISNULL(iu.token), iu.text, CONCAT("INVENTORY.UNITS.",iu.token,".TEXT")) AS unit_type,
       fs.label AS funding_source_label, fs.code AS funding_source_code,
       BUID(fs.uuid) AS funding_source_uuid,
@@ -858,7 +858,7 @@ async function getMovements(depotUuid, params) {
     BUID(m.document_uuid) AS document_uuid,
     m.flux_id, BUID(m.entity_uuid) AS entity_uuid, SUM(m.unit_cost * m.quantity) AS cost,
     f.label AS flux_label, BUID(m.invoice_uuid) AS invoice_uuid, dm.short_name AS documentReference,
-    BUID(m.stock_requisition_uuid) AS stock_requisition_uuid, sr_m.text AS document_requisition,
+    BUID(m.stock_requisition_uuid) AS stock_requisition_uuid, sr_m.short_name AS document_requisition,
     u.display_name AS userName, IFNULL(dp.text, IFNULL(serv.name, IFNULL(em.short_name, dm2.short_name))) AS target, sv.wac,
     fs.label AS funding_source_label, fs.code AS funding_source_code,
     BUID(fs.uuid) AS funding_source_uuid 

--- a/server/controllers/stock/core.js
+++ b/server/controllers/stock/core.js
@@ -134,7 +134,7 @@ function getLotFilters(parameters, tableAlias = 'm') {
     'voucherReference',
     `document_uuid = (
       SELECT DISTINCT vi.document_uuid FROM voucher_item AS vi
-      WHERE vi.voucher_uuid = (SELECT uuid FROM document_map WHERE document_map.text = ?)
+      WHERE vi.voucher_uuid = (SELECT uuid FROM uuid_map WHERE uuid_map.text = ?)
     )`,
   );
 
@@ -153,7 +153,7 @@ function getLotFilters(parameters, tableAlias = 'm') {
   // an "IN" filter because the patient could have a patient_uuid or debtor_uuid specified.
   filters.custom(
     'patientReference',
-    'entity_uuid IN (SELECT uuid FROM entity_map WHERE text = ?)',
+    'entity_uuid IN (SELECT uuid FROM uuid_map WHERE text = ?)',
   );
 
   filters.period('defaultPeriod', 'date', tableAlias);
@@ -230,13 +230,13 @@ function getLots(sqlQuery, parameters, finalClause = '', orderBy = '') {
         i.code, i.text, BUID(m.depot_uuid) AS depot_uuid, d.text AS depot_text,
         IF(ISNULL(iu.token), iu.text, CONCAT("INVENTORY.UNITS.",iu.token,".TEXT")) AS unit_type,
         BUID(ig.uuid) AS group_uuid, ig.name AS group_name,
-        dm.text AS documentReference, ser.name AS service_name, sv.wac
+        dm.short_name AS documentReference, ser.name AS service_name, sv.wac
       FROM lot l
         JOIN inventory i ON i.uuid = l.inventory_uuid
         JOIN inventory_unit iu ON iu.id = i.unit_id
         JOIN inventory_group ig ON ig.uuid = i.group_uuid
         JOIN stock_movement m ON m.lot_uuid = l.uuid AND m.flux_id = ${flux.FROM_PURCHASE}
-        LEFT JOIN document_map dm ON dm.uuid = m.document_uuid
+        LEFT JOIN uuid_map dm ON dm.uuid = m.document_uuid
         LEFT JOIN service AS ser ON ser.uuid = m.entity_uuid
         JOIN depot d ON d.uuid = m.depot_uuid
         JOIN stock_value sv ON sv.inventory_uuid = i.uuid
@@ -306,7 +306,7 @@ async function getAssets(params) {
       (((TIMESTAMPDIFF(YEAR, l.acquisition_date, CURRENT_DATE()) * ig.depreciation_rate) / 100)
       * l.unit_cost) AS depreciated_value,
       (l.unit_cost - (((TIMESTAMPDIFF(YEAR, l.acquisition_date, CURRENT_DATE()) * ig.depreciation_rate) / 100)
-      * l.unit_cost)) AS book_value, dm.text AS documentReference,
+      * l.unit_cost)) AS book_value, dm.short_name AS documentReference,
       CONCAT('LT', LEFT(HEX(l.uuid), 8)) AS barcode,
 
       BUID(sa.uuid) AS assignment_uuid, BUID(sa.entity_uuid) AS assigned_to_uuid,
@@ -326,7 +326,7 @@ async function getAssets(params) {
       JOIN inventory_unit iu ON iu.id = i.unit_id
       JOIN inventory_group ig ON ig.uuid = i.group_uuid
       JOIN depot d ON d.uuid = m.depot_uuid
-      LEFT JOIN document_map dm ON dm.uuid = m.document_uuid
+      LEFT JOIN uuid_map dm ON dm.uuid = m.document_uuid
 
       LEFT JOIN lot_tag lt ON lt.lot_uuid = l.uuid
       LEFT JOIN tags t ON t.uuid = lt.tag_uuid
@@ -427,7 +427,7 @@ async function getLotsDepotWithAssignment(depotUuid, params, finalClause) {
       m.date AS entry_date, i.purchase_interval, i.delay, i.is_count_per_container,
       IF(ISNULL(iu.token), iu.text, CONCAT("INVENTORY.UNITS.",iu.token,".TEXT")) AS unit_type,
       ig.name AS group_name, ig.tracking_expiration, ig.tracking_consumption,
-      dm.text AS documentReference, t.name AS tag_name, t.color, sv.wac,
+      dm.short_name AS documentReference, t.name AS tag_name, t.color, sv.wac,
       fs.label AS funding_source_label, fs.code AS funding_source_code,
       BUID(fs.uuid) AS funding_source_uuid,
       CONCAT('LT', LEFT(HEX(l.uuid), 8)) AS barcode
@@ -439,7 +439,7 @@ async function getLotsDepotWithAssignment(depotUuid, params, finalClause) {
       JOIN inventory_group ig ON ig.uuid = i.group_uuid
       JOIN depot d ON d.uuid = m.depot_uuid
       JOIN stock_value sv ON sv.inventory_uuid = i.uuid
-      LEFT JOIN document_map dm ON dm.uuid = m.document_uuid
+      LEFT JOIN uuid_map dm ON dm.uuid = m.document_uuid
       LEFT JOIN lot_tag lt ON lt.lot_uuid = l.uuid
       LEFT JOIN tags t ON t.uuid = lt.tag_uuid
       LEFT JOIN funding_source fs ON fs.uuid = l.funding_source_uuid
@@ -557,10 +557,10 @@ async function getLotsDepot(depotUuid, params, finalClause) {
   // an "IN" filter because the patient could have a patient_uuid or debtor_uuid specified.
   innerFilters.custom(
     'patientReference',
-    'entity_uuid IN (SELECT uuid FROM entity_map WHERE text = ?)',
+    'entity_uuid IN (SELECT uuid FROM uuid_map WHERE text = ?)',
   );
 
-  // NOTE(@jniles): we may want to include inventory and document_map joins in the
+  // NOTE(@jniles): we may want to include inventory and uuid_map joins in the
   // inner filters for speed in the future, since these may be commonly looked up.
   // innerFilters.equals('reference', 'text', 'dm');
 
@@ -817,7 +817,7 @@ async function getLotsMovements(depotUuid, params) {
       IF(ISNULL(iu.token), iu.text, CONCAT("INVENTORY.UNITS.",iu.token,".TEXT")) AS unit_type,
       fs.label AS funding_source_label, fs.code AS funding_source_code,
       BUID(fs.uuid) AS funding_source_uuid,
-      dm.text AS documentReference, sv.wac
+      dm.short_name AS documentReference, sv.wac
     FROM stock_movement m
     JOIN lot l ON l.uuid = m.lot_uuid
     JOIN inventory i ON i.uuid = l.inventory_uuid
@@ -825,13 +825,13 @@ async function getLotsMovements(depotUuid, params) {
     JOIN depot d ON d.uuid = m.depot_uuid
     JOIN flux f ON f.id = m.flux_id
     JOIN stock_value sv ON sv.inventory_uuid = i.uuid
-    LEFT JOIN document_map dm ON dm.uuid = m.document_uuid
-    LEFT JOIN document_map idm ON idm.uuid = m.invoice_uuid
+    LEFT JOIN uuid_map dm ON dm.uuid = m.document_uuid
+    LEFT JOIN uuid_map idm ON idm.uuid = m.invoice_uuid
     LEFT JOIN service AS serv ON serv.uuid = m.entity_uuid
     LEFT JOIN funding_source fs ON fs.uuid = l.funding_source_uuid
   `;
 
-  const orderBy = 'ORDER BY m.date, dm.text, l.label';
+  const orderBy = 'ORDER BY m.date, dm.short_name, l.label';
   const lots = await getLots(sql, params, finalClause, orderBy);
 
   return lots;
@@ -857,9 +857,9 @@ async function getMovements(depotUuid, params) {
     BUID(m.depot_uuid) AS depot_uuid, m.is_exit, m.date, m.created_at,
     BUID(m.document_uuid) AS document_uuid,
     m.flux_id, BUID(m.entity_uuid) AS entity_uuid, SUM(m.unit_cost * m.quantity) AS cost,
-    f.label AS flux_label, BUID(m.invoice_uuid) AS invoice_uuid, dm.text AS documentReference,
+    f.label AS flux_label, BUID(m.invoice_uuid) AS invoice_uuid, dm.short_name AS documentReference,
     BUID(m.stock_requisition_uuid) AS stock_requisition_uuid, sr_m.text AS document_requisition,
-    u.display_name AS userName, IFNULL(dp.text, IFNULL(serv.name, IFNULL(em.text, dm2.text))) AS target, sv.wac,
+    u.display_name AS userName, IFNULL(dp.text, IFNULL(serv.name, IFNULL(em.short_name, dm2.short_name))) AS target, sv.wac,
     fs.label AS funding_source_label, fs.code AS funding_source_code,
     BUID(fs.uuid) AS funding_source_uuid 
   FROM stock_movement m
@@ -868,12 +868,12 @@ async function getMovements(depotUuid, params) {
     JOIN depot d ON d.uuid = m.depot_uuid
     JOIN flux f ON f.id = m.flux_id
     JOIN user u ON u.id = m.user_id
-    LEFT JOIN document_map dm ON dm.uuid = m.document_uuid
-    LEFT JOIN entity_map em ON em.uuid = m.entity_uuid
+    LEFT JOIN uuid_map dm ON dm.uuid = m.document_uuid
+    LEFT JOIN uuid_map em ON em.uuid = m.entity_uuid
     LEFT JOIN service AS serv ON serv.uuid = m.entity_uuid
     LEFT JOIN depot AS dp ON dp.uuid = m.entity_uuid
-    LEFT JOIN document_map dm2 ON dm2.uuid = m.entity_uuid
-    LEFT JOIN document_map sr_m ON sr_m.uuid = m.stock_requisition_uuid
+    LEFT JOIN uuid_map dm2 ON dm2.uuid = m.entity_uuid
+    LEFT JOIN uuid_map sr_m ON sr_m.uuid = m.stock_requisition_uuid
     JOIN stock_value sv ON sv.inventory_uuid = i.uuid
     LEFT JOIN funding_source fs ON fs.uuid = l.funding_source_uuid 
   `;
@@ -1176,7 +1176,7 @@ async function getInventoryQuantityAndConsumption(params) {
       IF(ISNULL(iu.token), iu.text, CONCAT("INVENTORY.UNITS.",iu.token,".TEXT")) AS unit_type,
       ig.tracking_consumption, ig.tracking_expiration,
       BUID(ig.uuid) AS group_uuid, ig.name AS group_name,
-      dm.text AS documentReference, d.enterprise_id,
+      dm.short_name AS documentReference, d.enterprise_id,
       t.name AS tag_name, t.color AS tag_color, sv.wac
     FROM stock_movement m
       JOIN lot l ON l.uuid = m.lot_uuid
@@ -1184,7 +1184,7 @@ async function getInventoryQuantityAndConsumption(params) {
       JOIN inventory_unit iu ON iu.id = i.unit_id
       JOIN inventory_group ig ON ig.uuid = i.group_uuid
       JOIN depot d ON d.uuid = m.depot_uuid
-      LEFT JOIN document_map dm ON dm.uuid = m.document_uuid
+      LEFT JOIN uuid_map dm ON dm.uuid = m.document_uuid
       LEFT JOIN inventory_tag it ON it.inventory_uuid = i.uuid
       LEFT JOIN tags t ON t.uuid = it.tag_uuid
       JOIN stock_value sv ON sv.inventory_uuid = i.uuid
@@ -1434,17 +1434,17 @@ async function getInventoryMovements(params) {
       i.code, i.text, BUID(m.depot_uuid) AS depot_uuid,
       i.purchase_interval, i.delay,
       IF(ISNULL(iu.token), iu.text, CONCAT("INVENTORY.UNITS.",iu.token,".TEXT")) AS unit_type,
-      dm.text AS documentReference, flux.label as flux, sv.wac,
-      IF(m.flux_id = 8 OR m.flux_id = 2, d2.text, COALESCE(em.text, dm2.text, '')) as entityReference
+      dm.short_name AS documentReference, flux.label as flux, sv.wac,
+      IF(m.flux_id = 8 OR m.flux_id = 2, d2.text, COALESCE(em.short_name, dm2.short_name, '')) as entityReference
     FROM stock_movement m
       JOIN lot l ON l.uuid = m.lot_uuid
       JOIN inventory i ON i.uuid = l.inventory_uuid
       JOIN inventory_unit iu ON iu.id = i.unit_id
       JOIN depot d ON d.uuid = m.depot_uuid
       JOIN flux ON m.flux_id = flux.id
-      JOIN document_map dm ON dm.uuid = m.document_uuid
-      LEFT JOIN entity_map em ON em.uuid = m.entity_uuid
-      LEFT JOIN document_map dm2 ON dm2.uuid = m.entity_uuid
+      JOIN uuid_map dm ON dm.uuid = m.document_uuid
+      LEFT JOIN uuid_map em ON em.uuid = m.entity_uuid
+      LEFT JOIN uuid_map dm2 ON dm2.uuid = m.entity_uuid
       LEFT JOIN depot d2 ON d2.uuid = m.entity_uuid
       JOIN stock_value sv ON sv.inventory_uuid = i.uuid
   `;

--- a/server/controllers/stock/index.js
+++ b/server/controllers/stock/index.js
@@ -1406,19 +1406,19 @@ async function getStockTransfers(req, res) {
     SELECT
       BUID(m.document_uuid) AS document_uuid, m.date,
       d.text AS depot_name, dd.text AS other_depot_name,
-      dm.text AS document_reference,
+      dm.short_name AS document_reference,
       sh.name AS shipment_name,
       sh.created_at AS shipment_date,
-      dm2.text AS shipment_reference,
+      dm2.short_name AS shipment_reference,
       rx.countedReceived
     FROM
       stock_movement m
     JOIN depot d ON d.uuid = m.depot_uuid
     JOIN depot dd ON dd.uuid = m.entity_uuid
-    LEFT JOIN document_map dm ON dm.uuid = m.document_uuid
+    LEFT JOIN uuid_map dm ON dm.uuid = m.document_uuid
     LEFT JOIN (${queryReceived}) rx ON rx.binary_document_uuid = m.document_uuid
     LEFT JOIN shipment sh ON sh.document_uuid = m.document_uuid
-    LEFT JOIN document_map dm2 ON dm2.uuid = sh.uuid
+    LEFT JOIN uuid_map dm2 ON dm2.uuid = sh.uuid
     WHERE dd.uuid = ? AND m.is_exit = 1 AND m.flux_id = ${core.flux.TO_OTHER_DEPOT}
     GROUP BY m.document_uuid
   `;

--- a/server/controllers/stock/reports/common.js
+++ b/server/controllers/stock/reports/common.js
@@ -97,7 +97,7 @@ async function getDepotMovement(documentUuid, enterprise, isExit) {
       l.label, l.expiration_date, d.text AS depot_name, d.is_count_per_container, dd.text as otherDepotName,
       dm.short_name as document_reference, l.package_size, FLOOR(m.quantity / l.package_size) number_package,
       IF(l.package_size <= 1, 0, 1) AS displayDetail,
-      BUID(m.stock_requisition_uuid) AS stock_requisition_uuid, sr_m.text AS document_requisition,
+      BUID(m.stock_requisition_uuid) AS stock_requisition_uuid, sr_m.short_name AS document_requisition,
       BUID(s.uuid) AS shipment_uuid, s.status_id AS shipment_status, ship_dm.text AS shipment_reference
       ${joinToExitAttributes}
     FROM stock_movement m

--- a/server/controllers/stock/reports/common.js
+++ b/server/controllers/stock/reports/common.js
@@ -93,9 +93,9 @@ async function getDepotMovement(documentUuid, enterprise, isExit) {
       BUID(m.document_uuid) AS document_uuid,
       m.quantity, m.unit_cost, (m.quantity * m.unit_cost) AS total, m.date, m.description,
       u.display_name AS user_display_name,
-      dm.text AS document_reference,
+      dm.short_name AS document_reference,
       l.label, l.expiration_date, d.text AS depot_name, d.is_count_per_container, dd.text as otherDepotName,
-      dm.text as document_reference, l.package_size, FLOOR(m.quantity / l.package_size) number_package,
+      dm.short_name as document_reference, l.package_size, FLOOR(m.quantity / l.package_size) number_package,
       IF(l.package_size <= 1, 0, 1) AS displayDetail,
       BUID(m.stock_requisition_uuid) AS stock_requisition_uuid, sr_m.text AS document_requisition,
       BUID(s.uuid) AS shipment_uuid, s.status_id AS shipment_status, ship_dm.text AS shipment_reference
@@ -107,10 +107,10 @@ async function getDepotMovement(documentUuid, enterprise, isExit) {
       JOIN depot d ON d.uuid = m.depot_uuid
       JOIN user u ON u.id = m.user_id
       LEFT JOIN depot dd ON dd.uuid = entity_uuid
-      LEFT JOIN document_map dm ON dm.uuid = m.document_uuid
-      LEFT JOIN document_map sr_m ON sr_m.uuid = m.stock_requisition_uuid
+      LEFT JOIN uuid_map dm ON dm.uuid = m.document_uuid
+      LEFT JOIN uuid_map sr_m ON sr_m.uuid = m.stock_requisition_uuid
       LEFT JOIN shipment s ON s.document_uuid = m.document_uuid
-      LEFT JOIN document_map ship_dm ON ship_dm.uuid = s.uuid
+      LEFT JOIN uuid_map ship_dm ON ship_dm.uuid = s.uuid
       ${joinToExit}
     WHERE m.is_exit = ? AND m.flux_id = ? AND m.document_uuid = ?
     ORDER BY i.text, l.label, l.expiration_date DESC`;
@@ -156,10 +156,10 @@ const pdfOptions = {
  */
 async function getVoucherReferenceForStockMovement(documentUuid) {
   const sql = `
-    SELECT v.uuid, dm.text AS voucher_reference
+    SELECT v.uuid, dm.short_name AS voucher_reference
     FROM voucher AS v
       JOIN voucher_item AS vi ON vi.voucher_uuid = v.uuid
-      JOIN document_map AS dm ON dm.uuid = v.uuid
+      JOIN uuid_map AS dm ON dm.uuid = v.uuid
     WHERE vi.document_uuid = ?
     LIMIT 1;
   `;

--- a/server/controllers/stock/reports/purchase_order_analysis/index.js
+++ b/server/controllers/stock/reports/purchase_order_analysis/index.js
@@ -13,8 +13,9 @@ const DEFAULT_PARAMS = {
 };
 
 /**
+ * @param req
+ * @param res
  * @function report
- *
  * @description
  * This function renders the purchase order analysis report.
  */
@@ -103,13 +104,13 @@ async function report(req, res) {
         l.expiration_date,
         (SELECT MIN(sm.date) FROM stock_movement sm WHERE sm.lot_uuid = l.uuid) AS entry_date,
         iv.code,
-        d.text AS depotText, BUID(sm.uuid) AS stock_movement_uuid, dm1.text AS stock_movement_reference
+        d.text AS depotText, BUID(sm.uuid) AS stock_movement_uuid, dm1.short_name AS stock_movement_reference
       FROM purchase AS p
         JOIN stock_movement AS sm ON sm.entity_uuid = p.uuid
         JOIN lot AS l ON l.uuid = sm.lot_uuid
         JOIN inventory AS iv ON iv.uuid = l.inventory_uuid
         JOIN depot AS d ON d.uuid = sm.depot_uuid
-        JOIN document_map AS dm1 ON dm1.uuid = sm.document_uuid
+        JOIN uuid_map AS dm1 ON dm1.uuid = sm.document_uuid
       WHERE p.uuid = ? AND sm.is_exit = 0 AND sm.flux_id = ?
       ORDER BY iv.text ASC, entry_date ASC
     `;

--- a/server/controllers/stock/reports/purchase_prices/index.js
+++ b/server/controllers/stock/reports/purchase_prices/index.js
@@ -29,7 +29,7 @@ async function report(req, res) {
 
   const entriesSQL = `
     SELECT
-      sm.date, dm.text AS hrReference,
+      sm.date, dm.short_name AS hrReference,
       sm.unit_cost, sm.quantity,
       l.label AS lot_label,
       flux.label AS reason,
@@ -37,7 +37,7 @@ async function report(req, res) {
       sm.user_id, user.display_name AS userName
     FROM stock_movement sm
       JOIN lot l ON l.uuid = sm.lot_uuid
-      JOIN document_map dm ON dm.uuid = sm.document_uuid
+      JOIN uuid_map dm ON dm.uuid = sm.document_uuid
       JOIN inventory inv ON inv.uuid = l.inventory_uuid
       JOIN user ON sm.user_id = user.id
       JOIN flux ON sm.flux_id = flux.id

--- a/server/controllers/stock/reports/stock/adjustment_receipt.js
+++ b/server/controllers/stock/reports/stock/adjustment_receipt.js
@@ -25,12 +25,12 @@ async function stockAdjustmentReceipt(documentUuid, session, options) {
   const sql = `
     SELECT i.code, i.text, BUID(m.document_uuid) AS document_uuid, m.is_exit,
       m.quantity, m.unit_cost, (m.quantity * m.unit_cost) AS total , m.date, m.description,
-      u.display_name AS user_display_name, dm.text AS document_reference,
+      u.display_name AS user_display_name, dm.short_name AS document_reference,
       l.label, l.expiration_date, d.text AS depot_name, m.flux_id,
       sal.new_quantity, sal.old_quantity, (sal.new_quantity - sal.old_quantity) AS difference
     FROM stock_movement m
       LEFT JOIN stock_adjustment_log sal ON sal.movement_uuid = m.uuid
-      JOIN document_map dm ON dm.uuid = m.document_uuid
+      JOIN uuid_map dm ON dm.uuid = m.document_uuid
       JOIN lot l ON l.uuid = m.lot_uuid
       JOIN inventory i ON i.uuid = l.inventory_uuid
       JOIN depot d ON d.uuid = m.depot_uuid

--- a/server/controllers/stock/reports/stock/entry/entryFromDonation.js
+++ b/server/controllers/stock/reports/stock/entry/entryFromDonation.js
@@ -14,14 +14,14 @@ function fetch(depotUuid, dateFrom, dateTo, showDetails) {
     SUM(m.quantity) as quantity, m.date, m.description,
     u.display_name AS user_display_name,
     SUM(m.quantity * m.unit_cost) AS cost, m.unit_cost,
-    dm.text AS document_reference, d.text AS depot_name
+    dm.short_name AS document_reference, d.text AS depot_name
   FROM stock_movement m
     JOIN lot l ON l.uuid = m.lot_uuid
     JOIN inventory i ON i.uuid = l.inventory_uuid
     JOIN inventory_unit iu ON iu.id = i.unit_id 
     JOIN depot d ON d.uuid = m.depot_uuid
     JOIN user u ON u.id = m.user_id
-    LEFT JOIN document_map dm ON dm.uuid = m.document_uuid
+    LEFT JOIN uuid_map dm ON dm.uuid = m.document_uuid
   WHERE m.is_exit = ${IS_EXIT} AND m.flux_id = ${ENTRY_FROM_DONATION_ID} AND d.uuid = ? 
     AND (DATE(m.date) BETWEEN DATE(?) AND DATE(?))
   GROUP BY i.uuid`;

--- a/server/controllers/stock/reports/stock/entry/entryFromIntegration.js
+++ b/server/controllers/stock/reports/stock/entry/entryFromIntegration.js
@@ -14,14 +14,14 @@ function fetch(depotUuid, dateFrom, dateTo, showDetails) {
     SUM(m.quantity) as quantity, m.date, m.description,
     u.display_name AS user_display_name,
     SUM(m.quantity * m.unit_cost) AS cost, m.unit_cost,
-    dm.text AS document_reference, d.text AS depot_name
+    dm.short_name AS document_reference, d.text AS depot_name
   FROM stock_movement m
     JOIN lot l ON l.uuid = m.lot_uuid
     JOIN inventory i ON i.uuid = l.inventory_uuid
     JOIN inventory_unit iu ON iu.id = i.unit_id
     JOIN depot d ON d.uuid = m.depot_uuid
     JOIN user u ON u.id = m.user_id
-    LEFT JOIN document_map dm ON dm.uuid = m.document_uuid
+    LEFT JOIN uuid_map dm ON dm.uuid = m.document_uuid
   WHERE m.is_exit = ${IS_EXIT} AND m.flux_id = ${ENTRY_FROM_INTEGRATION_ID} AND d.uuid = ?
     AND (DATE(m.date) BETWEEN DATE(?) AND DATE(?))
   GROUP BY i.uuid`;

--- a/server/controllers/stock/reports/stock/entry/entryFromPurchase.js
+++ b/server/controllers/stock/reports/stock/entry/entryFromPurchase.js
@@ -14,8 +14,8 @@ function fetch(depotUuid, dateFrom, dateTo, showDetails) {
     SUM(m.quantity) as quantity, m.date, m.description,
     SUM(m.quantity * m.unit_cost) AS cost, m.unit_cost,
     u.display_name AS user_display_name, sup.display_name AS supplier_display_name,
-    dm.text AS document_reference, d.text AS depot_name,
-    dm2.text AS purchase_reference
+    dm.short_name AS document_reference, d.text AS depot_name,
+    dm2.short_name AS purchase_reference
   FROM stock_movement m
     JOIN lot l ON l.uuid = m.lot_uuid
     JOIN inventory i ON i.uuid = l.inventory_uuid
@@ -24,8 +24,8 @@ function fetch(depotUuid, dateFrom, dateTo, showDetails) {
     JOIN purchase p ON p.uuid = m.entity_uuid
     JOIN supplier sup ON sup.uuid = p.supplier_uuid
     JOIN user u ON u.id = m.user_id
-    LEFT JOIN document_map dm ON dm.uuid = m.document_uuid
-    LEFT JOIN document_map dm2 ON dm2.uuid = p.uuid
+    LEFT JOIN uuid_map dm ON dm.uuid = m.document_uuid
+    LEFT JOIN uuid_map dm2 ON dm2.uuid = p.uuid
   WHERE m.is_exit = ${IS_EXIT} AND m.flux_id = ${FROM_PURCHASE} AND d.uuid = ?
     AND (DATE(m.date) BETWEEN DATE(?) AND DATE(?))
   GROUP BY i.uuid`;

--- a/server/controllers/stock/reports/stock/entry/entryFromTransfer.js
+++ b/server/controllers/stock/reports/stock/entry/entryFromTransfer.js
@@ -14,7 +14,7 @@ function fetch(depotUuid, dateFrom, dateTo, showDetails) {
       SUM(m.quantity) as quantity, m.date, m.description,
       SUM(m.quantity * m.unit_cost) AS cost, m.unit_cost,
       u.display_name AS user_display_name,
-      dm.text AS document_reference, dd.text AS depot_name
+      dm.short_name AS document_reference, dd.text AS depot_name
     FROM stock_movement m
       JOIN lot l ON l.uuid = m.lot_uuid
       JOIN inventory i ON i.uuid = l.inventory_uuid
@@ -22,7 +22,7 @@ function fetch(depotUuid, dateFrom, dateTo, showDetails) {
       JOIN depot d ON d.uuid = m.depot_uuid
       JOIN depot dd ON dd.uuid = m.entity_uuid
       JOIN user u ON u.id = m.user_id
-      LEFT JOIN document_map dm ON dm.uuid = m.document_uuid
+      LEFT JOIN uuid_map dm ON dm.uuid = m.document_uuid
     WHERE m.is_exit = ${IS_EXIT} AND m.flux_id = ${ENTRY_FROM_DEPOT_ID} AND d.uuid = ?
       AND (DATE(m.date) BETWEEN DATE(?) AND DATE(?))
     GROUP BY i.uuid`;

--- a/server/controllers/stock/reports/stock/entry_donation_receipt.js
+++ b/server/controllers/stock/reports/stock/entry_donation_receipt.js
@@ -28,7 +28,7 @@ async function stockEntryDonationReceipt(documentUuid, session, options) {
       m.quantity, m.unit_cost, (m.quantity * m.unit_cost) AS total , m.date, m.description,
       u.display_name AS user_display_name,
       l.label, l.expiration_date, d.text AS depot_name, d.is_count_per_container,
-      dm.text as document_reference, ig.tracking_expiration,
+      dm.short_name as document_reference, ig.tracking_expiration,
       IF(ig.tracking_expiration = 1, TRUE, FALSE) as expires,
       l.package_size, FLOOR(m.quantity / l.package_size) number_package,
       IF(l.package_size <= 1, 0, 1) AS displayDetail,
@@ -39,7 +39,7 @@ async function stockEntryDonationReceipt(documentUuid, session, options) {
       JOIN inventory_group ig ON ig.uuid = i.group_uuid
       JOIN depot d ON d.uuid = m.depot_uuid
       JOIN user u ON u.id = m.user_id
-      LEFT JOIN document_map dm ON dm.uuid = m.document_uuid
+      LEFT JOIN uuid_map dm ON dm.uuid = m.document_uuid
       LEFT JOIN funding_source fs ON fs.uuid = l.funding_source_uuid
       WHERE m.is_exit = 0 AND m.flux_id = ${Stock.flux.FROM_DONATION} AND m.document_uuid = ?
     ORDER BY i.text, l.label

--- a/server/controllers/stock/reports/stock/entry_integration_receipt.js
+++ b/server/controllers/stock/reports/stock/entry_integration_receipt.js
@@ -27,7 +27,7 @@ async function stockEntryIntegrationReceipt(documentUuid, session, options) {
       l.label, l.expiration_date, d.text AS depot_name, d.is_count_per_container,
       m.description, ig.tracking_expiration,
       IF(ig.tracking_expiration = 1, TRUE, FALSE) as expires,
-      dm.text as document_reference, l.package_size, FLOOR(m.quantity / l.package_size) number_package,
+      dm.short_name as document_reference, l.package_size, FLOOR(m.quantity / l.package_size) number_package,
       IF(l.package_size <= 1, 0, 1) AS displayDetail,
       fs.label AS funding_source_label
     FROM stock_movement m
@@ -36,7 +36,7 @@ async function stockEntryIntegrationReceipt(documentUuid, session, options) {
     JOIN inventory_group ig ON ig.uuid = i.group_uuid
     JOIN depot d ON d.uuid = m.depot_uuid
     JOIN user u ON u.id = m.user_id
-    LEFT JOIN document_map dm ON dm.uuid = m.document_uuid
+    LEFT JOIN uuid_map dm ON dm.uuid = m.document_uuid
     LEFT JOIN funding_source fs ON fs.uuid = l.funding_source_uuid
     WHERE m.is_exit = 0 AND m.flux_id = ${Stock.flux.FROM_INTEGRATION} AND m.document_uuid = ?
     ORDER BY i.text, l.label

--- a/server/controllers/stock/reports/stock/entry_purchase_receipt.js
+++ b/server/controllers/stock/reports/stock/entry_purchase_receipt.js
@@ -27,10 +27,10 @@ async function stockEntryPurchaseReceipt(documentUuid, session, options) {
       m.quantity, m.unit_cost, (m.quantity * m.unit_cost) AS total , m.date, m.description,
       u.display_name AS user_display_name,
       l.label, l.expiration_date, d.text AS depot_name, d.is_count_per_container,
-      dm2.text AS purchase_reference,
+      dm2.short_name AS purchase_reference,
       p.note, p.cost, p.shipping_handling, p.currency_id, BUID(p.uuid) as po_uuid,
       p.date AS purchase_date, p.payment_method, s.display_name AS supplier_display_name,
-      dm.text as document_reference, ig.tracking_expiration,
+      dm.short_name as document_reference, ig.tracking_expiration,
       IF(ig.tracking_expiration = 1, TRUE, FALSE) as expires,
       l.package_size, FLOOR(m.quantity / l.package_size) number_package,
       IF(l.package_size <= 1, 0, 1) AS displayDetail,
@@ -43,8 +43,8 @@ async function stockEntryPurchaseReceipt(documentUuid, session, options) {
       JOIN user u ON u.id = m.user_id
       LEFT JOIN purchase p ON p.uuid = m.entity_uuid
       LEFT JOIN supplier s ON s.uuid = p.supplier_uuid
-      LEFT JOIN document_map dm ON dm.uuid = m.document_uuid
-      LEFT JOIN document_map dm2 ON dm2.uuid = m.entity_uuid
+      LEFT JOIN uuid_map dm ON dm.uuid = m.document_uuid
+      LEFT JOIN uuid_map dm2 ON dm2.uuid = m.entity_uuid
       LEFT JOIN funding_source fs ON fs.uuid = l.funding_source_uuid
     WHERE m.is_exit = 0 AND m.flux_id = ${Stock.flux.FROM_PURCHASE} AND m.document_uuid = ?
     ORDER BY i.text, l.label

--- a/server/controllers/stock/reports/stock/exit/exitToDepot.js
+++ b/server/controllers/stock/reports/stock/exit/exitToDepot.js
@@ -14,7 +14,7 @@ function fetch(depotUuid, dateFrom, dateTo, showDetails) {
     SUM(m.quantity * m.unit_cost) AS cost, m.unit_cost,
     SUM(m.quantity) as quantity, m.date, m.description,
     u.display_name AS user_display_name,
-    dm.text AS document_reference, dd.text AS depot_name
+    dm.short_name AS document_reference, dd.text AS depot_name
   FROM stock_movement m
     JOIN lot l ON l.uuid = m.lot_uuid
     JOIN inventory i ON i.uuid = l.inventory_uuid
@@ -22,7 +22,7 @@ function fetch(depotUuid, dateFrom, dateTo, showDetails) {
     JOIN depot d ON d.uuid = m.depot_uuid
     JOIN depot dd ON dd.uuid = m.entity_uuid
     JOIN user u ON u.id = m.user_id
-    JOIN document_map dm ON dm.uuid = m.document_uuid
+    JOIN uuid_map dm ON dm.uuid = m.document_uuid
   WHERE m.is_exit = ${IS_EXIT} AND m.flux_id = ${EXIT_TO_DEPOT_ID} AND d.uuid = ? 
     AND (DATE(m.date) BETWEEN DATE(?) AND DATE(?))
   GROUP BY i.uuid`;

--- a/server/controllers/stock/reports/stock/exit/exitToLoss.js
+++ b/server/controllers/stock/reports/stock/exit/exitToLoss.js
@@ -14,14 +14,14 @@ function fetch(depotUuid, dateFrom, dateTo, showDetails) {
     SUM(m.quantity * m.unit_cost) AS cost, m.unit_cost,
     SUM(m.quantity) as quantity, m.date, m.description,
     u.display_name AS user_display_name,
-    dm.text AS document_reference
+    dm.short_name AS document_reference
   FROM stock_movement m
     JOIN lot l ON l.uuid = m.lot_uuid
     JOIN inventory i ON i.uuid = l.inventory_uuid
     JOIN inventory_unit iu ON iu.id = i.unit_id 
     JOIN depot d ON d.uuid = m.depot_uuid
     JOIN user u ON u.id = m.user_id
-    JOIN document_map dm ON dm.uuid = m.document_uuid
+    JOIN uuid_map dm ON dm.uuid = m.document_uuid
   WHERE m.is_exit = ${IS_EXIT} AND m.flux_id = ${EXIT_TO_LOSS_ID} AND d.uuid = ? 
     AND (DATE(m.date) BETWEEN DATE(?) AND DATE(?))
   GROUP BY i.uuid`;

--- a/server/controllers/stock/reports/stock/exit/exitToPatient.js
+++ b/server/controllers/stock/reports/stock/exit/exitToPatient.js
@@ -14,8 +14,8 @@ function fetch(depotUuid, dateFrom, dateTo, showDetails) {
     SUM(m.quantity * m.unit_cost) AS cost, m.unit_cost,
     SUM(m.quantity) as quantity, m.date, m.description,
     u.display_name AS user_display_name, p.display_name AS patient_display_name,
-    dm.text AS document_reference, d.text AS depot_name,
-    em.text AS patient_reference, dm2.text AS invoice_reference
+    dm.short_name AS document_reference, d.text AS depot_name,
+    em.short_name AS patient_reference, dm2.short_name AS invoice_reference
   FROM stock_movement m
     JOIN lot l ON l.uuid = m.lot_uuid
     JOIN inventory i ON i.uuid = l.inventory_uuid
@@ -24,10 +24,10 @@ function fetch(depotUuid, dateFrom, dateTo, showDetails) {
     JOIN patient p ON p.uuid = m.entity_uuid
     JOIN project proj ON proj.id = p.project_id
     JOIN user u ON u.id = m.user_id
-    JOIN document_map dm ON dm.uuid = m.document_uuid
+    JOIN uuid_map dm ON dm.uuid = m.document_uuid
     LEFT JOIN invoice iv ON iv.uuid = m.invoice_uuid
-    LEFT JOIN document_map dm2 ON dm2.uuid = iv.uuid
-    LEFT JOIN entity_map em ON em.uuid = p.uuid
+    LEFT JOIN uuid_map dm2 ON dm2.uuid = iv.uuid
+    LEFT JOIN uuid_map em ON em.uuid = p.uuid
   WHERE m.is_exit = ${IS_EXIT} AND m.flux_id = ${EXIT_TO_PATIENT_ID} AND d.uuid = ?
     AND (DATE(m.date) BETWEEN DATE(?) AND DATE(?))
   GROUP BY i.uuid`;

--- a/server/controllers/stock/reports/stock/exit/exitToService.js
+++ b/server/controllers/stock/reports/stock/exit/exitToService.js
@@ -14,7 +14,7 @@ function fetch(depotUuid, dateFrom, dateTo, showDetails) {
     SUM(m.quantity * m.unit_cost) AS cost, m.unit_cost,
     SUM(m.quantity) as quantity, m.date, m.description,
     u.display_name AS user_display_name,
-    dm.text AS document_reference, d.text AS depot_name,
+    dm.short_name AS document_reference, d.text AS depot_name,
     s.name AS service_display_name
   FROM stock_movement m
     JOIN lot l ON l.uuid = m.lot_uuid
@@ -23,7 +23,7 @@ function fetch(depotUuid, dateFrom, dateTo, showDetails) {
     JOIN depot d ON d.uuid = m.depot_uuid
     JOIN service s ON s.uuid = m.entity_uuid
     JOIN user u ON u.id = m.user_id
-    JOIN document_map dm ON dm.uuid = m.document_uuid
+    JOIN uuid_map dm ON dm.uuid = m.document_uuid
   WHERE m.is_exit = ${IS_EXIT} AND m.flux_id = ${EXIT_TO_SERVICE_ID} AND d.uuid = ?
     AND (DATE(m.date) BETWEEN DATE(?) AND DATE(?))
   GROUP BY i.uuid`;

--- a/server/controllers/stock/reports/stock/exit_loss_receipt.js
+++ b/server/controllers/stock/reports/stock/exit_loss_receipt.js
@@ -34,7 +34,7 @@ async function stockExitLossReceipt(documentUuid, session, options) {
       BUID(m.document_uuid) AS document_uuid,
       m.quantity, m.unit_cost, (m.quantity * m.unit_cost) AS total , m.date, m.description,
       u.display_name AS user_display_name,
-      dm.text AS document_reference,
+      dm.short_name AS document_reference,
       l.label, l.expiration_date, d.text AS depot_name, d.is_count_per_container,
       l.package_size, FLOOR(m.quantity / l.package_size) number_package,
       IF(l.package_size <= 1, 0, 1) AS displayDetail
@@ -44,7 +44,7 @@ async function stockExitLossReceipt(documentUuid, session, options) {
     JOIN inventory_unit iu ON iu.id = i.unit_id
     JOIN depot d ON d.uuid = m.depot_uuid
     JOIN user u ON u.id = m.user_id
-    LEFT JOIN document_map dm ON dm.uuid = m.document_uuid
+    LEFT JOIN uuid_map dm ON dm.uuid = m.document_uuid
     WHERE m.is_exit = 1 AND m.flux_id = ${Stock.flux.TO_LOSS} AND m.document_uuid = ?
   `;
 

--- a/server/controllers/stock/reports/stock/exit_patient_receipt.js
+++ b/server/controllers/stock/reports/stock/exit_patient_receipt.js
@@ -38,7 +38,7 @@ async function stockExitPatientReceipt(documentUuid, session, options) {
       BUID(m.document_uuid) AS document_uuid,
       m.quantity, m.unit_cost, (m.quantity * m.unit_cost) AS total , m.date, m.description,
       u.display_name AS user_display_name, p.display_name AS patient_display_name,
-      dm.text AS document_reference,  BUID(m.invoice_uuid) as invoice_uuid,
+      dm.short_name AS document_reference,  BUID(m.invoice_uuid) as invoice_uuid,
       CONCAT_WS('.', '${identifiers.PATIENT.key}', proj.abbr, p.reference) AS patient_reference, p.hospital_no,
       l.label, l.expiration_date, d.text AS depot_name
     FROM stock_movement m
@@ -49,7 +49,7 @@ async function stockExitPatientReceipt(documentUuid, session, options) {
     JOIN patient p ON p.uuid = m.entity_uuid
     JOIN project proj ON proj.id = p.project_id
     JOIN user u ON u.id = m.user_id
-    LEFT JOIN document_map dm ON dm.uuid = m.document_uuid
+    LEFT JOIN uuid_map dm ON dm.uuid = m.document_uuid
     WHERE m.is_exit = 1 AND m.flux_id = ${Stock.flux.TO_PATIENT} AND m.document_uuid = ?
   `;
 
@@ -90,8 +90,8 @@ async function stockExitPatientReceipt(documentUuid, session, options) {
 
   if (line.invoice_uuid) {
     const invoiceDocumentSql = `
-      SELECT dm.text AS reference
-      FROM document_map dm
+      SELECT dm.short_name AS reference
+      FROM uuid_map dm
       WHERE dm.uuid = ?
     `;
     const doc = await db.one(invoiceDocumentSql, db.bid(line.invoice_uuid));

--- a/server/controllers/stock/reports/stock/exit_service_receipt.js
+++ b/server/controllers/stock/reports/stock/exit_service_receipt.js
@@ -36,7 +36,7 @@ async function stockExitServiceReceipt(documentUuid, session, options) {
       BUID(m.document_uuid) AS document_uuid,
       m.quantity, m.unit_cost, (m.quantity * m.unit_cost) AS total , m.date, m.description,
       u.display_name AS user_display_name, s.name AS service_display_name,
-      dm.text AS document_reference,
+      dm.short_name AS document_reference,
       l.label, l.expiration_date, d.text AS depot_name, d.is_count_per_container,
       l.package_size, FLOOR(m.quantity / l.package_size) number_package,
       IF(l.package_size <= 1, 0, 1) AS displayDetail,
@@ -48,8 +48,8 @@ async function stockExitServiceReceipt(documentUuid, session, options) {
     JOIN depot d ON d.uuid = m.depot_uuid
     JOIN service s ON s.uuid = m.entity_uuid
     JOIN user u ON u.id = m.user_id
-    LEFT JOIN document_map dm ON dm.uuid = m.document_uuid
-    LEFT JOIN document_map sr_m ON sr_m.uuid = m.stock_requisition_uuid
+    LEFT JOIN uuid_map dm ON dm.uuid = m.document_uuid
+    LEFT JOIN uuid_map sr_m ON sr_m.uuid = m.stock_requisition_uuid
     WHERE m.is_exit = 1 AND m.flux_id = ${Stock.flux.TO_SERVICE} AND m.document_uuid = ?
   `;
 

--- a/server/controllers/stock/reports/stock/exit_service_receipt.js
+++ b/server/controllers/stock/reports/stock/exit_service_receipt.js
@@ -40,7 +40,7 @@ async function stockExitServiceReceipt(documentUuid, session, options) {
       l.label, l.expiration_date, d.text AS depot_name, d.is_count_per_container,
       l.package_size, FLOOR(m.quantity / l.package_size) number_package,
       IF(l.package_size <= 1, 0, 1) AS displayDetail,
-      BUID(m.stock_requisition_uuid) AS stock_requisition_uuid, sr_m.text AS document_requisition
+      BUID(m.stock_requisition_uuid) AS stock_requisition_uuid, sr_m.short_name AS document_requisition
     FROM stock_movement m
     JOIN lot l ON l.uuid = m.lot_uuid
     JOIN inventory i ON i.uuid = l.inventory_uuid

--- a/server/controllers/stock/reports/stock/satisfaction.js
+++ b/server/controllers/stock/reports/stock/satisfaction.js
@@ -62,7 +62,7 @@ async function getSatisfactionData(options) {
     sr.validator_user_id, sr.depot_uuid AS depot_supplier_uuid, d.text AS depot_supplier_text,
     sr.requestor_uuid AS depot_requestor_uuid, dd.text AS depot_requestor_text,
     IF(sr.validator_user_id, it.old_quantity, it.quantity) AS quantity_requested,
-    it.quantity AS quantity_validated, map1.text AS requisition_reference
+    it.quantity AS quantity_validated, map1.short_name AS requisition_reference
     FROM stock_requisition AS sr
     JOIN stock_requisition_item AS it ON it.requisition_uuid = sr.uuid
     JOIN inventory AS inv ON inv.uuid = it.inventory_uuid
@@ -75,7 +75,7 @@ async function getSatisfactionData(options) {
   ) AS req
   LEFT JOIN (
     SELECT l.inventory_uuid, SUM(sm.quantity) AS quantity_delivered, sm.stock_requisition_uuid,
-    map.text AS stock_movement_text
+    map.short_name AS stock_movement_text
     FROM stock_movement AS sm
     JOIN lot AS l ON l.uuid = sm.lot_uuid
     JOIN inventory AS inv ON inv.uuid = l.inventory_uuid
@@ -101,7 +101,7 @@ async function getSatisfactionData(options) {
     sr.validator_user_id, sr.depot_uuid AS depot_supplier_uuid, d.text AS depot_supplier_text,
     sr.requestor_uuid AS depot_requestor_uuid, dd.text AS depot_requestor_text,
     IF(sr.validator_user_id, it.old_quantity, it.quantity) AS quantity_requested,
-    it.quantity AS quantity_validated, map1.text AS requisition_reference
+    it.quantity AS quantity_validated, map1.short_name AS requisition_reference
     FROM stock_requisition AS sr
     JOIN stock_requisition_item AS it ON it.requisition_uuid = sr.uuid
     JOIN inventory AS inv ON inv.uuid = it.inventory_uuid
@@ -114,7 +114,7 @@ async function getSatisfactionData(options) {
   ) AS req
   LEFT JOIN (
     SELECT l.inventory_uuid, SUM(sm.quantity) AS quantity_delivered, sm.stock_requisition_uuid,
-    map.text AS stock_movement_text
+    map.short_name AS stock_movement_text
     FROM stock_movement AS sm
     JOIN lot AS l ON l.uuid = sm.lot_uuid
     JOIN inventory AS inv ON inv.uuid = l.inventory_uuid

--- a/server/controllers/stock/reports/stock/satisfaction.js
+++ b/server/controllers/stock/reports/stock/satisfaction.js
@@ -68,7 +68,7 @@ async function getSatisfactionData(options) {
     JOIN inventory AS inv ON inv.uuid = it.inventory_uuid
     JOIN depot AS d ON d.uuid = sr.depot_uuid
     JOIN depot AS dd ON dd.uuid = sr.requestor_uuid
-    JOIN document_map AS map1 ON map1.uuid = sr.uuid
+    JOIN uuid_map AS map1 ON map1.uuid = sr.uuid
     WHERE sr.depot_uuid IN (?)
     AND DATE(sr.date) >= DATE(?) AND DATE(sr.date) <= DATE(?)
     ORDER BY d.text, dd.text, inv.text ASC
@@ -81,7 +81,7 @@ async function getSatisfactionData(options) {
     JOIN inventory AS inv ON inv.uuid = l.inventory_uuid
     JOIN stock_requisition AS sr ON sr.uuid = sm.stock_requisition_uuid
     JOIN depot AS d ON d.uuid = sm.depot_uuid
-    JOIN document_map AS map ON map.uuid = sm.document_uuid
+    JOIN uuid_map AS map ON map.uuid = sm.document_uuid
     WHERE d.uuid IN (?)
     GROUP BY sm.stock_requisition_uuid, inv.uuid
   ) AS mov ON mov.inventory_uuid = req.inventory_uuid AND mov.stock_requisition_uuid = req.stock_requisition_uuid
@@ -107,7 +107,7 @@ async function getSatisfactionData(options) {
     JOIN inventory AS inv ON inv.uuid = it.inventory_uuid
     JOIN depot AS d ON d.uuid = sr.depot_uuid
     JOIN depot AS dd ON dd.uuid = sr.requestor_uuid
-    JOIN document_map AS map1 ON map1.uuid = sr.uuid
+    JOIN uuid_map AS map1 ON map1.uuid = sr.uuid
     WHERE sr.depot_uuid IN (?)
     AND DATE(sr.date) >= DATE(?) AND DATE(sr.date) <= DATE(?)
     ORDER BY d.text, dd.text, inv.text ASC
@@ -120,7 +120,7 @@ async function getSatisfactionData(options) {
     JOIN inventory AS inv ON inv.uuid = l.inventory_uuid
     JOIN stock_requisition AS sr ON sr.uuid = sm.stock_requisition_uuid
     JOIN depot AS d ON d.uuid = sm.depot_uuid
-    JOIN document_map AS map ON map.uuid = sm.document_uuid
+    JOIN uuid_map AS map ON map.uuid = sm.document_uuid
     WHERE d.uuid IN (?)
     GROUP BY sm.stock_requisition_uuid, inv.uuid
   ) AS mov ON mov.inventory_uuid = req.inventory_uuid AND mov.stock_requisition_uuid = req.stock_requisition_uuid

--- a/server/controllers/stock/requisition/requisition.js
+++ b/server/controllers/stock/requisition/requisition.js
@@ -86,10 +86,8 @@ async function getDetailsBalance(identifier) {
 
 /**
  * @function binarize
- *
  * @description
  * returns binary version of given identifiers (uuids)
- *
  * @param {object} params an object which contains identifiers in string format
  * @returns {object} params with binary identifiers
  */
@@ -106,11 +104,9 @@ function binarize(params) {
 
 /**
  * @function getStockRequisition
- *
  * @description
  * build the query for getting stock requisition based on
  * a given parameters
- *
  * @param {object} params
  * @returns {object} { query:..., queryParameters:... }
  */
@@ -127,7 +123,7 @@ async function getStockRequisition(params) {
   filters.equals('requestor_uuid', 'requestor_uuid', 'sr');
   filters.equals('user_id', 'user_id', 'sr');
   filters.equals('project_id', 'project_id', 'sr');
-  filters.equals('reference', 'text', 'dm');
+  filters.equals('reference', 'short_name', 'dm');
   filters.period('date', 'date', 'sr');
   filters.period('period', 'date', 'sr');
   filters.dateFrom('custom_period_start', 'date', 'sr');

--- a/server/controllers/stock/requisition/requisition.js
+++ b/server/controllers/stock/requisition/requisition.js
@@ -17,11 +17,11 @@ const SELECT_QUERY = `
     sr.requestor_type_id, sr.description, sr.date, sr.user_id, sr.project_id, sr.status_id,
     u.display_name AS user_display_name, d.text AS depot_text, sr.validation_date,
     s.name service_requestor, dd.text depot_requestor, uu.display_name AS validator_display_name,
-    dm.text reference, stat.title_key, stat.status_key, stat.class_style, sr.created_at
+    dm.short_name reference, stat.title_key, stat.status_key, stat.class_style, sr.created_at
   FROM stock_requisition sr
   JOIN user u ON u.id = sr.user_id
   JOIN depot d ON d.uuid = sr.depot_uuid
-  JOIN document_map dm ON dm.uuid = sr.uuid
+  JOIN uuid_map dm ON dm.uuid = sr.uuid
   JOIN status stat ON stat.id = sr.status_id
   LEFT JOIN service s ON s.uuid = sr.requestor_uuid
   LEFT JOIN depot dd ON dd.uuid = sr.requestor_uuid

--- a/server/lib/referenceLookup.js
+++ b/server/lib/referenceLookup.js
@@ -60,7 +60,7 @@ async function getEntity(req, res) {
         SELECT BUID(employee.uuid) AS uuid
         FROM uuid_map
           JOIN employee ON employee.creditor_uuid = uuid_map.uuid
-        WHERE uuid_map.text = ?
+        WHERE uuid_map.short_name = ?
       `;
 
     const { uuid } = await db.one(queryEntity, [req.params.codeRef]);

--- a/server/lib/referenceLookup.js
+++ b/server/lib/referenceLookup.js
@@ -50,7 +50,7 @@ async function getEntity(req, res) {
 
   // render a stock movement receipt
   if (isStockMovement) {
-    const queryDocument = `SELECT BUID(uuid) as uuid FROM document_map WHERE text = ?`;
+    const queryDocument = `SELECT BUID(uuid) as uuid FROM uuid_map WHERE text = ?`;
     const { uuid } = await db.one(queryDocument, [req.params.codeRef]);
     url = `${documentDefinition.documentPath}${uuid}?lang=${language}&renderer=pdf`;
 
@@ -58,9 +58,9 @@ async function getEntity(req, res) {
   } else if (isEmployee) {
     const queryEntity = `
         SELECT BUID(employee.uuid) AS uuid
-        FROM entity_map
-          JOIN employee ON employee.creditor_uuid = entity_map.uuid
-        WHERE entity_map.text = ?
+        FROM uuid_map
+          JOIN employee ON employee.creditor_uuid = uuid_map.uuid
+        WHERE uuid_map.text = ?
       `;
 
     const { uuid } = await db.one(queryEntity, [req.params.codeRef]);

--- a/server/models/01-schema.sql
+++ b/server/models/01-schema.sql
@@ -497,13 +497,6 @@ CREATE TABLE discount (
 ) ENGINE=InnoDB;
 
 
-DROP TABLE IF EXISTS `document_map`;
-CREATE TABLE `document_map` (
-  `uuid`              BINARY(16) NOT NULL,
-  `text`              TEXT NOT NULL,
-  PRIMARY KEY (`uuid`)
-) ENGINE=InnoDB;
-
 DROP TABLE IF EXISTS `employee`;
 CREATE TABLE `employee` (
   `uuid`          BINARY(16) NOT NULL,
@@ -604,13 +597,6 @@ CREATE TABLE `enterprise_setting` (
   `percentage_fixed_bonus` TINYINT(3) UNSIGNED NOT NULL DEFAULT 100,
   PRIMARY KEY (`enterprise_id`),
   CONSTRAINT `enterprise_setting__enterprise` FOREIGN KEY (`enterprise_id`) REFERENCES `enterprise` (`id`)
-) ENGINE=InnoDB;
-
-DROP TABLE IF EXISTS `entity_map`;
-CREATE TABLE `entity_map` (
-  `uuid`              BINARY(16) NOT NULL,
-  `text`              TEXT NOT NULL,
-  PRIMARY KEY (`uuid`)
 ) ENGINE=InnoDB;
 
 DROP TABLE IF EXISTS `exchange_rate`;
@@ -2268,7 +2254,6 @@ CREATE TABLE `cashbox_permission` (
 
 
 DROP TABLE IF EXISTS `config_rubric`;
-
 CREATE TABLE `config_rubric` (
   `id` INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
   `label` text,
@@ -2297,7 +2282,6 @@ CREATE TABLE `config_employee` (
 ) ENGINE=InnoDB;
 
 DROP TABLE IF EXISTS `config_employee_item`;
-
 CREATE TABLE `config_employee_item` (
   `id` INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
   `config_employee_id` INT(10) UNSIGNED NOT NULL,
@@ -2874,6 +2858,15 @@ CREATE TABLE `smtp_configuration` (
   `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`)
+) ENGINE=InnoDB;
+
+DROP TABLE IF EXISTS `uuid_map`;
+CREATE TABLE `uuid_map` (
+  `uuid`         BINARY(16) NOT NULL,
+  `short_name`   TEXT NOT NULL,
+  `long_name`    TEXT,
+  `type`         TEXT NOT NULL,
+  PRIMARY KEY (`uuid`)
 ) ENGINE=InnoDB;
 
 SET foreign_key_checks = 1;

--- a/server/models/03-procedures.sql
+++ b/server/models/03-procedures.sql
@@ -1199,9 +1199,9 @@ BEGIN
   )
    SELECT
     HUID(UUID()), i.project_id, fiscalYearId, periodId, transId, transIdNumberPart, i.date, i.uuid,
-    CONCAT(dm.text,': ', inv.text) as txt, ig.sales_account, ii.debit, ii.credit, ii.debit, ii.credit,
+    CONCAT(dm.short_name,': ', inv.text) as txt, ig.sales_account, ii.debit, ii.credit, ii.debit, ii.credit,
     currencyId, 11, i.user_id, IFNULL(GetCostCenterByAccountId(ig.sales_account), serviceCostCenterId)
-  FROM invoice AS i JOIN invoice_item AS ii JOIN inventory as inv JOIN inventory_group AS ig JOIN document_map as dm ON
+  FROM invoice AS i JOIN invoice_item AS ii JOIN inventory as inv JOIN inventory_group AS ig JOIN uuid_map as dm ON
     i.uuid = ii.invoice_uuid AND
     ii.inventory_uuid = inv.uuid AND
     inv.group_uuid = ig.uuid AND
@@ -3623,5 +3623,38 @@ BEGIN
     FROM account AS act
     WHERE act.number = acctNumber;
 END $$
+
+/* This section contains utility  procedures */ 
+
+/**
+ * This procedure is used exclusively in triggers to update 
+ * the UUID mapping for our tables that use the project as part of 
+ * the reference.  It saves a lot of duplicate code.
+ */
+DROP PROCEDURE IF EXISTS UpdateUuidMap$$
+CREATE PROCEDURE UpdateUuidMap(
+    IN p_uuid        BINARY(16),
+    IN p_project_id  SMALLINT UNSIGNED,
+    IN p_prefix      VARCHAR(10),
+    IN p_reference   INT UNSIGNED,
+    IN p_long_name   VARCHAR(255),
+    IN p_type        VARCHAR(20)
+)
+BEGIN
+    DECLARE v_abbr VARCHAR(20);
+
+    SELECT project.abbr
+      INTO v_abbr
+      FROM project
+     WHERE project.id = p_project_id;
+
+    INSERT INTO uuid_map ( uuid, short_name, long_name, type)
+    VALUES ( p_uuid, CONCAT_WS('.', p_prefix, v_abbr, p_reference), p_long_name, p_type)
+    ON DUPLICATE KEY UPDATE
+        short_name = VALUES(short_name),
+        long_name  = VALUES(long_name),
+        type       = VALUES(type);
+END$$
+
 
 DELIMITER ;

--- a/server/models/03-procedures.sql
+++ b/server/models/03-procedures.sql
@@ -1193,20 +1193,26 @@ BEGIN
 
   -- copy the invoice_items into the posting_journal
   INSERT INTO posting_journal (
-    uuid, project_id, fiscal_year_id, period_id, trans_id, trans_id_reference_number, trans_date,
-    record_uuid, description, account_id, debit, credit, debit_equiv,
-    credit_equiv, currency_id, transaction_type_id, user_id, cost_center_id
+      uuid, project_id, fiscal_year_id, period_id, trans_id, trans_id_reference_number, trans_date,
+      record_uuid, description, account_id, debit, credit, debit_equiv, credit_equiv, currency_id,
+      transaction_type_id, user_id, cost_center_id
   )
-   SELECT
-    HUID(UUID()), i.project_id, fiscalYearId, periodId, transId, transIdNumberPart, i.date, i.uuid,
-    CONCAT(dm.short_name,': ', inv.text) as txt, ig.sales_account, ii.debit, ii.credit, ii.debit, ii.credit,
-    currencyId, 11, i.user_id, IFNULL(GetCostCenterByAccountId(ig.sales_account), serviceCostCenterId)
-  FROM invoice AS i JOIN invoice_item AS ii JOIN inventory as inv JOIN inventory_group AS ig JOIN uuid_map as dm ON
-    i.uuid = ii.invoice_uuid AND
-    ii.inventory_uuid = inv.uuid AND
-    inv.group_uuid = ig.uuid AND
-    dm.uuid = i.uuid
-  WHERE i.uuid = iuuid;
+  SELECT
+      HUID(UUID()), i.project_id, fiscalYearId, periodId, transId, transIdNumberPart, i.date,
+      i.uuid, CONCAT(dm.short_name, ': ', inv.text) AS description, ig.sales_account, ii.debit,
+      ii.credit, ii.debit, ii.credit, currencyId, 11, i.user_id,
+      COALESCE( GetCostCenterByAccountId(ig.sales_account), serviceCostCenterId) AS cost_center_id
+  FROM invoice AS i
+    JOIN invoice_item AS ii
+        ON ii.invoice_uuid = i.uuid
+    JOIN inventory AS inv
+        ON inv.uuid = ii.inventory_uuid
+    JOIN inventory_group AS ig
+        ON ig.uuid = inv.group_uuid
+    JOIN uuid_map AS dm
+        ON dm.uuid = i.uuid
+    WHERE i.uuid = iuuid;
+
 
   -- copy the invoice_subsidy records into the posting_journal (debits)
   INSERT INTO posting_journal (

--- a/server/models/04-triggers.sql
+++ b/server/models/04-triggers.sql
@@ -4,47 +4,40 @@ DELIMITER $$
 
 CREATE TRIGGER patient_reference BEFORE INSERT ON patient
 FOR EACH ROW
-  SET NEW.reference = (SELECT IF(NEW.reference, NEW.reference, IFNULL(MAX(patient.reference) + 1, 1)) FROM patient WHERE patient.project_id = new.project_id);$$
+  SET NEW.reference = (SELECT COALESCE(NULLIF(NEW.reference, 0), MAX(patient.reference) + 1, 1) FROM patient WHERE patient.project_id = NEW.project_id);$$
 
-CREATE TRIGGER patient_entity_map AFTER INSERT ON patient
+CREATE TRIGGER patient_uuid_map AFTER INSERT ON patient
 FOR EACH ROW BEGIN
-
-  -- this writes a patient entity into the entity_map table
-  INSERT INTO entity_map
-    SELECT new.uuid, CONCAT_WS('.', 'PA', project.abbr, new.reference) FROM project WHERE project.id = new.project_id ON DUPLICATE KEY UPDATE text=text;
+  -- Write both the debtor and patient to the uuid_map table. 
 
   -- debtor entity reference removed to allow for reverse lookups - if debit
   -- entity is refined this can point directly to the debtor
 
-  -- this writes a debtor entity into the entity_map table
-  -- NOTE: the debtor actually points to the patient entity for convenience
-  INSERT INTO entity_map
-    SELECT new.debtor_uuid, CONCAT_WS('.', 'PA', project.abbr, new.reference) FROM project WHERE project.id = new.project_id ON DUPLICATE KEY UPDATE text=text;
+  CALL UpdateUuidMap(NEW.uuid, NEW.project_id, 'PA', NEW.reference, NEW.display_name, 'entity');
+  CALL UpdateUuidMap(NEW.debtor_uuid, NEW.project_id, 'PA', NEW.reference, NEW.display_name, 'entity');
 END$$
 
 -- Purchase Triggers
 
 CREATE TRIGGER purchase_reference BEFORE INSERT ON purchase
 FOR EACH ROW
-  SET NEW.reference = (SELECT IF(NEW.reference, NEW.reference, IFNULL(MAX(purchase.reference) + 1, 1)) FROM purchase WHERE purchase.project_id = new.project_id);$$
+  SET NEW.reference = (SELECT COALESCE(NULLIF(NEW.reference, 0), MAX(purchase.reference) + 1, 1) FROM purchase WHERE purchase.project_id = NEW.project_id);$$
 
-CREATE TRIGGER purchase_document_map AFTER INSERT ON purchase
+CREATE TRIGGER purchase_uuid_map AFTER INSERT ON purchase
 FOR EACH ROW BEGIN
-  INSERT INTO document_map
-    SELECT new.uuid, CONCAT_WS('.', 'PO', project.abbr, new.reference) FROM project WHERE project.id = new.project_id ON DUPLICATE KEY UPDATE text=text;
+  CALL UpdateUuidMap(NEW.uuid, NEW.project_id, 'PO', NEW.reference, NEW.note, 'document');
 END$$
-
 
 -- Invoice Triggers
 
 CREATE TRIGGER invoice_reference BEFORE INSERT ON invoice
 FOR EACH ROW
-  SET NEW.reference = (SELECT IF(NEW.reference, NEW.reference, IFNULL(MAX(invoice.reference) + 1, 1)) FROM invoice WHERE invoice.project_id = new.project_id);$$
+  SET NEW.reference = (SELECT COALESCE(NULLIF(NEW.reference, 0), MAX(invoice.reference) + 1, 1) FROM invoice WHERE invoice.project_id = NEW.project_id);$$
 
-CREATE TRIGGER invoice_document_map AFTER INSERT ON invoice
-FOR EACH ROW BEGIN
-  INSERT INTO document_map
-    SELECT new.uuid, CONCAT_WS('.', 'IV', project.abbr, new.reference) FROM project WHERE project.id = new.project_id ON DUPLICATE KEY UPDATE text=text;
+CREATE TRIGGER invoice_uuid_map AFTER INSERT ON invoice
+FOR EACH ROW
+BEGIN
+    CALL UpdateUuidMap( NEW.uuid, NEW.project_id, 'IV', NEW.reference, NEW.description, 'document');
 END$$
 
 
@@ -52,24 +45,23 @@ END$$
 
 CREATE TRIGGER cash_before_insert BEFORE INSERT ON cash
 FOR EACH ROW
-  SET NEW.reference = (SELECT IF(NEW.reference, NEW.reference, IFNULL(MAX(cash.reference) + 1, 1)) FROM cash WHERE cash.project_id = new.project_id);$$
+  SET NEW.reference = (SELECT COALESCE(NULLIF(NEW.reference, 0), MAX(cash.reference) + 1, 1) FROM cash WHERE cash.project_id = NEW.project_id);$$
 
-CREATE TRIGGER cash_document_map AFTER INSERT ON cash
-FOR EACH ROW BEGIN
-  INSERT INTO document_map
-    SELECT new.uuid, CONCAT_WS('.', 'CP', project.abbr, new.reference) FROM project WHERE project.id = new.project_id ON DUPLICATE KEY UPDATE text=text;
+CREATE TRIGGER cash_uuid_map AFTER INSERT ON cash
+FOR EACH ROW
+BEGIN
+    CALL UpdateUuidMap(NEW.uuid, NEW.project_id, 'CP', NEW.reference, NEW.description, 'document');
 END$$
 
 -- Voucher Triggers
 
 CREATE TRIGGER voucher_before_insert BEFORE INSERT ON voucher
 FOR EACH ROW
-  SET NEW.reference = (SELECT IF(NEW.reference, NEW.reference, IFNULL(MAX(voucher.reference) + 1, 1)) FROM voucher WHERE voucher.project_id = new.project_id);$$
+  SET NEW.reference = (SELECT COALESCE(NULLIF(NEW.reference, 0), MAX(voucher.reference) + 1, 1) FROM voucher WHERE voucher.project_id = NEW.project_id);$$
 
-CREATE TRIGGER voucher_document_map AFTER INSERT ON voucher
+CREATE TRIGGER voucher_uuid_map AFTER INSERT ON voucher
 FOR EACH ROW BEGIN
-  INSERT INTO document_map
-    SELECT new.uuid, CONCAT_WS('.', 'VO', project.abbr, new.reference) FROM project WHERE project.id = new.project_id ON DUPLICATE KEY UPDATE text=text;
+  CALL UpdateUuidMap(NEW.uuid, NEW.project_id, 'VO', NEW.reference, NEW.description, 'document');
 END$$
 
 
@@ -77,27 +69,33 @@ END$$
 
 CREATE TRIGGER employee_before_insert BEFORE INSERT ON employee
 FOR EACH ROW
-  SET NEW.reference = (SELECT IF(NEW.reference, NEW.reference, IFNULL(MAX(employee.reference) + 1, 1)) FROM employee);$$
+  SET NEW.reference = (SELECT COALESCE(NULLIF(NEW.reference, 0), MAX(employee.reference) + 1, 1) FROM employee);$$
 
 -- Must be fixed if the system is to manage multiple Enterprises at the same time, which would add the Enterprise identifier to each employee : @lomamech
-CREATE TRIGGER employee_entity_map AFTER INSERT ON employee
+CREATE TRIGGER employee_uuid_map AFTER INSERT ON employee
 FOR EACH ROW BEGIN
-  INSERT INTO entity_map
-    SELECT new.creditor_uuid, CONCAT_WS('.', 'EM', enterprise.abbr, new.reference) FROM enterprise ON DUPLICATE KEY UPDATE text=text;
+  INSERT INTO uuid_map
+    SELECT NEW.creditor_uuid, CONCAT_WS('.', 'EM', enterprise.abbr, NEW.reference), patient.display_name, 'entity'
+      FROM patient 
+        JOIN project ON patient.project_id = project.id 
+        JOIN enterprise ON project.enterprise_id = enterprise.id 
+       WHERE patient.uuid = NEW.patient_uuid
+    ON DUPLICATE KEY UPDATE short_name = CONCAT_WS('.', 'EM', enterprise.abbr, NEW.reference), long_name = patient.display_name;
 END$$
 
 -- Supplier Triggers
 
 CREATE TRIGGER supplier_before_insert BEFORE INSERT ON supplier
 FOR EACH ROW
-  SET NEW.reference = (SELECT IF(NEW.reference, NEW.reference, IFNULL(MAX(supplier.reference) + 1, 1)) FROM supplier);$$
+  SET NEW.reference = (SELECT COALESCE(NULLIF(NEW.reference, 0), MAX(supplier.reference) + 1, 1) FROM supplier);$$
 
-CREATE TRIGGER supplier_entity_map AFTER INSERT ON supplier
+CREATE TRIGGER supplier_uuid_map AFTER INSERT ON supplier
 FOR EACH ROW BEGIN
 
-  -- this writes the supplier's creditor into the entity_map, pointing to the supplier
-  INSERT INTO entity_map
-    SELECT new.creditor_uuid, CONCAT_WS('.', 'FO', new.reference) ON DUPLICATE KEY UPDATE text=text;
+  -- this writes the supplier's creditor into the uuid_map, pointing to the supplier
+  INSERT INTO uuid_map
+    SELECT NEW.creditor_uuid, CONCAT_WS('.', 'FO', NEW.reference), NEW.note, 'entity'
+    ON DUPLICATE KEY UPDATE short_name = CONCAT_WS('.', 'FO', NEW.reference), long_name = NEW.note;
 END$$
 
 -- Stock Movement Triggers
@@ -105,38 +103,38 @@ END$$
 -- the stock_movement reference is incremented based on the document_uuid.
 CREATE TRIGGER stock_movement_reference BEFORE INSERT ON stock_movement
 FOR EACH ROW
-  SET NEW.reference = (SELECT IF(NEW.reference, NEW.reference, IFNULL(MAX(sm.reference) + 1, 1)) FROM stock_movement sm WHERE sm.document_uuid <> NEW.document_uuid);$$
+  SET NEW.reference = (SELECT COALESCE(NULLIF(NEW.reference, 0), MAX(sm.reference) + 1, 1) FROM stock_movement sm WHERE sm.document_uuid <> NEW.document_uuid);$$
 
 -- compute the document map by simply concatenating the flux_id and the reference
-CREATE TRIGGER stock_movement_document_map AFTER INSERT ON stock_movement
-FOR EACH ROW BEGIN
-  INSERT INTO `document_map` (uuid, text) VALUES (NEW.document_uuid, CONCAT_WS('.', 'SM', NEW.flux_id, NEW.reference))
-  ON DUPLICATE KEY UPDATE uuid = NEW.document_uuid;
-END$$
+CREATE TRIGGER stock_movement_uuid_map AFTER INSERT ON stock_movement FOR EACH ROW
+BEGIN
+    -- Refactored from VALUES to SELECT to fix the broken syntax and maintain consistency
+    INSERT INTO uuid_map
+    SELECT NEW.document_uuid, CONCAT_WS('.', 'SM', NEW.flux_id, NEW.reference), NEW.description, 'document'
+    ON DUPLICATE KEY UPDATE short_name = CONCAT_WS('.', 'SM', NEW.flux_id, NEW.reference), long_name = NEW.description;
+END $$
+
 
 -- Shipment Triggers
 -- the shipment reference is incremented based on the shipment uuid.
 CREATE TRIGGER shipment_reference BEFORE INSERT ON shipment
 FOR EACH ROW
-  SET NEW.reference = (SELECT IF(NEW.reference, NEW.reference, IFNULL(MAX(sh.reference) + 1, 1)) FROM shipment sh WHERE sh.uuid <> NEW.uuid);$$
+  SET NEW.reference = (SELECT COALESCE(NULLIF(NEW.reference, 0), MAX(sh.reference) + 1, 1) FROM shipment sh WHERE sh.uuid <> NEW.uuid);$$
 
 -- compute the document map
-CREATE TRIGGER shipment_document_map AFTER INSERT ON shipment
+CREATE TRIGGER shipment_uuid_map AFTER INSERT ON shipment
 FOR EACH ROW BEGIN
-  INSERT INTO `document_map`
-    SELECT NEW.uuid, CONCAT_WS('.', 'SHIP', project.abbr, new.reference) FROM project WHERE project.id = NEW.project_id
-  ON DUPLICATE KEY UPDATE text = text;
+  CALL UpdateUuidMap(NEW.uuid, NEW.project_id, 'SHIP', NEW.reference, NEW.description, 'document');
 END$$
 
 -- Stock Requisition Triggers
 CREATE TRIGGER stock_requisition_reference BEFORE INSERT ON stock_requisition
 FOR EACH ROW
-  SET NEW.reference = (SELECT IF(NEW.reference, NEW.reference, IFNULL(MAX(stock_requisition.reference) + 1, 1)) FROM stock_requisition  WHERE stock_requisition.project_id = new.project_id);$$
+  SET NEW.reference = (SELECT COALESCE(NULLIF(NEW.reference, 0), MAX(stock_requisition.reference) + 1, 1) FROM stock_requisition  WHERE stock_requisition.project_id = NEW.project_id);$$
 
-CREATE TRIGGER stock_requisition_document_map AFTER INSERT ON stock_requisition
+CREATE TRIGGER stock_requisition_uuid_map AFTER INSERT ON stock_requisition
 FOR EACH ROW BEGIN
-  INSERT INTO document_map
-    SELECT new.uuid, CONCAT_WS('.', 'SREQ', project.abbr, new.reference) FROM project WHERE project.id = new.project_id ON DUPLICATE KEY UPDATE text=text;
+  CALL UpdateUuidMap(NEW.uuid, NEW.project_id, 'SREQ', NEW.reference, NEW.description, 'document');
 END$$
 
 DELIMITER ;

--- a/server/models/98-admin.sql
+++ b/server/models/98-admin.sql
@@ -1,79 +1,83 @@
 DELIMITER $$
 
 /*
- zRecomputeEntityMap
+ zRecomputeUuidMapping
 
- Abolishes and recomputes the entity_map from the base tables in the system.  This is
+ Abolishes and recomputes the uuid_map from the base tables in the system.  This is
  useful in case of database corruption in which references get out of sync.
 */
-CREATE PROCEDURE zRecomputeEntityMap()
+CREATE PROCEDURE zRecomputeUuidMapping()
 BEGIN
-  DELETE FROM entity_map;
+    -- Clear the mapping table entirely
+    TRUNCATE `uuid_map`;
 
-  -- patient
-  INSERT INTO entity_map
-    SELECT patient.uuid, CONCAT_WS('.', 'PA', project.abbr, patient.reference)
-    FROM patient JOIN project ON patient.project_id = project.id;
+    -- patient 
+    INSERT INTO `uuid_map` (uuid, short_name, long_name, type)
+    SELECT p.uuid, CONCAT_WS('.', 'PA', pr.abbr, p.reference), p.display_name, 'entity'
+    FROM `patient` p
+    JOIN `project` pr ON p.project_id = pr.id;
 
-  -- patient debtor
-  INSERT INTO entity_map
-    SELECT patient.debtor_uuid, CONCAT_WS('.', 'PA', project.abbr, patient.reference)
-    FROM patient JOIN project ON patient.project_id = project.id;
+    -- patient debtor
+    INSERT INTO `uuid_map` (uuid, short_name, long_name, type)
+    SELECT p.debtor_uuid, CONCAT_WS('.', 'PA', pr.abbr, p.reference), p.display_name, 'entity'
+    FROM `patient` p
+      JOIN `project` pr ON p.project_id = pr.id;
 
-  -- employee
-  INSERT INTO entity_map
-    SELECT employee.creditor_uuid, CONCAT_WS('.', 'EM', enterprise.abbr, employee.reference)
-    FROM employee
-    JOIN patient ON patient.uuid = employee.patient_uuid
-    JOIN project ON project.id = patient.project_id
-    JOIN enterprise ON enterprise.id = project.enterprise_id;
+    -- employee
+    INSERT INTO `uuid_map` (uuid, short_name, long_name, type)
+    SELECT e.creditor_uuid, CONCAT_WS('.', 'EM', en.abbr, e.reference), p.display_name, 'entity'
+    FROM `employee` e
+      JOIN `patient` p ON p.uuid = e.patient_uuid
+      JOIN `project` pr ON pr.id = p.project_id
+      JOIN `enterprise` en ON en.id = pr.enterprise_id;
 
-  -- supplier
-  INSERT INTO entity_map
-    SELECT supplier.creditor_uuid, CONCAT_WS('.', 'FO', supplier.reference) FROM supplier;
+    -- supplier
+    INSERT INTO `uuid_map` (uuid, short_name, long_name, type)
+    SELECT s.creditor_uuid, CONCAT_WS('.', 'FO', s.reference), s.note, 'supplier'
+    FROM `supplier` s;
+
+    -- cash payments
+    INSERT INTO `uuid_map` (uuid, short_name, long_name, type)
+    SELECT c.uuid, CONCAT_WS('.', 'CP', pr.abbr, c.reference), c.description, 'document'
+    FROM `cash` c
+      JOIN `project` pr ON pr.id = c.project_id;
+
+    -- invoices
+    INSERT INTO `uuid_map` (uuid, short_name, long_name, type)
+    SELECT i.uuid, CONCAT_WS('.', 'IV', pr.abbr, i.reference), i.description, 'document'
+    FROM `invoice` i
+      JOIN `project` pr ON pr.id = i.project_id;
+
+    -- purchases
+    INSERT INTO `uuid_map` (uuid, short_name, long_name, type)
+    SELECT pu.uuid, CONCAT_WS('.', 'PO', pr.abbr, pu.reference), pu.note, 'document'
+    FROM `purchase` pu
+      JOIN `project` pr ON pr.id = pu.project_id;
+
+    -- vouchers
+    INSERT INTO `uuid_map` (uuid, short_name, long_name, type)
+    SELECT v.uuid, CONCAT_WS('.', 'VO', pr.abbr, v.reference), v.description, 'document'
+    FROM `voucher` v
+      JOIN `project` pr ON pr.id = v.project_id;
+
+    -- stock_requisition
+    INSERT INTO `uuid_map` (uuid, short_name, long_name, type)
+    SELECT sr.uuid, CONCAT_WS('.', 'SREQ', pr.abbr, sr.reference), sr.description, 'document'
+    FROM `stock_requisition` sr
+      JOIN `project` pr ON pr.id = sr.project_id;
+
+    -- stock movements (Using IGNORE to prevent failure on duplicate logic if applicable)
+    INSERT IGNORE INTO `uuid_map` (uuid, short_name, long_name, type)
+    SELECT sm.document_uuid, CONCAT_WS('.', 'SM', sm.flux_id, sm.reference), sm.description, 'document'
+    FROM `stock_movement` sm;
+
+    -- shipments
+    INSERT IGNORE INTO `uuid_map` (uuid, short_name, long_name, type)
+    SELECT s.document_uuid, CONCAT_WS('.', 'SHIP', pr.abbr, s.reference), s.description, 'document'
+    FROM `shipment` s
+      JOIN `project` pr ON pr.id = s.project_id;
 END $$
 
-/*
- zRecomputeDocumentMap
-
- Abolishes and recomputes the document_map entries from the base tables in the
- database.  This is useful in case of data corruption.
-*/
-CREATE PROCEDURE zRecomputeDocumentMap()
-BEGIN
-  DELETE FROM document_map;
-
-  -- cash payments
-  INSERT INTO document_map
-    SELECT cash.uuid, CONCAT_WS('.', 'CP', project.abbr, cash.reference)
-    FROM cash JOIN project where project.id = cash.project_id;
-
-  -- invoices
-  INSERT INTO document_map
-    SELECT invoice.uuid, CONCAT_WS('.', 'IV', project.abbr, invoice.reference)
-    FROM invoice JOIN project where project.id = invoice.project_id;
-
-  -- purchases
-  INSERT INTO document_map
-    SELECT purchase.uuid, CONCAT_WS('.', 'PO', project.abbr, purchase.reference)
-    FROM purchase JOIN project where project.id = purchase.project_id;
-
-  -- vouchers
-  INSERT INTO document_map
-    SELECT voucher.uuid, CONCAT_WS('.', 'VO', project.abbr, voucher.reference)
-    FROM voucher JOIN project where project.id = voucher.project_id;
-
-  -- stock_requisition
-  INSERT INTO document_map
-    SELECT stock_requisition.uuid, CONCAT_WS('.', 'SREQ', project.abbr, stock_requisition.reference)
-    FROM stock_requisition JOIN project where project.id = stock_requisition.project_id;
-
-  -- stock movements
-  INSERT INTO `document_map`
-    SELECT sm.document_uuid, CONCAT_WS('.', 'SM', sm.flux_id, sm.reference)
-    FROM stock_movement sm
-    ON DUPLICATE KEY UPDATE uuid = sm.document_uuid;
-END $$
 
 /*
  zRepostVoucher

--- a/server/models/migrations/next/migrate.sql
+++ b/server/models/migrations/next/migrate.sql
@@ -44,3 +44,9 @@ CREATE INDEX pj_entity_record ON posting_journal (entity_uuid, record_uuid);
 CREATE INDEX pj_entity_reference ON posting_journal (entity_uuid, reference_uuid);
 
 ALTER TABLE user MODIFY password VARCHAR(255) NOT NULL;
+
+-- author: jniles
+-- update UUID mappings.  This will take  along time!
+CALL zRecomputeUuidMapping();
+
+

--- a/sh/build-database.sh
+++ b/sh/build-database.sh
@@ -9,7 +9,7 @@ echo "[build]"
 echo "Building BHIMA Database"
 
 set -a
-source .env || { echo '[build-database.sh] did not load .env, using variables from environment.' ; }
+source .env || { echo '[build-database.sh] did not load .env, using variables from environment.'; }
 set +a
 
 # set build timeout
@@ -18,7 +18,7 @@ TIMEOUT=${BUILD_TIMEOUT:-8}
 fout=/dev/null
 
 if [ "$1" == "debug" ]; then
-    fout=/dev/tty
+  fout=/dev/tty
 fi
 
 # default database port
@@ -27,41 +27,82 @@ DB_PORT=${DB_PORT:-3306}
 echo "Building database: $DB_USER,$DB_PASS,$DB_HOST,$DB_PORT,$DB_NAME'"
 
 # build the test database
-mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT"  -e "DROP DATABASE IF EXISTS $DB_NAME ;" || { echo 'failed to drop DB' ; exit 1; }
-mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT"  -e "CREATE DATABASE $DB_NAME CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;" || { echo 'failed to create DB' ; exit 1; }
+mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" -e "DROP DATABASE IF EXISTS $DB_NAME ;" || {
+  echo 'failed to drop DB'
+  exit 1
+}
+mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" -e "CREATE DATABASE $DB_NAME CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;" || {
+  echo 'failed to create DB'
+  exit 1
+}
 
 echo "[build] database schema"
-mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" < server/models/01-schema.sql || { echo 'failed to build DB schema' ; exit 1; }
+mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" <server/models/01-schema.sql || {
+  echo 'failed to build DB schema'
+  exit 1
+}
 
 echo "[build] functions"
-mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" < server/models/02-functions.sql || { echo 'failed to import functions into DB' ; exit 1; }
+mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" <server/models/02-functions.sql || {
+  echo 'failed to import functions into DB'
+  exit 1
+}
 
 echo "[build] procedures"
-mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" < server/models/03-procedures.sql || { echo 'failed to import procedures into DB 1/2' ; exit 1; }
-mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" < server/models/98-admin.sql || { echo 'failed to import procedures into DB 2/2' ; exit 1; }
+mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" <server/models/03-procedures.sql || {
+  echo 'failed to import procedures into DB 1/2'
+  exit 1
+}
+mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" <server/models/98-admin.sql || {
+  echo 'failed to import procedures into DB 2/2'
+  exit 1
+}
 
 echo "[build] triggers"
-mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" < server/models/04-triggers.sql || { echo 'failed to import triggers into DB' ; exit 1; }
+mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" <server/models/04-triggers.sql || {
+  echo 'failed to import triggers into DB'
+  exit 1
+}
 
 echo "[build] default data"
-mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" < server/models/05-icd10.sql || { echo 'failed to import default data into DB 1/2' ; exit 1; }
+mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" <server/models/05-icd10.sql || {
+  echo 'failed to import default data into DB 1/2'
+  exit 1
+}
 
-mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" < server/models/06-bhima.sql || { echo 'failed to import default data into DB 2/2' ; exit 1; }
+mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" <server/models/06-bhima.sql || {
+  echo 'failed to import default data into DB 2/2'
+  exit 1
+}
 
 echo "[build] test data"
-mysql --default-character-set=utf8mb4 -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" < test/data.sql || { echo 'failed to import test data into DB' ; exit 1; }
+mysql --default-character-set=utf8mb4 -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" <test/data.sql || {
+  echo 'failed to import test data into DB'
+  exit 1
+}
 
 echo "[build] recomputing mappings"
-mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" -e "Call zRecomputeEntityMap();" || { echo 'failed to recompute mappings 1/2' ; exit 1; }
-mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" -e "Call zRecomputeDocumentMap();" || { echo 'failed to recompute mappings 2/2' ; exit 1; }
+mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" -e "Call zRecomputeUuidMapping();" || {
+  echo 'failed to recompute UUID mappings'
+  exit 1
+}
 
 echo "[build] recalculating period totals"
-mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" -e "Call zRecalculatePeriodTotals();" || { echo 'failed to recalculate period totals' ; exit 1; }
+mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" -e "Call zRecalculatePeriodTotals();" || {
+  echo 'failed to recalculate period totals'
+  exit 1
+}
 
 echo "[build] recalulcating stock_movement_status"
-mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" -e "CALL zRecomputeStockMovementStatus();" || { echo 'failed to recalculate stock movement status' ; exit 1; }
+mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" -e "CALL zRecomputeStockMovementStatus();" || {
+  echo 'failed to recalculate stock movement status'
+  exit 1
+}
 
 echo "[build] recalulcating stock_value"
-mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" -e "CALL RecomputeStockValue(NULL);" || { echo 'failed to recalculate stock value' ; exit 1; }
+mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" -e "CALL RecomputeStockValue(NULL);" || {
+  echo 'failed to recalculate stock value'
+  exit 1
+}
 
 echo "[/build]"

--- a/sh/build-init-database.sh
+++ b/sh/build-init-database.sh
@@ -9,7 +9,7 @@ set -o pipefail
 echo "[ build ] Building BHIMA Database"
 
 set -a
-source .env || { echo "[build-init-database.sh] could not load .env, using variables from environment." ; }
+source .env || { echo "[build-init-database.sh] could not load .env, using variables from environment."; }
 set +a
 
 # set build timeout
@@ -18,7 +18,7 @@ TIMEOUT=${BUILD_TIMEOUT:-8}
 fout=/dev/null
 
 if [ "$1" == "debug" ]; then
-    fout=/dev/tty
+  fout=/dev/tty
 fi
 
 # default database port
@@ -27,28 +27,51 @@ DB_PORT=${DB_PORT:-3306}
 echo "Building database: $DB_USER,$DB_PASS,$DB_HOST,$DB_PORT,$DB_NAME'"
 
 # build the initial database
-mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" -e "DROP DATABASE IF EXISTS $DB_NAME ;" || { echo "failed to drop DB" ; exit 1; }
-mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" -e "CREATE DATABASE $DB_NAME CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;" || { echo "failed to create DB" ; exit 1; }
+mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" -e "DROP DATABASE IF EXISTS $DB_NAME ;" || {
+  echo "failed to drop DB"
+  exit 1
+}
+mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" -e "CREATE DATABASE $DB_NAME CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;" || {
+  echo "failed to create DB"
+  exit 1
+}
 
 echo "[ build ] database schema"
-mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" < server/models/01-schema.sql || { echo "failed to build DB scheme" ; exit 1; }
+mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" <server/models/01-schema.sql || {
+  echo "failed to build DB scheme"
+  exit 1
+}
 
 echo "[ build ] functions"
-mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" < server/models/02-functions.sql || { echo "failed to import functions into DB" ; exit 1; }
+mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" <server/models/02-functions.sql || {
+  echo "failed to import functions into DB"
+  exit 1
+}
 
 echo "[ build ] procedures"
-mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" < server/models/03-procedures.sql
-mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" < server/models/98-admin.sql || { echo "failed to import procedures into DB 2/2" ; exit 1; }
+mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" <server/models/03-procedures.sql
+mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" <server/models/98-admin.sql || {
+  echo "failed to import procedures into DB 2/2"
+  exit 1
+}
 
 echo "[ build ] triggers"
-mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" < server/models/04-triggers.sql
+mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" <server/models/04-triggers.sql
 
 echo "[ build ] default data"
-mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" < server/models/05-icd10.sql || { echo "failed to import default data into DB 1/2" ; exit 1; }
-mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" < server/models/06-bhima.sql || { echo "failed to import default data into DB 2/2" ; exit 1; }
+mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" <server/models/05-icd10.sql || {
+  echo "failed to import default data into DB 1/2"
+  exit 1
+}
+mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" <server/models/06-bhima.sql || {
+  echo "failed to import default data into DB 2/2"
+  exit 1
+}
 
 echo "[build] recomputing mappings"
-mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" -e "Call zRecomputeEntityMap();" || { echo "failed to recompute mappings 1/2" ; exit 1; }
-mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" -e "Call zRecomputeDocumentMap();" || { echo "failed to recompute mappings 2/2" ; exit 1; }
+mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" -e "Call zRecomputeUuidMapping();" || {
+  echo "failed to recompute UUID mappings"
+  exit 1
+}
 
 echo "[ /build ]"

--- a/sh/build-stock-database.sh
+++ b/sh/build-stock-database.sh
@@ -98,12 +98,8 @@ mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" <test/data
 }
 
 echo "[build] recomputing mappings"
-mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" -e "Call zRecomputeEntityMap();" || {
-  echo 'failed to recompute mappings 1/2'
-  exit 1
-}
-mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" -e "Call zRecomputeDocumentMap();" || {
-  echo 'failed to recompute mappings 2/2'
+mysql -u "$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" -e "Call zRecomputeUuidMapping();" || {
+  echo 'failed to recompute UUID mappings'
   exit 1
 }
 


### PR DESCRIPTION
This PR migrates from using two different uuid maps (`entity_map` and `document_map`) to using a single `uuid_map`.  It should simplify lookups after the pain of migration.

Closes #6663.